### PR TITLE
Add 'Report an issue' button to popup

### DIFF
--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -133,6 +133,10 @@ body {
   color: var(--text-secondary);
 }
 
+.popup-btn--report {
+  color: var(--text-muted);
+}
+
 /* ─── Status toast ─── */
 .popup-status {
   padding: 8px 14px;

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -37,6 +37,15 @@
         <span id="hide-btn-label">Hide on this page</span>
       </button>
 
+      <button id="report-btn" class="popup-btn popup-btn--report" type="button">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+          <line x1="12" y1="9" x2="12" y2="13" />
+          <line x1="12" y1="17" x2="12.01" y2="17" />
+        </svg>
+        Report an issue on this domain
+      </button>
+
       <div class="popup-divider"></div>
 
       <button id="options-btn" class="popup-btn popup-btn--options" type="button">

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -6,12 +6,15 @@ const blockLabel = document.getElementById("block-btn-label")!;
 const hideBtn = document.getElementById("hide-btn")!;
 const hideLabel = document.getElementById("hide-btn-label")!;
 const optionsBtn = document.getElementById("options-btn")!;
+const reportBtn = document.getElementById("report-btn")!;
 const statusEl = document.getElementById("popup-status")!;
 
 let currentDomain = "";
 let blocked = false;
 let hidden = false;
 let activeTabId: number | undefined;
+
+reportBtn.style.display = "none";
 
 function showStatus(msg: string, type: "success" | "error"): void {
   statusEl.textContent = msg;
@@ -48,6 +51,7 @@ async function init(): Promise<void> {
     domainEl.textContent = "No active page";
     blockBtn.style.display = "none";
     hideBtn.style.display = "none";
+    reportBtn.style.display = "none";
     return;
   }
 
@@ -61,11 +65,13 @@ async function init(): Promise<void> {
     domainEl.textContent = "Internal page";
     blockBtn.style.display = "none";
     hideBtn.style.display = "none";
+    reportBtn.style.display = "none";
     return;
   }
 
   blocked = await isDomainBlocked(currentDomain);
   updateBlockUI();
+  reportBtn.style.display = "";
 
   // Ask the content script whether UI is currently hidden
   if (activeTabId != null) {
@@ -118,6 +124,16 @@ hideBtn.addEventListener("click", async () => {
   } catch {
     showStatus("No FLoRA content on this page", "error");
   }
+});
+
+// Report an issue on the current domain
+reportBtn.addEventListener("click", () => {
+  if (!currentDomain) return;
+  const title = encodeURIComponent(`Issue on domain: ${currentDomain}`);
+  const body = encodeURIComponent(`**Domain:** ${currentDomain}\n\n**Description:**\n`);
+  const url = `https://github.com/forrtproject/flora_chromium/issues/new?title=${title}&body=${body}&labels=domain-issue`;
+  chrome.tabs.create({ url });
+  window.close();
 });
 
 // Open settings page


### PR DESCRIPTION
Add a new "Report an issue on this domain" button to the extension popup (HTML + CSS) and wire it up in popup.ts. The button is hidden by default and only shown for regular webpages (not internal/no-active pages). Clicking it opens a prefilled GitHub issue (title/body) and applies a `domain-issue` label, then closes the popup. Also includes minor styling for the report button.