### PR TITLE
Use persistent LocalCache with quota and UI

### DIFF
--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -1,18 +1,39 @@
-import {SessionCache} from "@shared/cache";
+import {LocalCache, MONTH_MS} from "@shared/cache";
 import {lookupDOIs} from "@shared/flora-api";
 import {RET_MAP_KEY, storageSync} from "@shared/data-extract";
 import type {DoiString, ReplicationResult} from "@shared/types";
 import {LookupResponse, SheetFetchResponse} from "@shared/messages";
 import {isLookupRequest, isSheetFetchRequest} from "@shared/messages";
-import {isSetupComplete} from "@shared/settings";
+import {getSettings, isSetupComplete} from "@shared/settings";
 
-const cache = new SessionCache<ReplicationResult>("flora");
+const cache = new LocalCache<ReplicationResult>("flora");
 
-// Open the walkthrough on first install
+// Initialise cache quota from persisted settings (service worker may restart).
+getSettings().then(({ cacheQuotaMb }) => {
+    cache.setQuota(cacheQuotaMb === 0 ? 0 : cacheQuotaMb * 1024 * 1024);
+}).catch();
+
+// Keep quota in sync when the user changes the setting.
+chrome.storage.onChanged.addListener((changes, area) => {
+    if (area === "sync" && "flora_settings" in changes) {
+        const next = (changes["flora_settings"].newValue as { cacheQuotaMb?: number } | undefined);
+        if (next?.cacheQuotaMb != null) {
+            cache.setQuota(next.cacheQuotaMb === 0 ? 0 : next.cacheQuotaMb * 1024 * 1024);
+        }
+    }
+});
+
+// Open the walkthrough on first install and seed retraction data immediately.
 chrome.runtime.onInstalled.addListener((details) => {
     if (details.reason === "install") {
         chrome.tabs.create({ url: chrome.runtime.getURL("dist/walkthrough.html") });
     }
+    syncRetractionsInfo().then().catch();
+});
+
+// Refresh retraction data once per browser session (weekly interval enforced inside).
+chrome.runtime.onStartup.addListener(() => {
+    syncRetractionsInfo().then().catch();
 });
 
 
@@ -66,15 +87,6 @@ chrome.runtime.onMessage.addListener(
             });
             return true;
         }
-        if (
-            typeof message === "object" &&
-            message !== null &&
-            (message as { type?: string }).type === "FLORA_RET_SYNC"
-        ) {
-            syncRetractionsInfo().then().catch();
-            return true;
-        }
-
         if (isSheetFetchRequest(message)) {
             handleSheetFetch(message.spreadsheetId, message.gid)
                 .then(sendResponse)
@@ -100,8 +112,9 @@ async function handleLookup(dois: DoiString[]): Promise<LookupResponse> {
     // Check cache and in-flight requests
     for (const doi of dois) {
         const cached = await cache.get(doi);
-        if (cached !== null) {
-            results[doi] = cached;
+        if (cached !== undefined) {
+            // undefined = not cached; null = cached no-match; T = cached match
+            if (cached !== null) results[doi] = cached;
         } else if (inflight.has(doi)) {
             const r = await inflight.get(doi)!;
             if (r) results[doi] = r;
@@ -133,7 +146,9 @@ async function handleLookup(dois: DoiString[]): Promise<LookupResponse> {
             const r = apiResults.get(doi);
             if (r) {
                 results[doi] = r;
-                await cache.set(doi, r);
+                await cache.set(doi, r, null); // resolved — cache forever
+            } else {
+                await cache.set(doi, null, MONTH_MS); // no match — cache for 1 month
             }
         }
     } catch (err) {

--- a/src/content-general/index.ts
+++ b/src/content-general/index.ts
@@ -7,7 +7,6 @@ import {
 } from "@shared/doi-extractor";
 import {augmentDOIs, fetchTitleByDoi} from "@shared/doi-augment";
 import {validateDOIs} from "@shared/doi-validate";
-import {debounce} from "@shared/debounce";
 import type {DoiContext, DoiString, LookupState} from "@shared/types";
 import type {
     LookupRequest,
@@ -586,9 +585,14 @@ function startDomListener(callback: () => void) {
             }
         }, 1500);
     } else {
-        debounce(pageRenderChangeHandler, 1000);
-        startDomListener(pageRenderChangeHandler);
         // Initial run — static pages may never trigger the MutationObserver.
         void pageRenderChangeHandler();
+        // Defer the DOM observer until after full page load so mutations during
+        // initial resource loading don't trigger repeated handler calls.
+        if (document.readyState === "complete") {
+            startDomListener(pageRenderChangeHandler);
+        } else {
+            window.addEventListener("load", () => startDomListener(pageRenderChangeHandler), { once: true });
+        }
     }
 })();

--- a/src/options/index.html
+++ b/src/options/index.html
@@ -168,6 +168,45 @@
             </label>
           </div>
 
+          <!-- ═══ CACHE STORAGE ═══ -->
+          <div class="detail-card" style="margin-top: 1.25rem">
+            <div class="dh">
+              <div class="dh-label">Performance</div>
+              <h2 class="dh-title">Cache Storage Limit</h2>
+              <div class="dh-authors">
+                FLoRA stores DOI lookup results locally so pages load faster on
+                repeat visits. Set how much browser storage it may use. Enter
+                <strong>0</strong> for unlimited.
+              </div>
+            </div>
+
+            <div class="action-bar" style="align-items: flex-end;">
+              <div class="ab-group">
+                <label class="ab-label" for="cache-quota-input">Limit (MB)</label>
+                <input
+                  id="cache-quota-input"
+                  type="number"
+                  class="ab-input"
+                  min="0"
+                  step="50"
+                  placeholder="500"
+                  style="width: 120px;"
+                />
+              </div>
+              <div class="ab-sep"></div>
+              <div class="ab-group">
+                <button type="button" id="cache-quota-save-btn" class="ab-btn accent">
+                  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <path d="M20 6L9 17l-5-5" />
+                  </svg>
+                  Save
+                </button>
+              </div>
+            </div>
+
+            <p id="cache-quota-status" class="status domain-status" hidden></p>
+          </div>
+
           <!-- ═══ BLOCKED DOMAINS ═══ -->
           <div class="detail-card" style="margin-top: 1.25rem">
             <div class="dh">

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -47,6 +47,38 @@ allRefsToggle.addEventListener("change", () => {
   void saveSettings({ showDoiPillsOnAllReferences: allRefsToggle.checked });
 });
 
+// ── Cache storage quota ─────────────────────────────────────────────
+
+const cacheQuotaInput = document.getElementById("cache-quota-input") as HTMLInputElement;
+const cacheQuotaSaveBtn = document.getElementById("cache-quota-save-btn") as HTMLButtonElement;
+const cacheQuotaStatus = document.getElementById("cache-quota-status") as HTMLParagraphElement;
+
+getSettings().then(({ cacheQuotaMb }) => {
+  cacheQuotaInput.value = String(cacheQuotaMb);
+});
+
+cacheQuotaSaveBtn.addEventListener("click", async () => {
+  const raw = parseInt(cacheQuotaInput.value, 10);
+  const cacheQuotaMb = isNaN(raw) || raw < 0 ? 500 : raw;
+  cacheQuotaInput.value = String(cacheQuotaMb);
+  cacheQuotaSaveBtn.disabled = true;
+  try {
+    await saveSettings({ cacheQuotaMb });
+    cacheQuotaStatus.textContent = cacheQuotaMb === 0
+      ? "Storage limit removed — cache is unlimited."
+      : `Storage limit set to ${cacheQuotaMb} MB.`;
+    cacheQuotaStatus.className = "status domain-status success";
+    cacheQuotaStatus.hidden = false;
+    setTimeout(() => { cacheQuotaStatus.hidden = true; }, 3000);
+  } catch {
+    cacheQuotaStatus.textContent = "Failed to save — please try again.";
+    cacheQuotaStatus.className = "status domain-status error";
+    cacheQuotaStatus.hidden = false;
+  } finally {
+    cacheQuotaSaveBtn.disabled = false;
+  }
+});
+
 // ── Domain blocklist ────────────────────────────────────────────────
 
 const domainInput = document.getElementById("domain-input") as HTMLInputElement;

--- a/src/shared/cache.ts
+++ b/src/shared/cache.ts
@@ -1,35 +1,77 @@
 import type { CachedEntry } from "./types";
 
-const DEFAULT_TTL_MS = 60 * 60 * 1000; // 1 hour
+export const MONTH_MS = 30 * 24 * 60 * 60 * 1000;
 
 /**
- * Session cache wrapper using chrome.storage.session.
- * Entries expire after the configured TTL.
+ * Persistent cache using chrome.storage.local.
+ * Supports per-entry TTL or permanent storage (ttlMs = null).
+ * Enforces a soft storage quota by evicting expired entries when approached.
  */
-export class SessionCache<T> {
+export class LocalCache<T> {
+  private quotaBytes: number;
+
   constructor(
     private readonly prefix: string,
-    private readonly ttlMs: number = DEFAULT_TTL_MS
-  ) {}
+    quotaBytes: number = 500 * 1024 * 1024
+  ) {
+    this.quotaBytes = quotaBytes;
+  }
 
-  async get(key: string): Promise<T | null> {
+  /** Update the quota at runtime (e.g. after the user changes the setting). */
+  setQuota(bytes: number): void {
+    this.quotaBytes = bytes;
+  }
+
+  /**
+   * Returns:
+   *  - `undefined`  — not in cache (or expired)
+   *  - `null`       — cached no-match (negative result)
+   *  - `T`          — cached match
+   */
+  async get(key: string): Promise<T | null | undefined> {
     const storageKey = this.storageKey(key);
-    const result = await chrome.storage.session.get(storageKey);
+    const result = await chrome.storage.local.get(storageKey);
     const entry = result[storageKey] as CachedEntry<T> | undefined;
 
-    if (!entry) return null;
+    if (!entry) return undefined;
 
-    if (Date.now() - entry.timestamp > this.ttlMs) {
-      await chrome.storage.session.remove(storageKey);
-      return null;
+    if (entry.expiresAt !== null && Date.now() > entry.expiresAt) {
+      await chrome.storage.local.remove(storageKey);
+      return undefined;
     }
 
     return entry.data;
   }
 
-  async set(key: string, data: T): Promise<void> {
-    const entry: CachedEntry<T> = { data, timestamp: Date.now() };
-    await chrome.storage.session.set({ [this.storageKey(key)]: entry });
+  /**
+   * @param data    The value to cache; pass `null` to record a negative result.
+   * @param ttlMs   Milliseconds until expiry, or `null` to cache forever.
+   */
+  async set(key: string, data: T | null, ttlMs: number | null): Promise<void> {
+    await this.sweepIfOverQuota();
+    const expiresAt = ttlMs === null ? null : Date.now() + ttlMs;
+    const entry: CachedEntry<T> = { data, expiresAt };
+    await chrome.storage.local.set({ [this.storageKey(key)]: entry });
+  }
+
+  private async sweepIfOverQuota(): Promise<void> {
+    if (this.quotaBytes === 0) return; // 0 = unlimited
+    const used = await chrome.storage.local.getBytesInUse(null);
+    if (used < this.quotaBytes) return;
+
+    // Evict all expired entries for this cache prefix to reclaim space
+    const all = await chrome.storage.local.get(null);
+    const now = Date.now();
+    const expired = Object.keys(all)
+      .filter(k => k.startsWith(`${this.prefix}:`))
+      .filter(k => {
+        const e = all[k] as CachedEntry<T> | undefined;
+        return e?.expiresAt != null && now > e.expiresAt;
+      });
+
+    if (expired.length > 0) {
+      await chrome.storage.local.remove(expired);
+    }
   }
 
   private storageKey(key: string): string {

--- a/src/shared/doi-retraction.ts
+++ b/src/shared/doi-retraction.ts
@@ -120,31 +120,42 @@ const NORMALISED_BUNDLED: RetractionMaps = {
     concerns: lowercaseKeys((retractionData as RetractionMaps).concerns),
 };
 
+// In-memory cache of the normalized retraction source. Populated on the first
+// retractionCheck call and invalidated whenever the background sync writes new
+// data to storage — so lowercaseKeys runs once per sync, not once per call.
+let cachedSource: RetractionMaps | null = null;
+
+chrome.storage.onChanged.addListener((changes, area) => {
+    if (area === "local" && RET_MAP_KEY in changes) {
+        cachedSource = null;
+    }
+});
+
+async function getRetractionSource(): Promise<RetractionMaps> {
+    if (cachedSource) return cachedSource;
+
+    const storageResult = await chrome.storage.local.get([RET_MAP_KEY]);
+    const stored = storageResult[RET_MAP_KEY] as RetractionMaps | undefined;
+
+    const hasCachedData = !!stored && (
+        Object.keys(stored.retractions || {}).length > 0 ||
+        Object.keys(stored.concerns || {}).length > 0
+    );
+
+    cachedSource = hasCachedData
+        ? { retractions: lowercaseKeys(stored!.retractions), concerns: lowercaseKeys(stored!.concerns) }
+        : NORMALISED_BUNDLED;
+
+    return cachedSource;
+}
+
 /**
  * Request retraction status. Due to CORS policies, the request
  * must execute in the background context.
  */
 // @ts-ignore
 export async function retractionCheck(dois: DoiString[]): Promise<RetractionResponse[]> {
-    const storageResult = await chrome.storage.local.get([RET_MAP_KEY]) || {};
-    const cached = storageResult[RET_MAP_KEY] as RetractionMaps | undefined;
-    if (!cached)
-        chrome.runtime.sendMessage({type: "FLORA_RET_SYNC"}).then().catch();
-    // Prefer the runtime-refreshed map, fall back to the bundled data. A
-    // cached payload with only concerns is still useful, so consider both
-    // maps when deciding whether the cache is meaningful.
-    const hasCachedData = !!cached && (
-        Object.keys(cached.retractions || {}).length > 0 ||
-        Object.keys(cached.concerns || {}).length > 0
-    );
-    // Cached storage comes back as a fresh object every call (chrome.storage
-    // re-parses JSON), so we normalise on the spot rather than caching.
-    const source: RetractionMaps = hasCachedData
-        ? {
-            retractions: lowercaseKeys(cached!.retractions),
-            concerns: lowercaseKeys(cached!.concerns),
-        }
-        : NORMALISED_BUNDLED;
+    const source = await getRetractionSource();
     const result: RetractionResponse[] = [];
     for (const doi of dois) {
         const retractionDOI = source.retractions[doi];

--- a/src/shared/doi-retraction.ts
+++ b/src/shared/doi-retraction.ts
@@ -181,6 +181,11 @@ export function resetRetractionPills(): void {
     pilledRetractionDois.clear();
 }
 
+/** Reset the in-memory retraction source cache — for use in tests only. */
+export function resetRetractionCache(): void {
+    cachedSource = null;
+}
+
 export interface InjectRetractionOptions {
     /**
      * Skip the link-search smart placement and append the pill directly to

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -9,6 +9,11 @@ export interface FloraSettings {
    * visible DOI of their own get a pill.
    */
   showDoiPillsOnAllReferences: boolean;
+  /**
+   * Soft cap on chrome.storage.local usage in MB. 0 = unlimited.
+   * Expired cache entries are evicted when this limit is approached.
+   */
+  cacheQuotaMb: number;
 }
 
 const STORAGE_KEY = "flora_settings";
@@ -16,6 +21,7 @@ const STORAGE_KEY = "flora_settings";
 const DEFAULTS: FloraSettings = {
   email: "",
   showDoiPillsOnAllReferences: false,
+  cacheQuotaMb: 500,
 };
 
 /** Read current settings (returns defaults for any missing keys). */

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -94,8 +94,8 @@ export type ApiResponse = z.infer<typeof ApiResponseSchema>;
 
 /** Cache entry with TTL tracking */
 export interface CachedEntry<T> {
-  data: T;
-  timestamp: number;
+  data: T | null; // null = cached no-match
+  expiresAt: number | null; // null = never expires
 }
 
 /** How a DOI was classified on the page */

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -20,7 +20,13 @@ const storageMock = {
 
 Object.defineProperty(globalThis, "chrome", {
   value: {
-    storage: storageMock,
+    storage: {
+      ...storageMock,
+      onChanged: {
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+      },
+    },
     runtime: {
       id: "test-extension-id",
       sendMessage: vi.fn().mockResolvedValue({
@@ -33,6 +39,9 @@ Object.defineProperty(globalThis, "chrome", {
         removeListener: vi.fn(),
       },
       onInstalled: {
+        addListener: vi.fn(),
+      },
+      onStartup: {
         addListener: vi.fn(),
       },
       openOptionsPage: vi.fn(),

--- a/tests/unit/cache.test.ts
+++ b/tests/unit/cache.test.ts
@@ -1,70 +1,94 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { SessionCache } from "../../src/shared/cache";
+import { LocalCache } from "../../src/shared/cache";
 
-describe("SessionCache", () => {
+describe("LocalCache", () => {
   let store: Record<string, unknown>;
 
   beforeEach(() => {
     store = {};
 
-    chrome.storage.session.get = vi.fn(async (key: string) => {
-      return key in store ? { [key]: store[key] } : {};
+    chrome.storage.local.get = vi.fn(async (key: string | string[] | null) => {
+      if (key === null) return { ...store };
+      const k = Array.isArray(key) ? key[0] : key;
+      return k in store ? { [k]: store[k] } : {};
     });
 
-    chrome.storage.session.set = vi.fn(async (items: Record<string, unknown>) => {
+    chrome.storage.local.set = vi.fn(async (items: Record<string, unknown>) => {
       Object.assign(store, items);
     });
 
-    (chrome.storage.session as unknown as Record<string, unknown>).remove = vi.fn(
-      async (key: string) => {
-        delete store[key];
-      }
-    );
+    chrome.storage.local.remove = vi.fn(async (key: string | string[]) => {
+      const keys = Array.isArray(key) ? key : [key];
+      for (const k of keys) delete store[k];
+    });
+
+    // getBytesInUse: report 0 so quota sweep never triggers in basic tests
+    (chrome.storage.local as unknown as Record<string, unknown>).getBytesInUse =
+      vi.fn().mockResolvedValue(0);
   });
 
-  it("returns null on cache miss", async () => {
-    const cache = new SessionCache<string>("test");
-    expect(await cache.get("missing")).toBeNull();
+  it("returns undefined on cache miss", async () => {
+    const cache = new LocalCache<string>("test");
+    expect(await cache.get("missing")).toBeUndefined();
   });
 
   it("returns cached data on hit", async () => {
-    const cache = new SessionCache<string>("test");
-    await cache.set("key1", "hello");
+    const cache = new LocalCache<string>("test");
+    await cache.set("key1", "hello", null);
     expect(await cache.get("key1")).toBe("hello");
   });
 
-  it("returns null for expired entries", async () => {
-    const cache = new SessionCache<string>("test", 1000); // 1s TTL
-
-    await cache.set("key1", "hello");
-
-    // Simulate time passing by manipulating the stored timestamp
-    const storageKey = "test:key1";
-    store[storageKey] = {
-      data: "hello",
-      timestamp: Date.now() - 2000, // 2s ago, past 1s TTL
-    };
-
+  it("returns null for a cached no-match entry", async () => {
+    const cache = new LocalCache<string>("test");
+    await cache.set("key1", null, 60_000);
     expect(await cache.get("key1")).toBeNull();
   });
 
-  it("uses prefix to namespace keys", async () => {
-    const cacheA = new SessionCache<string>("a");
-    const cacheB = new SessionCache<string>("b");
+  it("returns undefined for expired entries", async () => {
+    const cache = new LocalCache<string>("test");
+    await cache.set("key1", "hello", 1000); // 1s TTL
 
-    await cacheA.set("key", "from-a");
-    await cacheB.set("key", "from-b");
+    // Back-date the stored expiresAt so the entry looks expired
+    const storageKey = "test:key1";
+    store[storageKey] = { data: "hello", expiresAt: Date.now() - 2000 };
+
+    expect(await cache.get("key1")).toBeUndefined();
+  });
+
+  it("permanent entries (ttlMs = null) never expire", async () => {
+    const cache = new LocalCache<string>("test");
+    await cache.set("key1", "permanent", null);
+
+    const storageKey = "test:key1";
+    const entry = store[storageKey] as { expiresAt: unknown };
+    expect(entry.expiresAt).toBeNull();
+
+    expect(await cache.get("key1")).toBe("permanent");
+  });
+
+  it("uses prefix to namespace keys", async () => {
+    const cacheA = new LocalCache<string>("a");
+    const cacheB = new LocalCache<string>("b");
+
+    await cacheA.set("key", "from-a", null);
+    await cacheB.set("key", "from-b", null);
 
     expect(await cacheA.get("key")).toBe("from-a");
     expect(await cacheB.get("key")).toBe("from-b");
   });
 
-  it("deduplicates by overwriting same key", async () => {
-    const cache = new SessionCache<string>("test");
-
-    await cache.set("key", "first");
-    await cache.set("key", "second");
-
+  it("overwrites the same key", async () => {
+    const cache = new LocalCache<string>("test");
+    await cache.set("key", "first", null);
+    await cache.set("key", "second", null);
     expect(await cache.get("key")).toBe("second");
+  });
+
+  it("setQuota(0) disables quota enforcement", async () => {
+    const cache = new LocalCache<string>("test");
+    cache.setQuota(0);
+    // getBytesInUse should not be called when quota is 0
+    await cache.set("key", "value", null);
+    expect(chrome.storage.local.getBytesInUse).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/doi-retraction.test.ts
+++ b/tests/unit/doi-retraction.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
-import { retractionCheck } from "../../src/shared/doi-retraction";
+import { retractionCheck, resetRetractionCache } from "../../src/shared/doi-retraction";
 import { RET_MAP_KEY } from "../../src/shared/data-extract";
 import type { DoiString } from "../../src/shared/types";
 
@@ -14,6 +14,7 @@ const BUNDLED_RETRACTION_NOTICE = "10.1007/s00500-025-11130-9";
 
 describe("retractionCheck", () => {
   beforeEach(() => {
+    resetRetractionCache();
     (chrome.storage.local.get as ReturnType<typeof vi.fn>).mockReset();
   });
 

--- a/tests/unit/service-worker.test.ts
+++ b/tests/unit/service-worker.test.ts
@@ -14,24 +14,29 @@ vi.mock("../../src/shared/flora-api", () => ({
 // Mock settings
 vi.mock("../../src/shared/settings", () => ({
     isSetupComplete: vi.fn().mockResolvedValue(true),
-    getSettings: vi.fn().mockResolvedValue({email: "test@example.com"}),
+    getSettings: vi.fn().mockResolvedValue({email: "test@example.com", cacheQuotaMb: 500}),
 }));
 
 // Mock cache
 const cacheStore = new Map<string, unknown>();
 vi.mock("../../src/shared/cache", () => ({
-    SessionCache: class {
+    MONTH_MS: 30 * 24 * 60 * 60 * 1000,
+    LocalCache: class {
         prefix: string;
 
         constructor(prefix: string) {
             this.prefix = prefix;
         }
 
+        setQuota(_bytes: number) {}
+
         async get(key: string) {
-            return cacheStore.get(`${this.prefix}:${key}`) ?? null;
+            return cacheStore.has(`${this.prefix}:${key}`)
+                ? cacheStore.get(`${this.prefix}:${key}`)
+                : undefined;
         }
 
-        async set(key: string, data: unknown) {
+        async set(key: string, data: unknown, _ttlMs: number | null) {
             cacheStore.set(`${this.prefix}:${key}`, data);
         }
     },


### PR DESCRIPTION
Replace the ephemeral SessionCache with a new LocalCache that stores entries in chrome.storage.local, supports per-entry TTL or permanent caching, and enforces a soft storage quota. The service worker now initialises and watches the cache quota from settings, seeds and refreshes retraction data on install/startup, and adapts cache behaviour (undefined = missing, null = negative result, T = match). Options UI and logic were added to let users set the cache quota (MB) and persist it to settings. Also: defer the content script DOM observer until full page load to reduce spurious runs; add an in-memory normalised retraction source with storage change invalidation to avoid repeated normalisation; update types/settings to include cacheQuotaMb and adjust CachedEntry shape (data nullable, expiresAt).