### PR TITLE
Add DOI validation via doi.org Handle API before expensive augmentation

### DIFF
--- a/src/content-general/index.ts
+++ b/src/content-general/index.ts
@@ -1,5 +1,6 @@
 import { extractDOIs, extractDOIsFromText } from "../shared/doi-extractor";
 import { augmentDOIs } from "../shared/doi-augment";
+import { validateDOIs } from "../shared/doi-validate";
 import { debounce } from "../shared/debounce";
 import type { DoiString, LookupState } from "../shared/types";
 import type { LookupRequest, LookupResponse, SheetFetchRequest, SheetFetchResponse } from "../shared/messages";
@@ -68,12 +69,27 @@ async function run(): Promise<void> {
   }
   debugLog(isSheets ? "Sheets:" : "General:", "Extracted DOIs:", dois.length, dois);
 
+  // Validate extracted DOIs via doi.org — remove invalid ones
+  if (dois.length > 0 && !isSheets) {
+    try {
+      const validation = await validateDOIs(dois);
+      const before = dois.length;
+      dois = dois.filter((doi) => validation.get(doi) !== false);
+      const removed = before - dois.length;
+      if (removed > 0) {
+        debugLog(`Validation: removed ${removed} invalid DOI(s)`);
+      }
+    } catch {
+      // Validation failed — keep all extracted DOIs as-is
+    }
+  }
+
   // Filter out already-processed DOIs
   const newDois = dois.filter((doi) => !processedDois.has(doi));
 
-  // If no new DOIs found directly, try augmenting from page title in the background
+  // If no valid DOIs found, try augmenting from page title in the background
   if (newDois.length === 0 && dois.length === 0) {
-    debugLog("No DOIs found on page, attempting title augmentation");
+    debugLog("No valid DOIs found on page, attempting title augmentation");
     if (!isSheets) augmentFromTitle();
     return;
   }

--- a/src/content-scholar/observer.ts
+++ b/src/content-scholar/observer.ts
@@ -1,5 +1,6 @@
 import { normaliseDOI } from "../shared/doi-normalise";
 import { augmentDOIs } from "../shared/doi-augment";
+import { validateDOI, validateDOIs } from "../shared/doi-validate";
 import type { DoiString, DoiSource } from "../shared/types";
 import type { LookupRequest, LookupResponse } from "../shared/messages";
 import { renderScholarBadge } from "./badge";
@@ -69,6 +70,7 @@ export async function processScholarResults(doc: Document): Promise<void> {
 
     // Confident extractions (doi.org URLs, explicit text) → green immediately
     if (extraction?.confident) {
+      debugLog(`Scholar resolve [confident] "${title}" → ${extraction.doi}`);
       rowDois.push({ row, doi: extraction.doi, source: "extracted" });
       injectDoiLabel(row, extraction.doi, "#1a7f37", false);
     } else {
@@ -82,40 +84,87 @@ export async function processScholarResults(doc: Document): Promise<void> {
     }
   }
 
-  // Phase 2: Augment ALL pending titles via OpenAlex to cross-validate
+  // Phase 2: Validate extracted DOIs via doi.org, then augment only what's still unresolved
   if (rowInfos.length > 0) {
-    const titlesToAugment = rowInfos.filter((r) => r.title).map((r) => r.title);
-    let augmented = new Map<string, DoiString | null>();
-    try {
-      if (titlesToAugment.length > 0) {
-        augmented = await augmentDOIs(titlesToAugment);
+    // Step 1: Validate extracted DOIs with doi.org (cheap HEAD-like check)
+    const doisToValidate = rowInfos
+      .filter((r) => r.extractedDoi !== null)
+      .map((r) => r.extractedDoi!);
+
+    let validated = new Map<DoiString, boolean>();
+    if (doisToValidate.length > 0) {
+      try {
+        validated = await validateDOIs(doisToValidate);
+      } catch {
+        // Validation failed — all remain unvalidated
       }
-    } catch {
-      // Augmentation failed — fall through with empty map
     }
 
+    // Separate rows into validated (done) vs still-pending (need augmentation)
+    const pendingInfos: RowInfo[] = [];
     for (const info of rowInfos) {
-      const augmentedDoi = augmented.get(info.title) ?? null;
-
-      if (info.extractedDoi && augmentedDoi === info.extractedDoi) {
-        // Cross-validated: URL extraction matches augmentation → green ✓
+      if (info.extractedDoi && validated.get(info.extractedDoi)) {
+        // doi.org confirms this DOI exists → treat as confident
+        debugLog(`Scholar resolve [doi.org-validated] "${info.title}" → ${info.extractedDoi}`);
         rowDois.push({ row: info.row, doi: info.extractedDoi, source: "extracted" });
         injectDoiLabel(info.row, info.extractedDoi, "#1a7f37", false);
-      } else if (info.extractedDoi && augmentedDoi && augmentedDoi !== info.extractedDoi) {
-        // Conflict: prefer augmented DOI → gray (augmented)
-        debugLog("DOI conflict — extracted:", info.extractedDoi, "augmented:", augmentedDoi, "— using augmented");
-        rowDois.push({ row: info.row, doi: augmentedDoi, source: "augmented" });
-        injectDoiLabel(info.row, augmentedDoi, "#656d76", true);
-      } else if (info.extractedDoi && !augmentedDoi) {
-        // Extracted but unconfirmed → gray with dotted underline
-        rowDois.push({ row: info.row, doi: info.extractedDoi, source: "extracted" });
-        injectDoiLabel(info.row, info.extractedDoi, "#656d76", true);
-      } else if (!info.extractedDoi && augmentedDoi) {
-        // No extraction, only augmented → gray with dotted underline
-        rowDois.push({ row: info.row, doi: augmentedDoi, source: "augmented" });
-        injectDoiLabel(info.row, augmentedDoi, "#656d76", true);
+      } else {
+        if (info.extractedDoi) {
+          debugLog(`Scholar: "${info.title}" — extracted ${info.extractedDoi} failed doi.org validation, falling back to augmentation`);
+        }
+        pendingInfos.push(info);
       }
-      // else: neither source found a DOI — no label
+    }
+
+    // Step 2: Augment only the remaining unresolved rows
+    if (pendingInfos.length > 0) {
+      const titlesToAugment = pendingInfos.filter((r) => r.title).map((r) => r.title);
+      let augmented = new Map<string, DoiString | null>();
+      try {
+        if (titlesToAugment.length > 0) {
+          augmented = await augmentDOIs(titlesToAugment);
+        }
+      } catch {
+        // Augmentation failed — fall through with empty map
+      }
+
+      for (const info of pendingInfos) {
+        const augmentedDoi = augmented.get(info.title) ?? null;
+
+        if (info.extractedDoi && augmentedDoi === info.extractedDoi) {
+          // Cross-validated: URL extraction matches augmentation → green ✓
+          debugLog(`Scholar resolve [cross-validated] "${info.title}" → ${info.extractedDoi} (extracted = augmented)`);
+          rowDois.push({ row: info.row, doi: info.extractedDoi, source: "extracted" });
+          injectDoiLabel(info.row, info.extractedDoi, "#1a7f37", false);
+        } else if (info.extractedDoi && augmentedDoi && augmentedDoi !== info.extractedDoi) {
+          // Conflict: prefer augmented DOI → gray (augmented)
+          debugLog(`Scholar resolve [conflict] "${info.title}" → using augmented ${augmentedDoi} (extracted was ${info.extractedDoi})`);
+          rowDois.push({ row: info.row, doi: augmentedDoi, source: "augmented" });
+          injectDoiLabel(info.row, augmentedDoi, "#656d76", true);
+        } else if (info.extractedDoi && !augmentedDoi) {
+          // Extracted but augmentation found nothing — last-resort doi.org check
+          let valid = false;
+          try {
+            valid = await validateDOI(info.extractedDoi);
+          } catch { /* validation failed */ }
+
+          if (valid) {
+            debugLog(`Scholar resolve [extracted-revalidated] "${info.title}" → ${info.extractedDoi} (doi.org confirmed on retry)`);
+            rowDois.push({ row: info.row, doi: info.extractedDoi, source: "extracted" });
+            injectDoiLabel(info.row, info.extractedDoi, "#1a7f37", false);
+          } else {
+            // Invalid DOI — show nothing rather than an incorrect DOI
+            debugLog(`Scholar resolve [extracted-invalid] "${info.title}" → ${info.extractedDoi} rejected (doi.org says invalid)`);
+          }
+        } else if (!info.extractedDoi && augmentedDoi) {
+          // No extraction, only augmented → gray with dotted underline
+          debugLog(`Scholar resolve [augmented-only] "${info.title}" → ${augmentedDoi} (no extraction)`);
+          rowDois.push({ row: info.row, doi: augmentedDoi, source: "augmented" });
+          injectDoiLabel(info.row, augmentedDoi, "#656d76", true);
+        } else {
+          debugLog(`Scholar resolve [no-doi] "${info.title}" → no DOI from extraction or augmentation`);
+        }
+      }
     }
   }
 
@@ -358,21 +407,32 @@ interface ExtractionResult {
 }
 
 function extractDoiFromScholarRow(row: HTMLElement): ExtractionResult | null {
+  const title = row.querySelector(".gs_rt")?.textContent?.trim() ?? "(untitled)";
+
   // 1. Title link href — doi.org URL is inherently trustworthy
   const titleLink = row.querySelector<HTMLAnchorElement>(".gs_rt a");
   if (titleLink?.href) {
     const doi = normaliseDOI(titleLink.href);
-    if (doi) return { doi, confident: true };
+    if (doi) {
+      debugLog(`Scholar DOI [title-link doi.org] "${title}" → ${doi} (confident) from ${titleLink.href}`);
+      return { doi, confident: true };
+    }
     // DOI explicitly named in query params (e.g. ?doi=10.xxx/yyy, ?identifierName=doi&identifierValue=10.xxx)
     const doiFromParams = extractDoiFromQueryParams(titleLink.href);
-    if (doiFromParams) return { doi: doiFromParams, confident: true };
+    if (doiFromParams) {
+      debugLog(`Scholar DOI [title-link query-param] "${title}" → ${doiFromParams} (confident) from ${titleLink.href}`);
+      return { doi: doiFromParams, confident: true };
+    }
     // DOI may be embedded in path (e.g. /edit/10.xxx/yyy/slug)
     try {
       const decoded = decodeURIComponent(titleLink.href);
       const m = decoded.match(/\b(10\.\d{4,}(?:\.\d+)*\/[^\s&"'#?/]+)/);
       if (m) {
         const embeddedDoi = normaliseDOI(m[1]);
-        if (embeddedDoi) return { doi: embeddedDoi, confident: false };
+        if (embeddedDoi) {
+          debugLog(`Scholar DOI [title-link embedded-path] "${title}" → ${embeddedDoi} (not confident) from ${titleLink.href}`);
+          return { doi: embeddedDoi, confident: false };
+        }
       }
     } catch { /* invalid encoding — skip */ }
   }
@@ -385,7 +445,10 @@ function extractDoiFromScholarRow(row: HTMLElement): ExtractionResult | null {
     );
     if (match) {
       const doi = normaliseDOI(match[1]);
-      if (doi) return { doi, confident: true };
+      if (doi) {
+        debugLog(`Scholar DOI [author-line text] "${title}" → ${doi} (confident) from "${authorLine.textContent.trim()}"`);
+        return { doi, confident: true };
+      }
     }
   }
 
@@ -394,14 +457,20 @@ function extractDoiFromScholarRow(row: HTMLElement): ExtractionResult | null {
   for (const link of links) {
     if (link.href.includes("doi.org/")) {
       const doi = normaliseDOI(link.href);
-      if (doi) return { doi, confident: true };
+      if (doi) {
+        debugLog(`Scholar DOI [doi.org link] "${title}" → ${doi} (confident) from ${link.href}`);
+        return { doi, confident: true };
+      }
     }
   }
 
   // 4. DOI in query params of any link (explicitly labelled → confident)
   for (const link of links) {
     const paramDoi = extractDoiFromQueryParams(link.href);
-    if (paramDoi) return { doi: paramDoi, confident: true };
+    if (paramDoi) {
+      debugLog(`Scholar DOI [link query-param] "${title}" → ${paramDoi} (confident) from ${link.href}`);
+      return { doi: paramDoi, confident: true };
+    }
   }
 
   // 5. DOI embedded in any link URL path (e.g. /edit/10.xxx/yyy/slug)
@@ -412,11 +481,15 @@ function extractDoiFromScholarRow(row: HTMLElement): ExtractionResult | null {
       const m = decoded.match(doiInUrlRe);
       if (m) {
         const doi = normaliseDOI(m[1]);
-        if (doi) return { doi, confident: false };
+        if (doi) {
+          debugLog(`Scholar DOI [link embedded-path] "${title}" → ${doi} (not confident) from ${link.href}`);
+          return { doi, confident: false };
+        }
       }
     } catch { /* invalid encoding */ }
   }
 
+  debugLog(`Scholar DOI [none] "${title}" → no DOI extracted`);
   return null;
 }
 

--- a/src/shared/doi-validate.ts
+++ b/src/shared/doi-validate.ts
@@ -1,0 +1,96 @@
+import type { DoiString } from "./types";
+import { debugLog } from "./debug";
+
+/**
+ * Validate DOIs by checking the doi.org Handle System API.
+ * A responseCode of 1 means the DOI exists and resolves.
+ * This is much cheaper than full augmentation (Crossref/OpenAlex title search).
+ */
+
+const HANDLE_API = "https://doi.org/api/handles/";
+const CACHE_PREFIX = "flora_doival:";
+const CACHE_TTL = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+interface CachedValidation {
+  valid: boolean;
+  timestamp: number;
+}
+
+/**
+ * Check whether a single DOI resolves via doi.org.
+ * Results are cached in chrome.storage.local for 7 days.
+ */
+export async function validateDOI(doi: DoiString): Promise<boolean> {
+  const result = await validateDOIs([doi]);
+  return result.get(doi) ?? false;
+}
+
+/**
+ * Validate multiple DOIs in parallel via the doi.org Handle System API.
+ * Returns a Map of DOI → valid (true/false).
+ * Cached results are reused; uncached DOIs are checked in parallel.
+ */
+export async function validateDOIs(
+  dois: DoiString[]
+): Promise<Map<DoiString, boolean>> {
+  const results = new Map<DoiString, boolean>();
+  if (dois.length === 0) return results;
+
+  // Check cache first
+  const uncached: DoiString[] = [];
+  const cacheKeys = dois.map((d) => CACHE_PREFIX + d);
+
+  try {
+    const cached = await chrome.storage.local.get(cacheKeys);
+    for (const doi of dois) {
+      const entry = cached[CACHE_PREFIX + doi] as CachedValidation | undefined;
+      if (entry && Date.now() - entry.timestamp < CACHE_TTL) {
+        results.set(doi, entry.valid);
+      } else {
+        uncached.push(doi);
+      }
+    }
+  } catch {
+    uncached.push(...dois);
+  }
+
+  if (uncached.length === 0) {
+    debugLog(`DOI validation: ${dois.length} DOI(s) all cached`);
+    return results;
+  }
+
+  debugLog(`DOI validation: ${uncached.length} uncached DOI(s) to check`);
+
+  // Validate uncached DOIs in parallel
+  await Promise.allSettled(
+    uncached.map(async (doi) => {
+      try {
+        const response = await fetch(
+          `${HANDLE_API}${encodeURIComponent(doi)}`
+        );
+        if (!response.ok) {
+          results.set(doi, false);
+          cacheResult(doi, false);
+          return;
+        }
+        const data = (await response.json()) as { responseCode?: number };
+        // responseCode 1 = success (handle exists)
+        const valid = data.responseCode === 1;
+        results.set(doi, valid);
+        cacheResult(doi, valid);
+        debugLog(`DOI validation: ${doi} → ${valid ? "valid" : "invalid"}`);
+      } catch {
+        // Network error — don't cache, assume invalid for this run
+        results.set(doi, false);
+      }
+    })
+  );
+
+  return results;
+}
+
+function cacheResult(doi: DoiString, valid: boolean): void {
+  const key = CACHE_PREFIX + doi;
+  const entry: CachedValidation = { valid, timestamp: Date.now() };
+  chrome.storage.local.set({ [key]: entry }).catch(() => {});
+}

--- a/tests/unit/doi-validate.test.ts
+++ b/tests/unit/doi-validate.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, beforeEach, beforeAll, afterAll, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+
+import { validateDOI, validateDOIs } from "../../src/shared/doi-validate";
+import type { DoiString } from "../../src/shared/types";
+
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: "bypass" }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+const doi = (s: string) => s as DoiString;
+
+// The encoded DOI URL uses encodeURIComponent, so 10.1038/nature12373
+// becomes 10.1038%2Fnature12373 — a single path segment.
+// Use a wildcard to match all handle API requests.
+const HANDLE_PATTERN = "https://doi.org/api/handles/:encoded";
+
+describe("validateDOI", () => {
+  beforeEach(() => {
+    (chrome.storage.local.get as ReturnType<typeof vi.fn>).mockResolvedValue({});
+    (chrome.storage.local.set as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+  });
+
+  it("returns true for a valid DOI (responseCode 1)", async () => {
+    server.use(
+      http.get(HANDLE_PATTERN, () =>
+        HttpResponse.json({ responseCode: 1, handle: "10.1038/nature12373" })
+      )
+    );
+
+    const result = await validateDOI(doi("10.1038/nature12373"));
+    expect(result).toBe(true);
+  });
+
+  it("returns false for an invalid DOI (responseCode 100)", async () => {
+    server.use(
+      http.get(HANDLE_PATTERN, () =>
+        HttpResponse.json({ responseCode: 100, handle: "10.1038/doesnotexist" })
+      )
+    );
+
+    const result = await validateDOI(doi("10.1038/doesnotexist"));
+    expect(result).toBe(false);
+  });
+
+  it("returns false on HTTP error", async () => {
+    server.use(
+      http.get(HANDLE_PATTERN, () =>
+        new HttpResponse(null, { status: 500 })
+      )
+    );
+
+    const result = await validateDOI(doi("10.1038/nature12373"));
+    expect(result).toBe(false);
+  });
+
+  it("returns false on network error", async () => {
+    server.use(
+      http.get(HANDLE_PATTERN, () =>
+        HttpResponse.error()
+      )
+    );
+
+    const result = await validateDOI(doi("10.1038/nature12373"));
+    expect(result).toBe(false);
+  });
+
+  it("caches valid results", async () => {
+    server.use(
+      http.get(HANDLE_PATTERN, () =>
+        HttpResponse.json({ responseCode: 1 })
+      )
+    );
+
+    await validateDOI(doi("10.1038/nature12373"));
+
+    expect(chrome.storage.local.set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        "flora_doival:10.1038/nature12373": expect.objectContaining({
+          valid: true,
+          timestamp: expect.any(Number),
+        }),
+      })
+    );
+  });
+
+  it("caches invalid results", async () => {
+    server.use(
+      http.get(HANDLE_PATTERN, () =>
+        HttpResponse.json({ responseCode: 100 })
+      )
+    );
+
+    await validateDOI(doi("10.1038/doesnotexist"));
+
+    expect(chrome.storage.local.set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        "flora_doival:10.1038/doesnotexist": expect.objectContaining({
+          valid: false,
+        }),
+      })
+    );
+  });
+
+  it("uses cached result on second call", async () => {
+    (chrome.storage.local.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+      "flora_doival:10.1038/cached": { valid: true, timestamp: Date.now() },
+    });
+
+    const result = await validateDOI(doi("10.1038/cached"));
+    expect(result).toBe(true);
+  });
+
+  it("ignores expired cache entries", async () => {
+    const eightDaysAgo = Date.now() - 8 * 24 * 60 * 60 * 1000;
+    (chrome.storage.local.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+      "flora_doival:10.1038/expired": { valid: false, timestamp: eightDaysAgo },
+    });
+
+    server.use(
+      http.get(HANDLE_PATTERN, () =>
+        HttpResponse.json({ responseCode: 1 })
+      )
+    );
+
+    const result = await validateDOI(doi("10.1038/expired"));
+    expect(result).toBe(true);
+  });
+});
+
+describe("validateDOIs", () => {
+  beforeEach(() => {
+    (chrome.storage.local.get as ReturnType<typeof vi.fn>).mockResolvedValue({});
+    (chrome.storage.local.set as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+  });
+
+  it("returns empty map for empty input", async () => {
+    const results = await validateDOIs([]);
+    expect(results.size).toBe(0);
+  });
+
+  it("validates multiple DOIs in parallel", async () => {
+    server.use(
+      http.get(HANDLE_PATTERN, ({ params }) => {
+        const encoded = params.encoded as string;
+        const decoded = decodeURIComponent(encoded);
+        if (decoded === "10.1038/valid1") {
+          return HttpResponse.json({ responseCode: 1 });
+        }
+        return HttpResponse.json({ responseCode: 100 });
+      })
+    );
+
+    const results = await validateDOIs([
+      doi("10.1038/valid1"),
+      doi("10.1038/invalid1"),
+    ]);
+
+    expect(results.get(doi("10.1038/valid1"))).toBe(true);
+    expect(results.get(doi("10.1038/invalid1"))).toBe(false);
+  });
+
+  it("mixes cached and uncached DOIs", async () => {
+    (chrome.storage.local.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+      "flora_doival:10.1038/cached": { valid: true, timestamp: Date.now() },
+    });
+
+    server.use(
+      http.get(HANDLE_PATTERN, () =>
+        HttpResponse.json({ responseCode: 1 })
+      )
+    );
+
+    const results = await validateDOIs([
+      doi("10.1038/cached"),
+      doi("10.1038/uncached"),
+    ]);
+
+    expect(results.get(doi("10.1038/cached"))).toBe(true);
+    expect(results.get(doi("10.1038/uncached"))).toBe(true);
+  });
+});


### PR DESCRIPTION
Extracted DOIs are now checked against doi.org/api/handles/ to confirm they resolve before falling back to Crossref/OpenAlex title augmentation. Invalid DOIs are suppressed entirely — better to show nothing than an incorrect DOI. Adds detailed per-row debug logging on Scholar so the source of each DOI (extraction layer, validation outcome) is visible in the console.