### PR TITLE
Add per sheet dismiss and snooze for Sheets modal

### DIFF
--- a/src/content-general/index.ts
+++ b/src/content-general/index.ts
@@ -3,7 +3,7 @@ import { augmentDOIs } from "../shared/doi-augment";
 import { debounce } from "../shared/debounce";
 import type { DoiString, LookupState } from "../shared/types";
 import type { LookupRequest, LookupResponse, SheetFetchRequest, SheetFetchResponse } from "../shared/messages";
-import { renderErrorBanner, renderMatchedBanner, removeBanner, renderInlineBadges, renderSheetsModal, removeSheetsModal, renderSetupPrompt, hideAllFloraUI, showAllFloraUI } from "./injector";
+import { renderErrorBanner, renderMatchedBanner, removeBanner, renderInlineBadges, renderSheetsModal, removeSheetsModal, renderSetupPrompt, hideAllFloraUI, showAllFloraUI, type SheetsModalCallbacks } from "./injector";
 import { debugLog, debugWarn } from "../shared/debug";
 import { isSetupComplete } from "../shared/settings";
 import { isDomainBlocked } from "../shared/domains";
@@ -130,7 +130,9 @@ async function run(): Promise<void> {
 
     if (matched.length > 0) {
       if (isSheets) {
-        renderSheetsModal(matched);
+        if (!isSheetsModalSuppressed()) {
+          renderSheetsModal(matched, sheetsModalCallbacks);
+        }
       } else {
         renderMatchedBanner(matched);
       }
@@ -157,6 +159,33 @@ const debouncedRun = debounce(run, 1000);
 
 // DOIs extracted from the full sheet CSV (populated asynchronously on Sheets)
 let sheetCsvDois: DoiString[] = [];
+
+// ── Sheets modal: per-gid dismiss tracking & snooze ──
+/** Gids where the user explicitly dismissed the modal (session only). */
+const dismissedGids = new Set<string>();
+/** Timestamp until which all Sheets modals are snoozed. */
+let snoozeUntil = 0;
+
+function currentGid(): string {
+  return parseSheetsUrl(location.href)?.gid ?? "0";
+}
+
+function isSheetsModalSuppressed(): boolean {
+  if (Date.now() < snoozeUntil) return true;
+  if (dismissedGids.has(currentGid())) return true;
+  return false;
+}
+
+const sheetsModalCallbacks: SheetsModalCallbacks = {
+  onDismiss() {
+    dismissedGids.add(currentGid());
+    debugLog("Sheets modal dismissed for gid:", currentGid());
+  },
+  onSnooze() {
+    snoozeUntil = Date.now() + 10 * 60 * 1000; // 10 minutes
+    debugLog("Sheets modal snoozed until", new Date(snoozeUntil).toLocaleTimeString());
+  },
+};
 
 /**
  * Parse the spreadsheet ID and gid from a Google Sheets URL.
@@ -255,10 +284,10 @@ async function fetchSheetDois(): Promise<void> {
   // fire hashchange/popstate, so we poll for gid changes instead.
   let lastGid = parseSheetsUrl(location.href)?.gid ?? "0";
   setInterval(() => {
-    const currentGid = parseSheetsUrl(location.href)?.gid ?? "0";
-    if (currentGid !== lastGid) {
-      lastGid = currentGid;
-      console.log("[FLoRA:Sheets] Tab change detected (gid:", currentGid, ") — re-fetching…");
+    const nowGid = parseSheetsUrl(location.href)?.gid ?? "0";
+    if (nowGid !== lastGid) {
+      lastGid = nowGid;
+      console.log("[FLoRA:Sheets] Tab change detected (gid:", nowGid, ") — re-fetching…");
       sheetFetchGen++;
       sheetCsvDois = [];
       processedDois.clear();

--- a/src/content-general/injector.ts
+++ b/src/content-general/injector.ts
@@ -329,8 +329,14 @@ function escapeHtml(s: string): string {
 
 const SHEETS_MODAL_ID = "flora-sheets-modal";
 
+export interface SheetsModalCallbacks {
+  onDismiss: () => void;
+  onSnooze: () => void;
+}
+
 export function renderSheetsModal(
-  matched: { doi: string; result: ReplicationResult }[]
+  matched: { doi: string; result: ReplicationResult }[],
+  callbacks?: SheetsModalCallbacks
 ): void {
   if (matched.length === 0) {
     removeSheetsModal();
@@ -425,7 +431,12 @@ export function renderSheetsModal(
       </div>
 
       <!-- Footer -->
-      <div style="padding:10px 16px 14px;display:flex;justify-content:flex-end;gap:8px;">
+      <div style="padding:10px 16px 14px;display:flex;align-items:center;gap:8px;">
+        <button class="flora-modal-snooze" title="Snooze for 10 minutes" style="
+          all:unset;cursor:pointer;padding:7px 8px;font-size:0;line-height:0;
+          color:#5f6368;border-radius:6px;transition:color 0.15s;
+          display:flex;align-items:center;justify-content:center;margin-right:auto;
+        "><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg></button>
         <button class="flora-modal-dismiss" style="
           all:unset;cursor:pointer;padding:7px 18px;font-size:13px;font-weight:500;
           color:#5f6368;border-radius:6px;transition:background 0.15s;
@@ -446,10 +457,19 @@ export function renderSheetsModal(
 
   document.body.appendChild(host);
 
-  // Wire up close / dismiss buttons
+  // Wire up close / dismiss
   for (const el of host.querySelectorAll(".flora-modal-close, .flora-modal-dismiss")) {
-    el.addEventListener("click", () => removeSheetsModal());
+    el.addEventListener("click", () => {
+      removeSheetsModal();
+      callbacks?.onDismiss();
+    });
   }
+
+  // Wire up snooze
+  host.querySelector(".flora-modal-snooze")?.addEventListener("click", () => {
+    removeSheetsModal();
+    callbacks?.onSnooze();
+  });
 }
 
 export function removeSheetsModal(): void {


### PR DESCRIPTION
Introduce session-scoped per-sheet dismissals and a global 10-minute snooze for the Sheets modal to avoid repeatedly showing it. Add a SheetsModalCallbacks type and pass callbacks into renderSheetsModal; wire dismiss and snooze buttons to call those callbacks. Prevent modal rendering when suppressed, track dismissed gids and snoozeUntil timestamp, and log state changes. Also small refactors: import the new type, adjust modal rendering call site, and rename local gid variable in the polling loop for clearer logging.