### PR TITLE
Install banner integration

### DIFF
--- a/esbuild.config.ts
+++ b/esbuild.config.ts
@@ -25,6 +25,11 @@ const configs: esbuild.BuildOptions[] = [
   },
   {
     ...sharedOptions,
+    entryPoints: ["src/content-forrt/index.ts"],
+    outfile: "dist/content-forrt.js",
+  },
+  {
+    ...sharedOptions,
     entryPoints: ["src/background/service-worker.ts"],
     outfile: "dist/background.js",
   },

--- a/manifest.json
+++ b/manifest.json
@@ -53,6 +53,13 @@
     },
     {
       "matches": [
+        "*://forrt.org/*"
+      ],
+      "js": [ "dist/content-forrt.js" ],
+      "run_at": "document_idle"
+    },
+    {
+      "matches": [
         "*://scholar.google.com/*",
         "*://scholar.google.co.uk/*",
         "*://scholar.google.co.in/*",

--- a/src/content-forrt/index.ts
+++ b/src/content-forrt/index.ts
@@ -24,4 +24,4 @@ export function main() {
     observer.observe(document.body, {childList: true, subtree: true});
 }
 
-document.addEventListener('DOMContentLoaded', main);
+(() => main())();

--- a/src/content-forrt/index.ts
+++ b/src/content-forrt/index.ts
@@ -1,0 +1,27 @@
+// The special key to identify an installation banner
+export const INSTALL_BANNER_UUID = "#flora-plugin-install-banner-aa93b13084f7";
+
+/**
+ * Remove installation encouragement banner if it exists
+ */
+function clearInstallBanner(): void {
+    const target = document.querySelector(INSTALL_BANNER_UUID);
+    if (target) target.remove();
+}
+
+export function main() {
+    clearInstallBanner();
+    let debounceTimer: number;
+    const observer = new MutationObserver((mutations) => {
+        const hasNewNodes = mutations.some(m => m.addedNodes.length > 0);
+        if (hasNewNodes) {
+            clearTimeout(debounceTimer);
+            debounceTimer = window.setTimeout(() => {
+                clearInstallBanner();
+            }, 300);
+        }
+    });
+    observer.observe(document.body, {childList: true, subtree: true});
+}
+
+document.addEventListener('DOMContentLoaded', main);

--- a/tests/fixtures/forrt-website.html
+++ b/tests/fixtures/forrt-website.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Forrt.org</title>
+</head>
+<body>
+  <h1>FORRT's Replication Hub</h1>
+  <p>With the FORRT Replication Hub, our mission is to support reproduction and replication studies across all stages of the research process as well as all research disciplines. It consists of a comprehensive collection of resources and tools designed to assist researchers in the tracking, finding & exploring, conducting, and publishing & dissemination of reproduction and replication studies.</p>
+  <div id="flora-plugin-install-banner-aa93b13084f7" style="border: 1px solid #333">Install Flora Plugin at The Chrome Webstore</div>
+</body>
+</html>

--- a/tests/unit/forrt-content.test.ts
+++ b/tests/unit/forrt-content.test.ts
@@ -1,0 +1,31 @@
+import {describe, it, expect} from "vitest";
+import {readFileSync} from "fs";
+import {join} from "path";
+import {JSDOM} from "jsdom";
+import {main as ContentScriptMainLogic, INSTALL_BANNER_UUID} from "../../src/content-forrt"
+
+
+function loadFixture(name: string): void {
+    const html = readFileSync(
+        join(__dirname, "..", "fixtures", name),
+        "utf-8"
+    );
+    const dom =  new JSDOM(html, { url: "https://forrt.org/index.html" });
+    global.window = dom.window as any;
+    global.document = dom.window.document;
+    global.NodeFilter = dom.window.NodeFilter;
+    global.MutationObserver = dom.window.MutationObserver;
+}
+
+describe("FORRT content script", () => {
+    it("removes installation banner", () => {
+        loadFixture("forrt-website.html");
+
+        const bannerPre = document.querySelector(INSTALL_BANNER_UUID);
+        expect(bannerPre).not.toBeNull();
+        ContentScriptMainLogic();
+
+        const bannerPost = document.querySelector(INSTALL_BANNER_UUID);
+        expect(bannerPost).toBeNull();
+    });
+})


### PR DESCRIPTION
Adds the logic to hide an installation encouragement banner.

Assumptions about the website:
1. Host URL must match pattern `*://forrt.org/*`
2. The HTML banner id must be exactly
     ```
     flora-plugin-install-banner-aa93b13084f7
     ````

For example:

Somewhere on forrt.org, add:
```html
<div id="flora-plugin-install-banner-aa93b13084f7">
    Install the Flora Plugin at <a href="">...</a>
</div>
```

If the plugin is not installed, the banner will display.    
If the plugin is installed, the banner will not appear because the plugin will remove it.   
