### PR TITLE
Improve PubPeer lookups and DOI reference handling

### DIFF
--- a/src/content-general/index.ts
+++ b/src/content-general/index.ts
@@ -43,7 +43,8 @@ const processedDois = new Set<DoiString>();
 const doiContext = new Map<DoiString, DoiContext>();
 let lastUrl = location.href;
 let augmentAttempted = false;
-let pubpeerChecked = false;
+let articleFeedbacksFetched = false;
+let lastReferenceDoiKey = "";
 let lastArticleFeedbacks: PubPeerFeedback[] = [];
 let lastRefFeedbackByDoi: Map<DoiString, PubPeerFeedback> = new Map();
 
@@ -89,6 +90,8 @@ async function pageRenderChangeHandler(): Promise<void> {
         doiContext.clear();
         lastArticleFeedbacks = [];
         lastRefFeedbackByDoi = new Map();
+        articleFeedbacksFetched = false;
+        lastReferenceDoiKey = "";
         pageState.clear();
         augmentAttempted = false;
         if (isSheets) {
@@ -277,8 +280,7 @@ async function augmentFromTitle(): Promise<void> {
 }
 
 async function checkPubPeer(): Promise<void> {
-    if (pubpeerChecked || isSheets) return;
-    pubpeerChecked = true;
+    if (isSheets) return;
     const primaryDoi = extractPrimaryDOI(document);
     if (!primaryDoi) return;
     try {
@@ -295,15 +297,30 @@ async function checkPubPeer(): Promise<void> {
         }
         const referenceDois = references.map((r) => r.doi);
 
-        // Article: URL-based lookup. References: per-DOI lookups (cached and
-        // concurrency-limited) so every reference is reliably keyed by its DOI
-        // — the batch endpoint returns no DOI per feedback entry.
+        // Content-keyed gate: skip re-rendering when the article side is
+        // already fetched AND the set of reference DOIs is unchanged. This is
+        // what lets lazily-loaded references (e.g. Wiley's collapsible "Citing
+        // Literature" / references section) flow into the panel — the DOM
+        // observer fires checkPubPeer again, finds new DOIs, and re-renders.
+        const refKey = [...referenceDois].sort().join("|");
+        if (articleFeedbacksFetched && refKey === lastReferenceDoiKey) return;
+
+        // Article: URL-based lookup, fetched once per page. References:
+        // per-DOI lookups (cached and concurrency-limited) so every reference
+        // is reliably keyed by its DOI — the batch endpoint returns no DOI
+        // per feedback entry. The reference-side cache makes re-runs after
+        // lazy loads cheap (already-seen DOIs hit chrome.storage).
+        const articlePromise = articleFeedbacksFetched
+            ? Promise.resolve(lastArticleFeedbacks)
+            : lookupPubPeer([primaryDoi], [location.href]);
         const [articleFeedbacks, refFeedbackByDoi] = await Promise.all([
-            lookupPubPeer([primaryDoi], [location.href]),
+            articlePromise,
             lookupPubPeerForDois(referenceDois),
         ]);
+        articleFeedbacksFetched = true;
         lastArticleFeedbacks = articleFeedbacks;
         lastRefFeedbackByDoi = refFeedbackByDoi;
+        lastReferenceDoiKey = refKey;
 
         renderPubPeerPanel(articleFeedbacks, references, pageState, doiContext, refFeedbackByDoi, redacts);
     } catch {

--- a/src/content-general/injector.ts
+++ b/src/content-general/injector.ts
@@ -792,8 +792,11 @@ export function renderPubPeerPanel(
   retractions: RetractionResponse[] = []
 ): void {
   const existingHost = document.getElementById(PUBPEER_PANEL_ID);
-  const existingPanel = existingHost?.querySelector<HTMLElement>(".flora-sliding-panel");
-  const wasOpen = existingPanel?.style.transform === "translateX(0)";
+  // Track open state via a stateful marker on the host — comparing inline
+  // `transform` strings is fragile because browsers may normalise the value
+  // (e.g. `translateX(0)` → `translateX(0px)`). The marker is set in
+  // openPanel/closePanel below so reading it here is always reliable.
+  const wasOpen = existingHost?.dataset.floraPanelOpen === "1";
   cleanupTabPositioning();
   existingHost?.remove();
 
@@ -1409,6 +1412,7 @@ export function renderPubPeerPanel(
     // Clear animation fill so JS can freely control 'right'
     tab.style.animation = "none";
     isOpen = true;
+    host.dataset.floraPanelOpen = "1";
     panel.style.transform = "translateX(0)";
     tab.style.right = `${PANEL_WIDTH}px`;
     arrow.style.transform = "rotate(180deg)";
@@ -1421,6 +1425,7 @@ export function renderPubPeerPanel(
   const closePanel = (): void => {
     tab.style.animation = "none";
     isOpen = false;
+    host.dataset.floraPanelOpen = "0";
     panel.style.transform = "translateX(100%)";
     tab.style.right = "0";
     arrow.style.transform = "rotate(0deg)";
@@ -1445,7 +1450,20 @@ export function renderPubPeerPanel(
 
   setupTabPositioning(tab);
 
-  if (wasOpen) openPanel();
+  if (wasOpen) {
+    // The panel was already open before this re-render (e.g. references
+    // lazy-loaded and triggered a content refresh). Snap it straight to the
+    // open position without the 0.3s slide-in — otherwise the user perceives
+    // the panel as closing and reopening on every content update. Drop the
+    // transition for one frame, set the open state, then restore it so future
+    // user-driven open/close still animates.
+    const savedTransition = panel.style.transition;
+    panel.style.transition = "none";
+    openPanel();
+    // Force a reflow so the transition reset takes effect before re-enabling.
+    void panel.offsetHeight;
+    panel.style.transition = savedTransition;
+  }
 }
 
 export function removePubPeerPanel(): void {

--- a/src/content-general/references.ts
+++ b/src/content-general/references.ts
@@ -1,11 +1,10 @@
 // Reference-list DOI resolution for article pages.
 //
-// Surfaces a DOI pill on a reference whenever the DOI is *not visible to the
-// reader* — either because the page exposes no DOI for it at all (resolved via
-// Crossref/OpenAlex) or because the DOI is tucked into a non-doi.org button
-// link URL (e.g. tiny "Crossref"/"PubMed" buttons) where the reader can't see
-// it. References whose DOI is plainly written or on a doi.org link are left
-// alone.
+// Surfaces a DOI pill on every reference that has a DOI, so the reader gets
+// a consistent click-to-open/copy action on each citation. The pill colour
+// signals provenance: pink = DOI found directly on the page (in text or a
+// link href), gray dotted = DOI resolved via Crossref/OpenAlex augmentation
+// for entries that exposed no DOI of their own.
 
 import {findReferenceEntries, type ReferenceEntry} from "@shared/doi-extractor";
 import {augmentDOIs} from "@shared/doi-augment";
@@ -25,6 +24,11 @@ const CONFIDENT_COLOR = "#853953";
 const MAX_REFERENCE_AUGMENTATIONS = 30;
 // Skip entries too short to be a real citation (avoids junk augmentation queries).
 const MIN_CITATION_LENGTH = 16;
+// Real citations always have a publication year. Without one, the entry is
+// almost certainly a navigation stub (pagination, source-tab label, "Show more")
+// inside a reference container — sending those to Crossref/OpenAlex would
+// hallucinate a DOI and surface a stray pill on the section header.
+const YEAR_RE = /\b(?:18|19|20)\d{2}\b/;
 
 type PendingEntry =
   | { entry: ReferenceEntry; mode: "augment"; doi: null }
@@ -48,11 +52,16 @@ export async function processReferenceDois(): Promise<void> {
         if (entry.text.length < MIN_CITATION_LENGTH) continue;
 
         if (entry.doi === null) {
+            // Gate augmentation on year presence — avoids spending Crossref
+            // queries on navigation stubs that pass the length check.
+            if (!YEAR_RE.test(entry.text)) continue;
             pending.push({entry, mode: "augment", doi: null});
-        } else if (!isDoiVisibleToReader(entry, entry.doi)) {
+        } else {
+            // Pill on every entry with a DOI, regardless of whether the DOI
+            // string is written out in the citation — the pill gives a
+            // consistent copy/open affordance the reader can rely on.
             pending.push({entry, mode: "hidden", doi: entry.doi});
         }
-        // else: DOI is plainly visible — no pill needed
     }
     if (pending.length === 0) return;
 
@@ -130,14 +139,3 @@ export async function processReferenceDois(): Promise<void> {
     debugLog(`References: rendered ${confirmed.length} inline DOI pill(s)`);
 }
 
-/**
- * Decide whether a reference's DOI is already visible to the reader.
- *
- * "Visible" means the DOI string appears as a substring of the rendered
- * citation text (which includes every link's inner text). A doi.org URL with
- * a label like "Crossref" or "PubMed" does NOT count as visible — the reader
- * sees the label, not the DOI — and is exactly the case the pill surfaces.
- */
-function isDoiVisibleToReader(entry: ReferenceEntry, doi: DoiString): boolean {
-    return entry.text.toLowerCase().includes(doi);
-}

--- a/src/shared/doi-extractor.ts
+++ b/src/shared/doi-extractor.ts
@@ -416,8 +416,17 @@ export function extractDOIsFromText(text: string): DoiString[] {
   return [...found];
 }
 
-// Class/id tokens that indicate a reference or bibliography section
-const REFERENCE_SECTION_RE = /^(?:cited|cites?|citations?|bibliography|bibliograph(?:y|ies)|references?|reflist|ref-list|works-cited|footnotes?)$/i;
+// Class/id tokens that indicate a reference or bibliography section.
+// Plural/list-only forms — singular tokens like `citation`, `reference`, or
+// `footnote` are used by some publishers (notably Wiley's `class="citation"`
+// on the whole article wrapper) for non-list "how to cite" / single-ref UI,
+// which would otherwise mis-classify the entire article body as a reference
+// list. `works-cited` and `reflist`/`ref-list` are kept because the compound
+// form is unambiguous. `cited-by[__*]` covers Wiley's BEM-style citing-list
+// section (`<section class="cited-by">` / `id="cited-by"`); we deliberately
+// do not match Wiley's `rlist` class because it's a generic <ul> reset used
+// for skip-links, search nav, footer, related-journals, etc.
+const REFERENCE_SECTION_RE = /^(?:cites|citations|bibliography|bibliographies|references|reflist|ref-list|works-cited|footnotes|cited-by(?:__[\w-]+)?)$/i;
 
 function isReferenceContainer(el: Element): boolean {
   if (el.className) {
@@ -471,14 +480,12 @@ function cleanReferenceText(text: string): string {
 }
 
 /** Find the DOI already present in a single reference entry, if any. */
-function extractDoiFromEntry(entry: HTMLElement): DoiString | null {
-  // DOI links inside the entry — recognises doi.org URLs, ?doi= query params,
-  // and DOIs embedded in publisher landing-page URLs.
-  for (const link of entry.querySelectorAll<HTMLAnchorElement>("a[href]")) {
-    const doi = extractDoiFromHref(link.href);
-    if (doi) return doi;
-  }
-  // DOI written out in the visible citation text
+function extractDoiFromEntry(entry: HTMLElement, hostDoi: DoiString | null): DoiString | null {
+  // Visible citation text wins — that's the reliable signal of which paper
+  // the entry is *about*. Links inside the entry are often nav/action
+  // buttons ("View", "Cite", "Add to favorites") that point at the current
+  // article, not the cited/citing paper — using them first caused every
+  // Wiley cited-by row to resolve to the host article's own DOI.
   const text = entry.innerText ?? entry.textContent ?? "";
   const cleaned = decodeEncodedDois(text.replace(WORD_BREAK_CHARS, ""));
   for (const match of cleaned.matchAll(DOI_TEXT_REGEX)) {
@@ -486,6 +493,15 @@ function extractDoiFromEntry(entry: HTMLElement): DoiString | null {
     if (!isValidDoiSuffix(raw)) continue;
     const doi = normaliseDOI(raw);
     if (doi) return doi;
+  }
+  // Fall back to link hrefs only when no DOI is written out — covers entries
+  // where the DOI is tucked into a "Crossref"/"PubMed" button URL. Skip
+  // links resolving to the host article's own DOI (Wiley sprinkles "View"
+  // jumplinks pointing at the current article inside the cited-by section),
+  // otherwise those non-citation stubs render a stray pill on the header.
+  for (const link of entry.querySelectorAll<HTMLAnchorElement>("a[href]")) {
+    const doi = extractDoiFromHref(link.href);
+    if (doi && doi !== hostDoi) return doi;
   }
   return null;
 }
@@ -565,9 +581,10 @@ export function findReferenceEntries(doc: Document): ReferenceEntry[] {
     }
   }
 
+  const hostDoi = extractPrimaryDOI(doc);
   return elements.map((element) => ({
     element,
-    doi: extractDoiFromEntry(element),
+    doi: extractDoiFromEntry(element, hostDoi),
     text: cleanReferenceText(element.innerText ?? element.textContent ?? ""),
   }));
 }

--- a/src/shared/pubpeer-api.ts
+++ b/src/shared/pubpeer-api.ts
@@ -10,6 +10,12 @@ export interface PubPeerFeedback {
   url: string;
 }
 
+export class PubPeerRateLimitError extends Error {
+  constructor(public retryAfterMs: number) {
+    super(`PubPeer rate limited (retry after ${retryAfterMs}ms)`);
+  }
+}
+
 export async function lookupPubPeer(
   dois: string[],
   urls: string[]
@@ -27,6 +33,10 @@ export async function lookupPubPeer(
       }),
     }
   );
+  if (response.status === 429) {
+    const retryAfter = parseInt(response.headers.get("Retry-After") ?? "0", 10);
+    throw new PubPeerRateLimitError((retryAfter > 0 ? retryAfter : 60) * 1000);
+  }
   if (!response.ok) {
     throw new Error(`PubPeer API error: ${response.status}`);
   }
@@ -37,8 +47,18 @@ export async function lookupPubPeer(
 const CACHE_PREFIX = "flora_pubpeer:";
 const CACHE_TTL = 24 * 60 * 60 * 1000; // 24h — comment counts change over time
 // How many per-DOI PubPeer requests to keep in flight at once. Reference lists
-// can be long; this keeps page load from issuing dozens of parallel requests.
-const DOI_LOOKUP_CONCURRENCY = 6;
+// can be long (Wiley cited-by sections hit 100+); a low ceiling avoids
+// tripping PubPeer's per-IP rate limit on first page load.
+const DOI_LOOKUP_CONCURRENCY = 2;
+// Hard cap on per-page reference lookups. Anything past this is left for the
+// next page visit (already-cached DOIs from prior visits still resolve). 60 is
+// chosen so a typical bibliography fits while pathological cited-by lists
+// (100s of entries) don't burst-DDoS PubPeer.
+const MAX_REFERENCE_LOOKUPS = 60;
+
+// Module-level back-off — when PubPeer returns 429, suppress further requests
+// until this timestamp passes so we don't keep retrying every DOM tick.
+let rateLimitedUntil = 0;
 
 interface CachedFeedback {
   feedback: PubPeerFeedback | null;
@@ -63,10 +83,18 @@ export async function lookupPubPeerByDoi(doi: string): Promise<PubPeerFeedback |
     // storage unavailable — fall through to network
   }
 
+  // Honour module-level back-off after a 429 — avoids piling on requests we
+  // know will fail and prolong the rate limit.
+  if (Date.now() < rateLimitedUntil) return null;
+
   let feedback: PubPeerFeedback | null;
   try {
     feedback = (await lookupPubPeer([doi], []))[0] ?? null;
-  } catch {
+  } catch (err) {
+    if (err instanceof PubPeerRateLimitError) {
+      rateLimitedUntil = Date.now() + err.retryAfterMs;
+      debugLog(`PubPeer: rate limited; backing off ${err.retryAfterMs}ms`);
+    }
     return null; // network/API error — don't cache a failure
   }
 
@@ -90,10 +118,27 @@ export async function lookupPubPeerForDois<T extends string>(
   const result = new Map<T, PubPeerFeedback>();
   if (dois.length === 0) return result;
 
+  // Cap network lookups. Already-cached DOIs are served by lookupPubPeerByDoi
+  // (cheap), so split the list: serve cached entries for everything, but only
+  // issue network requests for up to MAX_REFERENCE_LOOKUPS uncached DOIs.
+  let networkBudget = MAX_REFERENCE_LOOKUPS;
   let index = 0;
   const worker = async (): Promise<void> => {
     while (index < dois.length) {
       const doi = dois[index++];
+      const key = CACHE_PREFIX + doi;
+      let isCached = false;
+      try {
+        const cached = await chrome.storage.local.get(key);
+        const entry = cached[key] as CachedFeedback | undefined;
+        isCached = !!(entry && Date.now() - entry.timestamp < CACHE_TTL);
+      } catch {
+        // storage unavailable — treat as uncached
+      }
+      if (!isCached) {
+        if (networkBudget <= 0) continue;
+        networkBudget--;
+      }
       const feedback = await lookupPubPeerByDoi(doi);
       if (feedback) result.set(doi, feedback);
     }

--- a/tests/unit/doi-extractor.test.ts
+++ b/tests/unit/doi-extractor.test.ts
@@ -2,7 +2,12 @@ import { describe, it, expect } from "vitest";
 import { readFileSync } from "fs";
 import { join } from "path";
 import { JSDOM } from "jsdom";
-import { extractDOIs, extractDOIsFromText } from "../../src/shared/doi-extractor";
+import {
+  extractDOIs,
+  extractDOIsFromText,
+  findReferenceContainers,
+  findReferenceEntries,
+} from "../../src/shared/doi-extractor";
 
 function loadFixture(name: string): Document {
   const html = readFileSync(
@@ -476,5 +481,162 @@ describe("extractDOIsFromText", () => {
   it("extracts DOI with Unicode characters in the suffix (spec example 3)", () => {
     const dois = extractDOIsFromText("10.26321/Á.GUTIÉRREZ.ZARZA.02.2018.03");
     expect(dois).toEqual(["10.26321/á.gutiérrez.zarza.02.2018.03"]);
+  });
+});
+
+// Reference-section detection covers two recurring failure modes seen on
+// Wiley:
+//   1. Singular tokens (`citation`, `reference`, `footnote`) are used as
+//      wrappers for non-list UI (e.g. the whole article body lives in
+//      `<div class="citation">`); matching them mis-classifies body content.
+//   2. The class `rlist` is Wiley's generic <ul> reset, used everywhere
+//      (skip-links, search nav, footer, recommended sidebar) — matching it
+//      pulls in dozens of non-references.
+// Plural / list-only tokens, the BEM `cited-by[__suffix]` family, and the
+// `cited-by` id stay matched.
+describe("findReferenceContainers", () => {
+  it("does not match Wiley's `<div class=\"citation\">` article wrapper (singular token)", () => {
+    const html = `<!DOCTYPE html>
+      <html><body>
+        <div class="citation">
+          <p>Article body paragraph one with 10.1111/aaa.0001.</p>
+          <p>Article body paragraph two with 10.1111/bbb.0002.</p>
+        </div>
+      </body></html>`;
+    const doc = new JSDOM(html).window.document;
+    expect(findReferenceContainers(doc)).toHaveLength(0);
+  });
+
+  it("does not match `rlist` alone (Wiley's generic <ul> reset class)", () => {
+    const html = `<!DOCTYPE html>
+      <html><body>
+        <ul class="rlist"><li>Skip to content</li><li>Skip to info</li></ul>
+        <ul class="rlist tab__content"><li>Search</li><li>Browse</li></ul>
+        <ul class="rlist lot"><li>Recommended A</li><li>Recommended B</li></ul>
+      </body></html>`;
+    const doc = new JSDOM(html).window.document;
+    expect(findReferenceContainers(doc)).toHaveLength(0);
+  });
+
+  it("matches `cited-by` id and class (Wiley's citing-literature section)", () => {
+    const html = `<!DOCTYPE html>
+      <html><body>
+        <section id="cited-by" class="article-section cited-by">
+          <ul><li>Entry 1</li><li>Entry 2</li></ul>
+        </section>
+      </body></html>`;
+    const doc = new JSDOM(html).window.document;
+    const containers = findReferenceContainers(doc);
+    expect(containers).toHaveLength(1);
+    expect((containers[0] as HTMLElement).id).toBe("cited-by");
+  });
+
+  it("matches BEM `cited-by__list` suffix token", () => {
+    const html = `<!DOCTYPE html>
+      <html><body>
+        <ul class="rlist cited-by__list">
+          <li>Entry 1</li><li>Entry 2</li>
+        </ul>
+      </body></html>`;
+    const doc = new JSDOM(html).window.document;
+    const containers = findReferenceContainers(doc);
+    expect(containers).toHaveLength(1);
+    expect((containers[0] as HTMLElement).tagName).toBe("UL");
+  });
+
+  it("still matches traditional `references` / `bibliography` containers", () => {
+    const html = `<!DOCTYPE html>
+      <html><body>
+        <ol class="references"><li>Ref A</li><li>Ref B</li></ol>
+        <ul id="bibliography"><li>Bib A</li><li>Bib B</li></ul>
+      </body></html>`;
+    const doc = new JSDOM(html).window.document;
+    expect(findReferenceContainers(doc)).toHaveLength(2);
+  });
+});
+
+describe("findReferenceEntries", () => {
+  it("prefers DOI written in entry text over a link href", () => {
+    // Wiley cited-by rows write the citing paper's DOI in plain text but
+    // their single link is a redirect URL containing the *host* article's
+    // DOI as a query param. Text-first extraction is what avoids resolving
+    // every row to the host paper.
+    const html = `<!DOCTYPE html>
+      <html><body>
+        <section id="cited-by">
+          <ul>
+            <li class="citedByEntry">
+              <span>Author A, Title, Journal, 10.1111/aaa.0001, (2025).</span>
+              <a href="https://example.com/action?doi=10.9999/host.doi&doiOfLink=10.1111/aaa.0001">View</a>
+            </li>
+            <li class="citedByEntry">
+              <span>Author B, Title, Journal, 10.2222/bbb.0002, (2024).</span>
+              <a href="https://example.com/action?doi=10.9999/host.doi&doiOfLink=10.2222/bbb.0002">View</a>
+            </li>
+          </ul>
+        </section>
+      </body></html>`;
+    const doc = new JSDOM(html).window.document;
+    const entries = findReferenceEntries(doc);
+    expect(entries).toHaveLength(2);
+    expect(entries[0].doi).toBe("10.1111/aaa.0001");
+    expect(entries[1].doi).toBe("10.2222/bbb.0002");
+  });
+
+  it("skips host-article DOI in link fallback so navigation stubs resolve to null", () => {
+    // Entry has no DOI in visible text and its only link is a Wiley
+    // redirect whose `doi=` query param is the host article — without the
+    // host-DOI guard, this would mis-resolve to the page's own DOI and
+    // surface a stray pill.
+    const html = `<!DOCTYPE html>
+      <html>
+        <head><meta name="citation_doi" content="10.9999/host.doi"></head>
+        <body>
+          <section id="cited-by">
+            <ul>
+              <li class="citedByEntry">
+                <span>Long enough non-citation header text for the length gate</span>
+                <a href="https://example.com/action?doi=10.9999/host.doi">More</a>
+              </li>
+              <li class="citedByEntry">
+                <span>Another non-citation stub long enough to pass min length</span>
+                <a href="https://example.com/action?doi=10.9999/host.doi">More</a>
+              </li>
+            </ul>
+          </section>
+        </body>
+      </html>`;
+    const doc = new JSDOM(html).window.document;
+    const entries = findReferenceEntries(doc);
+    expect(entries).toHaveLength(2);
+    expect(entries[0].doi).toBeNull();
+    expect(entries[1].doi).toBeNull();
+  });
+
+  it("falls back to a non-host link DOI when entry text has no DOI", () => {
+    // This is the legitimate hidden-DOI case (Crossref-style button URL).
+    // Link fallback should fire when text yields nothing AND the link's DOI
+    // is not the host's.
+    const html = `<!DOCTYPE html>
+      <html>
+        <head><meta name="citation_doi" content="10.9999/host.doi"></head>
+        <body>
+          <ol class="references">
+            <li>
+              Smith J. Title. Journal. 2020.
+              <a href="https://www.crossref.org/openurl?doi=10.1234/found.via.button">Crossref</a>
+            </li>
+            <li>
+              Jones K. Another. 2021.
+              <a href="https://www.crossref.org/openurl?doi=10.5678/also.found">Crossref</a>
+            </li>
+          </ol>
+        </body>
+      </html>`;
+    const doc = new JSDOM(html).window.document;
+    const entries = findReferenceEntries(doc);
+    expect(entries).toHaveLength(2);
+    expect(entries[0].doi).toBe("10.1234/found.via.button");
+    expect(entries[1].doi).toBe("10.5678/also.found");
   });
 });


### PR DESCRIPTION
Add smarter PubPeer request handling and make reference DOI pills more consistent. Key changes:

- Track articleFeedbacksFetched and lastReferenceDoiKey to skip redundant re-renders when the article feedbacks and reference DOI set are unchanged.
- PubPeer API: add PubPeerRateLimitError, handle 429 Retry-After, introduce module-level back-off (rateLimitedUntil), reduce per-DOI concurrency from 6 to 2, and add a MAX_REFERENCE_LOOKUPS cap to avoid bursting many requests. Network lookups honor the back-off and cached entries are served from storage.
- Reference processing: always surface a DOI pill for entries that have a DOI (consistent copy/open affordance). Gate Crossref/OpenAlex augmentation on the presence of a 4-digit year to avoid augmenting navigation stubs, and cap augmentations.
- DOI extraction improvements: refine reference-section detection regex to avoid mis-classifying article wrapper elements; prefer visible citation text when extracting a DOI and only fall back to link hrefs (skipping links pointing to the host DOI) to prevent false matches (e.g., Wiley cited-by rows).

These changes reduce unnecessary network traffic, avoid false-positive DOI matches, and provide a more consistent UI for reference DOIs.