### PR TITLE
Add prominent callout explaining email use

### DIFF
--- a/src/options/index.html
+++ b/src/options/index.html
@@ -60,25 +60,50 @@
                 data on every article you read.
               </div>
 
-              <div class="dh-apa">
-                <div class="dh-apa-label">Why an Email?</div>
-                <div class="dh-apa-text">
-                  FLoRA queries the
-                  <a
-                    href="https://api.crossref.org"
-                    target="_blank"
-                    rel="noopener"
-                    >Crossref</a
+              <div class="dh-callout" role="note">
+                <div class="dh-callout-icon" aria-hidden="true">
+                  <svg
+                    width="20"
+                    height="20"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
                   >
-                  and
-                  <a
-                    href="https://api.openalex.org"
-                    target="_blank"
-                    rel="noopener"
-                    >OpenAlex</a
-                  >
-                  APIs to resolve article DOIs. Both services request a contact
-                  email for their polite-access pool &mdash; faster rate limits
+                    <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z" />
+                    <polyline points="22,6 12,13 2,6" />
+                  </svg>
+                </div>
+                <div class="dh-callout-body">
+                  <div class="dh-callout-title">Why we ask for your email</div>
+                  <p class="dh-callout-text">
+                    FLoRA queries the
+                    <a
+                      href="https://api.crossref.org"
+                      target="_blank"
+                      rel="noopener"
+                      >Crossref</a
+                    >
+                    and
+                    <a
+                      href="https://api.openalex.org"
+                      target="_blank"
+                      rel="noopener"
+                      >OpenAlex</a
+                    >
+                    APIs to resolve article DOIs. Both services ask for a
+                    contact email so they can place your requests in their
+                    <strong>polite-access pool</strong> &mdash; meaning faster
+                    rate limits and more reliable lookups while you browse.
+                  </p>
+                  <p class="dh-callout-text dh-callout-text--muted">
+                    Your email is used <strong>only</strong> as a
+                    <code>mailto</code> parameter sent to Crossref &amp;
+                    OpenAlex. It is never stored on a FLoRA server, shared, or
+                    used for anything else.
+                  </p>
                 </div>
               </div>
             </div>
@@ -116,14 +141,7 @@
               </div>
             </form>
 
-            <!-- Info section -->
-            <div class="info-section">
-              <p class="hint">
-                Your email is only sent as a <code>mailto</code> query parameter
-                to Crossref &amp; OpenAlex for polite API access.
-              </p>
-              <p id="status-msg" class="status" hidden></p>
-            </div>
+            <p id="status-msg" class="status status-block" hidden></p>
           </div>
 
           <!-- ═══ BLOCKED DOMAINS ═══ -->

--- a/src/options/styles.css
+++ b/src/options/styles.css
@@ -250,6 +250,82 @@ body {
   text-decoration: underline;
 }
 
+/* Prominent callout (e.g. "Why we ask for your email") */
+.dh-callout {
+  margin-top: 1.1rem;
+  padding: 1rem 1.1rem;
+  background: var(--primary-faint);
+  border: 1px solid var(--success-border);
+  border-left: 4px solid var(--primary);
+  border-radius: var(--radius);
+  display: flex;
+  gap: 0.85rem;
+  align-items: flex-start;
+}
+
+.dh-callout-icon {
+  flex: 0 0 auto;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: var(--primary);
+  color: var(--white);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 2px;
+}
+
+.dh-callout-body {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.dh-callout-title {
+  font-family: var(--font-display);
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--primary-dark);
+  line-height: 1.3;
+  margin-bottom: 0.4rem;
+}
+
+.dh-callout-text {
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--text);
+  margin-bottom: 0.55rem;
+}
+
+.dh-callout-text:last-child {
+  margin-bottom: 0;
+}
+
+.dh-callout-text--muted {
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.dh-callout-text a {
+  color: var(--primary);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  font-weight: 600;
+}
+
+.dh-callout-text a:hover {
+  color: var(--primary-dark);
+}
+
+.dh-callout-text code {
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 0.85em;
+  padding: 1px 5px;
+  background: var(--white);
+  border: 1px solid var(--border-light);
+  border-radius: 4px;
+}
+
 /* ─── Form section ─── */
 .form-section {
   padding: 1.5rem 1.75rem;
@@ -264,27 +340,6 @@ label {
 }
 
 /* email input styling now handled by .ab-input */
-
-.info-section {
-  padding: 0.75rem 1.75rem 1rem;
-  border-top: 1px solid var(--border-light);
-}
-
-.hint {
-  font-size: 11.5px;
-  color: var(--text-muted);
-  margin-top: 0.4rem;
-  margin-bottom: 0;
-  line-height: 1.45;
-}
-
-.hint code {
-  background: var(--surface);
-  padding: 0.1rem 0.35rem;
-  border-radius: 3px;
-  font-size: 10.5px;
-  color: var(--text-secondary);
-}
 
 /* ─── Action bar ─── */
 .action-bar {
@@ -391,6 +446,10 @@ label {
   color: var(--error);
   background: var(--error-bg);
   border: 1px solid rgba(180, 35, 24, 0.15);
+}
+
+.status-block {
+  margin: 0 1.75rem 1.25rem;
 }
 
 /* ═══════════════════════════════


### PR DESCRIPTION
Replace the small info section with a styled .dh-callout component in the options page to clearly explain why an email is requested (polite-access pool for Crossref/OpenAlex and privacy guarantees). Add comprehensive CSS for the callout (icon, title, body, link and code styles), remove the old .info-section/.hint styles, and adjust the status message to use .status-block for consistent spacing.