### PR TITLE
Add active-tab icon, OA lookup, and working toast

### DIFF
--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -23,6 +23,50 @@ chrome.storage.onChanged.addListener((changes, area) => {
     }
 });
 
+// ── Toolbar icon: maroon "F" when FLoRA is active on a tab, gray when not.
+// Drawn on an OffscreenCanvas so no separate icon assets are needed.
+function drawFloraIcon(size: number, active: boolean): ImageData {
+    const canvas = new OffscreenCanvas(size, size);
+    const ctx = canvas.getContext("2d");
+    if (!ctx) throw new Error("no 2d context");
+    const r = size * 0.22;
+    ctx.fillStyle = active ? "#853953" : "#9aa0a6";
+    ctx.beginPath();
+    ctx.roundRect(0.5, 0.5, size - 1, size - 1, r);
+    ctx.fill();
+    ctx.fillStyle = active ? "#ffffff" : "#eceff1";
+    ctx.font = `bold ${Math.round(size * 0.68)}px -apple-system, "Segoe UI", Roboto, Arial, sans-serif`;
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    ctx.fillText("F", size / 2, size * 0.56);
+    return ctx.getImageData(0, 0, size, size);
+}
+
+function setActionIcon(active: boolean, tabId?: number): void {
+    let imageData: Record<number, ImageData>;
+    try {
+        imageData = { 16: drawFloraIcon(16, active), 32: drawFloraIcon(32, active) };
+    } catch {
+        return; // OffscreenCanvas unavailable — leave the default icon
+    }
+    const details = tabId != null ? { tabId, imageData } : { imageData };
+    chrome.action.setIcon(details).catch(() => {});
+
+    const title = active
+        ? "FLoRA — active on this page"
+        : "FLoRA — inactive on this page";
+    chrome.action.setTitle(tabId != null ? { tabId, title } : { title }).catch(() => {});
+}
+
+// Default to inactive; an applicable page's content script flips it to active.
+setActionIcon(false);
+
+// Reset to inactive while a tab navigates — the content script re-activates it
+// if the new page is applicable (so leaving a site clears the active state).
+chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
+    if (changeInfo.status === "loading") setActionIcon(false, tabId);
+});
+
 // Open the walkthrough on first install and seed retraction data immediately.
 chrome.runtime.onInstalled.addListener((details) => {
     if (details.reason === "install") {
@@ -41,7 +85,18 @@ chrome.runtime.onStartup.addListener(() => {
 const inflight = new Map<DoiString, Promise<ReplicationResult | null>>();
 
 chrome.runtime.onMessage.addListener(
-    (message: unknown, _sender, sendResponse) => {
+    (message: unknown, sender, sendResponse) => {
+        if (
+            typeof message === "object" &&
+            message !== null &&
+            (message as { type?: string }).type === "FLORA_ACTIVE_STATE"
+        ) {
+            const active = (message as { active?: boolean }).active === true;
+            const tabId = sender.tab?.id;
+            if (tabId != null) setActionIcon(active, tabId);
+            return false;
+        }
+
         if (isLookupRequest(message)) {
             handleLookup(message.dois)
                 .then(sendResponse)

--- a/src/content-general/index.ts
+++ b/src/content-general/index.ts
@@ -16,6 +16,8 @@ import type {
     SheetFetchResponse
 } from "@shared/messages";
 import {
+    beginWorkIndicator,
+    endWorkIndicator,
     hideAllFloraUI,
     removePubPeerPanel,
     removeSheetsModal,
@@ -66,6 +68,16 @@ const isSheets = location.href.includes("docs.google.com/spreadsheets");
 let floraHidden = false;
 let dismissRedacts = false;
 
+// Tell the service worker whether FLoRA is active on this tab so it can swap the
+// toolbar icon (maroon = active, gray = inactive).
+function reportActiveState(active: boolean): void {
+    try {
+        chrome.runtime.sendMessage({type: "FLORA_ACTIVE_STATE", active}).catch(() => {});
+    } catch {
+        // extension context unavailable — ignore
+    }
+}
+
 // Listen for popup messages (works regardless of gate checks above)
 chrome.runtime.onMessage.addListener((message: unknown, _sender, sendResponse) => {
     if (typeof message !== "object" || message === null) return;
@@ -74,10 +86,12 @@ chrome.runtime.onMessage.addListener((message: unknown, _sender, sendResponse) =
     if (type === "FLORA_HIDE_UI") {
         floraHidden = true;
         hideAllFloraUI();
+        reportActiveState(false);
         sendResponse({ok: true});
     } else if (type === "FLORA_SHOW_UI") {
         floraHidden = false;
         showAllFloraUI();
+        reportActiveState(true);
         sendResponse({ok: true});
     } else if (type === "FLORA_GET_STATE") {
         sendResponse({hidden: floraHidden});
@@ -143,6 +157,7 @@ async function pageRenderChangeHandler(): Promise<void> {
 
     // Validate extracted DOIs via doi.org — remove invalid ones
     if (hasDoiChange && !isSheets && dois.length > 0) {
+        beginWorkIndicator();
         try {
             const validation = await validateDOIs(dois);
             const before = dois.length;
@@ -153,6 +168,8 @@ async function pageRenderChangeHandler(): Promise<void> {
             }
         } catch {
             // Validation failed — keep all extracted DOIs as-is
+        } finally {
+            endWorkIndicator();
         }
     }
 
@@ -233,6 +250,7 @@ async function pageRenderChangeHandler(): Promise<void> {
 
     const request: LookupRequest = {type: "FLORA_LOOKUP", dois: newDois};
 
+    beginWorkIndicator();
     try {
         const response: LookupResponse =
             await chrome.runtime.sendMessage(request);
@@ -299,6 +317,8 @@ async function pageRenderChangeHandler(): Promise<void> {
         }
     } catch {
         renderErrorBanner("Failed to contact FLoRA service");
+    } finally {
+        endWorkIndicator();
     }
 }
 
@@ -511,6 +531,8 @@ function isFloraOwnedNode(node: Node): boolean {
 function startDomListener(callback: () => void) {
     let debounceTimer: number;
     const observer = new MutationObserver((mutations) => {
+        // Do no work while this tab is in the background.
+        if (document.hidden) return;
         const hasExternalChange = mutations.some(m => {
             if (m.addedNodes.length === 0) return false;
             // Skip mutations inside FLoRA's own injected containers.
@@ -527,6 +549,11 @@ function startDomListener(callback: () => void) {
         }
     });
     observer.observe(document.body, { childList: true, subtree: true });
+    // Re-scan when the tab becomes active again — mutations that happened while
+    // it was hidden were ignored above.
+    document.addEventListener("visibilitychange", () => {
+        if (!document.hidden) callback();
+    });
 }
 
 // Gate: skip iframes and blocked domains
@@ -575,38 +602,57 @@ function startDomListener(callback: () => void) {
 
     if (await isDomainBlocked(location.hostname)) {
         debugLog("Domain is blocked:", location.hostname);
+        reportActiveState(false); // gray toolbar icon — disabled on this domain
         return;
     }
+    // Applicable page — mark the toolbar icon active for this tab.
+    reportActiveState(true);
     // Show setup prompt if email not configured (non-blocking — extension still runs)
     if (!(await isSetupComplete())) {
         renderSetupPrompt().then().catch();
     }
-    if (isSheets) {
-        // Fetch full sheet data via CSV export to get all DOIs regardless of scroll
-        fetchSheetDois();
-        // Poll for sheet tab switches — Sheets uses replaceState (no popstate).
-        let lastGid = parseSheetsUrl(location.href)?.gid ?? "0";
-        setInterval(() => {
-            const nowGid = parseSheetsUrl(location.href)?.gid ?? "0";
-            if (nowGid !== lastGid) {
-                lastGid = nowGid;
-                console.log("[FLoRA:Sheets] Tab change detected (gid:", nowGid, ") — re-fetching…");
-                sheetFetchGen++;
-                sheetCsvDois = [];
-                processedDois.clear();
-                pageState.clear();
-                removeSheetsModal();
-                fetchSheetDois();
-            }
-        }, 1500);
-    } else {
-        // Initial run — static pages may never trigger the MutationObserver.
-        void pageRenderChangeHandler();
-        // Defer the observer until full load so load-time mutations don't spam it.
-        if (document.readyState === "complete") {
-            startDomListener(pageRenderChangeHandler);
+    const startFlora = (): void => {
+        if (isSheets) {
+            // Fetch full sheet data via CSV export to get all DOIs regardless of scroll
+            fetchSheetDois();
+            // Poll for sheet tab switches — Sheets uses replaceState (no popstate).
+            let lastGid = parseSheetsUrl(location.href)?.gid ?? "0";
+            setInterval(() => {
+                const nowGid = parseSheetsUrl(location.href)?.gid ?? "0";
+                if (nowGid !== lastGid) {
+                    lastGid = nowGid;
+                    console.log("[FLoRA:Sheets] Tab change detected (gid:", nowGid, ") — re-fetching…");
+                    sheetFetchGen++;
+                    sheetCsvDois = [];
+                    processedDois.clear();
+                    pageState.clear();
+                    removeSheetsModal();
+                    fetchSheetDois();
+                }
+            }, 1500);
         } else {
-            window.addEventListener("load", () => startDomListener(pageRenderChangeHandler), { once: true });
+            // Initial run — static pages may never trigger the MutationObserver.
+            void pageRenderChangeHandler();
+            // Defer the observer until full load so load-time mutations don't spam it.
+            if (document.readyState === "complete") {
+                startDomListener(pageRenderChangeHandler);
+            } else {
+                window.addEventListener("load", () => startDomListener(pageRenderChangeHandler), { once: true });
+            }
         }
+    };
+
+    // Only run on the active/visible tab. Content scripts auto-inject into every
+    // matching tab (including background ones); defer all work until this tab is
+    // shown so background tabs don't scan, look up, or render.
+    if (document.visibilityState === "visible") {
+        startFlora();
+    } else {
+        document.addEventListener("visibilitychange", function onVisible() {
+            if (document.visibilityState === "visible") {
+                document.removeEventListener("visibilitychange", onVisible);
+                startFlora();
+            }
+        });
     }
 })();

--- a/src/content-general/injector.ts
+++ b/src/content-general/injector.ts
@@ -425,6 +425,71 @@ function escapeHtml(s: string): string {
 }
 
 // ──────────────────────────────────────────────
+// "Working" toast — small bottom-right indicator shown while FLoRA queries.
+// ──────────────────────────────────────────────
+
+const WORKING_TOAST_ID = "flora-working-toast";
+let workingRefCount = 0;
+let workingHideTimer: ReturnType<typeof setTimeout> | null = null;
+// Suppressed while the user has hidden FLoRA UI on this page.
+let floraUiHidden = false;
+
+function ensureWorkingToast(): HTMLElement {
+    const existing = document.getElementById(WORKING_TOAST_ID);
+    if (existing) return existing;
+    const host = document.createElement("div");
+    host.id = WORKING_TOAST_ID;
+    host.style.cssText =
+        "position:fixed;bottom:18px;right:18px;z-index:2147483647;" +
+        "display:flex;align-items:center;gap:8px;pointer-events:none;" +
+        "background:linear-gradient(135deg,#853953,#612D53);color:#fff;" +
+        "font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;" +
+        "font-size:12px;font-weight:500;padding:8px 12px;border-radius:8px;" +
+        "box-shadow:0 4px 16px rgba(0,0,0,0.18);" +
+        "opacity:0;transform:translateY(6px);transition:opacity 0.18s ease,transform 0.18s ease;";
+    const style = document.createElement("style");
+    style.textContent = "@keyframes flora-working-spin{to{transform:rotate(360deg)}}";
+    const spinner = document.createElement("span");
+    spinner.style.cssText =
+        "width:12px;height:12px;border-radius:50%;flex-shrink:0;box-sizing:border-box;" +
+        "border:2px solid rgba(255,255,255,0.35);border-top-color:#fff;" +
+        "animation:flora-working-spin 0.7s linear infinite;";
+    const label = document.createElement("span");
+    label.textContent = "FLoRA is scanning this page…";
+    host.appendChild(style);
+    host.appendChild(spinner);
+    host.appendChild(label);
+    document.body.appendChild(host);
+    return host;
+}
+
+/** Show the working toast (ref-counted — nested calls keep it visible). */
+export function beginWorkIndicator(): void {
+    workingRefCount++;
+    if (floraUiHidden) return; // user hid FLoRA UI — don't surface the toast
+    if (workingHideTimer) { clearTimeout(workingHideTimer); workingHideTimer = null; }
+    const host = ensureWorkingToast();
+    requestAnimationFrame(() => {
+        host.style.opacity = "1";
+        host.style.transform = "translateY(0)";
+    });
+}
+
+/** Hide the working toast once all outstanding work has finished. */
+export function endWorkIndicator(): void {
+    workingRefCount = Math.max(0, workingRefCount - 1);
+    if (workingRefCount > 0) return;
+    const host = document.getElementById(WORKING_TOAST_ID);
+    if (!host) return;
+    // Brief delay so quick back-to-back passes don't flicker the toast.
+    workingHideTimer = setTimeout(() => {
+        host.style.opacity = "0";
+        host.style.transform = "translateY(6px)";
+        setTimeout(() => host.remove(), 200);
+    }, 500);
+}
+
+// ──────────────────────────────────────────────
 // Google Sheets modal
 // ──────────────────────────────────────────────
 
@@ -582,6 +647,9 @@ export function removeSheetsModal(): void {
 // ──────────────────────────────────────────────
 
 export function hideAllFloraUI(): void {
+    floraUiHidden = true;
+    const toast = document.getElementById(WORKING_TOAST_ID);
+    if (toast) toast.remove();
     const banner = document.getElementById(BANNER_HOST_ID);
     if (banner) banner.style.display = "none";
 
@@ -604,6 +672,7 @@ export function hideAllFloraUI(): void {
 }
 
 export function showAllFloraUI(): void {
+    floraUiHidden = false;
     const banner = document.getElementById(BANNER_HOST_ID);
     if (banner) banner.style.display = "";
 
@@ -628,6 +697,26 @@ export function showAllFloraUI(): void {
 // ──────────────────────────────────────────────
 // PubPeer panel
 // ──────────────────────────────────────────────
+
+/**
+ * Best on-page article title. Scholarly meta tags first, then headings, with
+ * document.title last — some publishers (e.g. APA PsycNet) set document.title to
+ * the site name ("APA PsycNet") rather than the paper title.
+ */
+function getPageArticleTitle(): string | null {
+    for (const sel of [
+        'meta[name="citation_title"]',
+        'meta[name="dc.Title" i]',
+        'meta[property="og:title"]',
+        'meta[name="twitter:title"]',
+    ]) {
+        const content = document.querySelector<HTMLMetaElement>(sel)?.content?.trim();
+        if (content) return content;
+    }
+    const h1 = document.querySelector<HTMLHeadingElement>("h1")?.textContent?.trim();
+    if (h1) return h1;
+    return document.title?.trim() || null;
+}
 
 const PUBPEER_PANEL_ID = "flora-pubpeer-panel";
 
@@ -837,32 +926,12 @@ export function renderPubPeerPanel(
     }
   }
 
-  // Fallback: when the article itself has no replications/reproductions, surface
-  // the ones found among the page's references in the same top sections, so they
-  // render exactly like an article's own replications (title · authors · outcome).
-  if (allReplicationEntries.length === 0 && allReproductionEntries.length === 0) {
-    const seenRepl = new Set<string>();
-    const seenRepro = new Set<string>();
-    for (const ref of references) {
-      const state = pageState.get(ref.doi);
-      if (state?.status !== "matched") continue;
-      for (const e of state.result.record.replications) {
-        const key = e.doi ?? e.title ?? "";
-        if (key && seenRepl.has(key)) continue;
-        if (key) seenRepl.add(key);
-        allReplicationEntries.push(e);
-      }
-      for (const e of state.result.record.reproductions ?? []) {
-        const key = e.doi ?? e.title ?? "";
-        if (key && seenRepro.has(key)) continue;
-        if (key) seenRepro.add(key);
-        allReproductionEntries.push(e);
-      }
-    }
-  }
+  // When the viewed paper is itself a replication (it has original studies), the
+  // panel should focus on the original(s) it replicated — not list it as a
+  // replication. Suppress the replication/reproduction sections in that case.
+  const articleIsReplication = articleOriginals > 0;
 
-  const hasReplicationData = articleReplications > 0 || articleReproductions > 0 || articleOriginals > 0
-    || allReplicationEntries.length > 0 || allReproductionEntries.length > 0;
+  const hasReplicationData = articleReplications > 0 || articleReproductions > 0 || articleOriginals > 0;
 
   // Notice status — keyed by the DOI as it appears on the page (originDoi).
   // A "notice" is either a retraction or an expression of concern; the kind
@@ -994,8 +1063,7 @@ export function renderPubPeerPanel(
   // Article title — use PubPeer title if available, else h1/document.title
   const articleTitleText =
     primary?.title ||
-    document.querySelector<HTMLHeadingElement>("h1")?.textContent?.trim() ||
-    document.title ||
+    getPageArticleTitle() ||
     "Article";
   const articleFloraUrl = articleDois.length > 0
     ? `https://forrt.org/flora-replication-atlas/?doi=${encodeURIComponent(articleDois[0])}`
@@ -1143,8 +1211,14 @@ export function renderPubPeerPanel(
     return oaPlaceholders;
   };
 
-  const oaPlaceholders = renderEntrySection(allReplicationEntries, `Replication${allReplicationEntries.length !== 1 ? "s" : ""}`, true);
-  renderEntrySection(allReproductionEntries, `Reproduction${allReproductionEntries.length !== 1 ? "s" : ""}`);
+  // A replication paper shows only the original study it replicated; otherwise
+  // show what replicated/reproduced this paper.
+  const oaPlaceholders = articleIsReplication
+    ? new Map<string, HTMLElement>()
+    : renderEntrySection(allReplicationEntries, `Replication${allReplicationEntries.length !== 1 ? "s" : ""}`, true);
+  if (!articleIsReplication) {
+    renderEntrySection(allReproductionEntries, `Reproduction${allReproductionEntries.length !== 1 ? "s" : ""}`);
+  }
   renderEntrySection(allOriginalEntries, `Original Paper${allOriginalEntries.length !== 1 ? "s" : ""}`);
 
   // Include the main article in the Unpaywall lookup. Skip if its DOI already
@@ -1213,7 +1287,6 @@ export function renderPubPeerPanel(
     titleLink.href = feedback?.url || `https://doi.org/${doi}`;
     titleLink.target = "_blank";
     titleLink.rel = "noopener";
-    titleLink.title = title;
     // Clamp to 3 lines so a long/unparsed citation can't blow up the row.
     titleLink.style.cssText =
       "display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:3;" +
@@ -1254,7 +1327,7 @@ export function renderPubPeerPanel(
         ));
       }
       if (n_originals_total > 0) {
-        tagsRow.appendChild(makeTag("Is Replication", "#fef9c3", "#854d0e", "#fde047"));
+        tagsRow.appendChild(makeTag("View in Atlas", "#fef9c3", "#854d0e", "#fde047"));
       }
     }
 
@@ -1275,25 +1348,32 @@ export function renderPubPeerPanel(
 
     if (feedback && feedback.total_comments > 0) {
       const commentText = `${feedback.total_comments} ${feedback.total_comments === 1 ? "comment" : "comments"}`;
-      const pillW = Math.ceil(commentText.length * 6 + 14);
-      const pillH = 18;
-      const tmp = document.createElement("div");
-      tmp.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="${pillW}" height="${pillH}" style="flex-shrink:0;cursor:pointer;display:inline-block;vertical-align:middle;">
-        <a href="${feedback.url}" target="_blank" rel="noopener" style="text-decoration:none;">
-          <rect x="0.5" y="0.5" width="${pillW - 1}" height="${pillH - 1}" rx="8.5" fill="#f9f0f4" stroke="#d4a5b8" stroke-width="1"/>
-          <text x="${pillW / 2}" y="13" fill="#853953" font-size="10" font-weight="600" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif" text-anchor="middle" text-decoration="none">${commentText}</text>
-        </a>
-      </svg>`;
-      const countPill = tmp.firstElementChild as SVGElement;
-      tagsRow.appendChild(countPill);
-    } else {
-      const noCommentsTag = document.createElement("span");
-      noCommentsTag.style.cssText =
-        "flex-shrink:0;font-size:10px;font-weight:600;color:#9aa0a6;" +
-        "background:#f1f3f4;border:1px solid #e0e0e0;padding:1px 7px;border-radius:10px;" +
-        "white-space:nowrap;";
-      noCommentsTag.textContent = "No PubPeer comments";
-      tagsRow.appendChild(noCommentsTag);
+      // PubPeer-branded pill: speech-bubble mark + count in PubPeer's colours
+      // (#446058 teal on a light-teal background).
+      const commentTag = document.createElement("a");
+      commentTag.href = feedback.url;
+      commentTag.target = "_blank";
+      commentTag.rel = "noopener noreferrer";
+      commentTag.title = "View on PubPeer";
+      commentTag.style.cssText =
+        "flex-shrink:0;display:inline-flex;align-items:center;gap:4px;" +
+        "font-size:10px;font-weight:600;color:#446058;" +
+        "background:#e9f3f1;border:1px solid #7accc8;padding:1px 7px;border-radius:10px;" +
+        "white-space:nowrap;text-decoration:none;cursor:pointer;";
+      commentTag.innerHTML =
+        `<svg width="9" height="13" viewBox="0 0 98.5 146.5" fill="none" stroke="#446058" ` +
+        `stroke-width="7" stroke-linecap="round" style="display:block;flex-shrink:0;">` +
+        `<circle cx="13.667" cy="34.833" r="10.167"/>` +
+        `<circle cx="86.302" cy="80.344" r="10.167"/>` +
+        `<circle cx="86.302" cy="12.741" r="10.167"/>` +
+        `<circle cx="13.04" cy="133.811" r="10.166"/>` +
+        `<line x1="13.04" y1="45" x2="13.04" y2="123.645"/>` +
+        `<line x1="23.44" y1="32.04" x2="76.554" y2="15.626"/>` +
+        `<line x1="86.303" y1="22.907" x2="86.303" y2="70.177"/>` +
+        `<line x1="18.027" y1="124.955" x2="80.772" y2="21.267"/>` +
+        `<line x1="76.136" y1="80.344" x2="45.023" y2="80.344"/></svg>` +
+        `<span>${commentText}</span>`;
+      tagsRow.appendChild(commentTag);
     }
 
     li.appendChild(titleLink);
@@ -1315,7 +1395,7 @@ export function renderPubPeerPanel(
     label.style.cssText =
       "font-size:14px;font-weight:600;color:#5f6368;text-transform:uppercase;" +
       "letter-spacing:0.5px;border-bottom:1px solid #e8e8e8;padding:10px 16px;";
-    label.textContent = `${headingText} (${refs.length})`;
+    label.textContent = `${headingText} with Tags (${refs.length})`;
     section.appendChild(label);
 
     const list = document.createElement("ul");
@@ -1393,7 +1473,39 @@ export function renderPubPeerPanel(
     iframe.style.cssText = "width:100%;height:200px;border:none;display:block;opacity:0;transition:opacity 0.15s;overflow:hidden;";
 
     const revealIframe = (): void => { iframe.style.opacity = "1"; };
-    const fallbackTimer = setTimeout(revealIframe, 3000);
+
+    // When PubPeer refuses to embed (X-Frame-Options / CSP frame-ancestors) the
+    // frame stays blank and our in-iframe script never posts CSS_READY. Swap the
+    // broken frame for an external link so the comments are still reachable.
+    const showFallback = (): void => {
+      if (iframeWrap.dataset.floraFallback === "1") return;
+      iframeWrap.dataset.floraFallback = "1";
+      clearTimeout(fallbackTimer);
+      window.removeEventListener("message", onIframeMessage);
+      iframe.remove();
+
+      const fb = document.createElement("div");
+      fb.style.cssText =
+        "display:flex;flex-direction:column;align-items:center;gap:10px;" +
+        "padding:24px 20px;text-align:center;color:#5f6368;";
+      const msg = document.createElement("span");
+      msg.style.cssText = "font-size:12px;line-height:1.5;";
+      msg.textContent = "PubPeer comments can't be shown inline here.";
+      const link = document.createElement("a");
+      link.href = primary.url;
+      link.target = "_blank";
+      link.rel = "noopener noreferrer";
+      link.textContent = "View comments on PubPeer ↗";
+      link.style.cssText =
+        "display:inline-flex;align-items:center;gap:6px;padding:8px 14px;" +
+        "font-size:13px;font-weight:600;color:#fff;background:#853953;" +
+        "border-radius:6px;text-decoration:none;";
+      fb.appendChild(msg);
+      fb.appendChild(link);
+      iframeWrap.appendChild(fb);
+    };
+
+    const fallbackTimer = setTimeout(showFallback, 4000);
     const onIframeMessage = (e: MessageEvent): void => {
       if (e.source !== iframe.contentWindow) return;
       const data = e.data as { type?: string; height?: number };
@@ -1405,6 +1517,7 @@ export function renderPubPeerPanel(
       }
     };
     window.addEventListener("message", onIframeMessage);
+    iframe.addEventListener("error", showFallback);
 
     iframeWrap.appendChild(iframe);
     scrollBody.appendChild(iframeWrap);

--- a/src/content-general/references.ts
+++ b/src/content-general/references.ts
@@ -16,6 +16,7 @@ import {augmentDOIs} from "@shared/doi-augment";
 import {validateDOIs} from "@shared/doi-validate";
 import {injectRetractionInfo, type RetractionResponse} from "@shared/doi-retraction";
 import {createDoiPill} from "@shared/doi-label";
+import {fetchOpenAccess} from "@shared/openaccess";
 import {getSettings} from "@shared/settings";
 import {debugLog} from "@shared/debug";
 import type {DoiString} from "@shared/types";
@@ -222,7 +223,9 @@ export function renderResolvedReferences(
     for (const {entry, doi, mode} of resolved) {
         const isAugmented = mode === "augment";
         const color = isAugmented ? AUGMENTED_COLOR : CONFIDENT_COLOR;
-        placeReferencePill(entry.element, doi, mode, createDoiPill(doi, color, isAugmented));
+        // Pass the Open Access lookup so the padlock renders inside the pill.
+        const pill = createDoiPill(doi, color, isAugmented, fetchOpenAccess(doi));
+        placeReferencePill(entry.element, doi, mode, pill);
         const notice = retractionByDoi.get(doi);
         if (notice) injectRetractionInfo(entry.element, notice);
         debugLog(`References: surfaced "${entry.text.slice(0, 60)}" → ${doi} (${mode})`);

--- a/src/content-scholar/index.ts
+++ b/src/content-scholar/index.ts
@@ -4,13 +4,24 @@ import { isSetupComplete } from "@shared/settings";
 import { isDomainBlocked } from "@shared/domains";
 import { renderSetupPrompt, hideAllFloraUI, showAllFloraUI } from "../content-general/injector";
 
+// Tell the service worker whether FLoRA is active on this tab (toolbar icon).
+function reportActiveState(active: boolean): void {
+  try {
+    chrome.runtime.sendMessage({ type: "FLORA_ACTIVE_STATE", active }).catch(() => {});
+  } catch {
+    // extension context unavailable — ignore
+  }
+}
+
 (async () => {
   if (window !== window.top) return;
 
   if (await isDomainBlocked(location.hostname)) {
     debugLog("Domain is blocked:", location.hostname);
+    reportActiveState(false);
     return;
   }
+  reportActiveState(true);
 
   if (!(await isSetupComplete())) {
     renderSetupPrompt();
@@ -54,10 +65,12 @@ chrome.runtime.onMessage.addListener((message: unknown, _sender, sendResponse) =
   if (type === "FLORA_HIDE_UI") {
     floraHidden = true;
     hideScholarUI();
+    reportActiveState(false);
     sendResponse({ ok: true });
   } else if (type === "FLORA_SHOW_UI") {
     floraHidden = false;
     showScholarUI();
+    reportActiveState(true);
     sendResponse({ ok: true });
   } else if (type === "FLORA_GET_STATE") {
     sendResponse({ hidden: floraHidden });

--- a/src/shared/doi-label.ts
+++ b/src/shared/doi-label.ts
@@ -1,6 +1,8 @@
-// Shared inline "DOI" pill — a small rounded label that reveals the resolved
+1111// Shared inline "DOI" pill — a small rounded label that reveals the resolved
 // DOI (plus a copy button) on hover. Used by Google Scholar result rows and by
 // reference-list entries on article pages.
+
+import type { OpenAccessStatus } from "./openaccess";
 
 export const DOI_LABEL_CLASS = "flora-doi-label";
 
@@ -26,6 +28,12 @@ function ensureInlinePillStyle(): void {
 // :not(:first-child) margin rule above.
 export const FLORA_NOTICE_PILL_CLASS = "flora-notice-pill";
 
+// Open padlock — shown inside the pill only when a free full text exists.
+const OA_UNLOCK_SVG =
+    `<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" ` +
+    `stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" style="display:block;">` +
+    `<rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 9.9-1"/></svg>`;
+
 /**
  * Build a DOI pill element (pill + hover popover with copy button).
  *
@@ -37,8 +45,16 @@ export const FLORA_NOTICE_PILL_CLASS = "flora-notice-pill";
  * @param isAugmented  true when the DOI came from Crossref/OpenAlex augmentation
  *                     rather than direct extraction — renders a dotted "DOI"
  *                     label instead of the "DOI ✓" check.
+ * @param oaStatus     optional Open Access lookup; when it resolves to an open
+ *                     access result, an open-padlock link to the free full text
+ *                     is added inside the pill. Paywalled/unknown adds nothing.
  */
-export function createDoiPill(doi: string, color: string, isAugmented = false): HTMLElement {
+export function createDoiPill(
+    doi: string,
+    color: string,
+    isAugmented = false,
+    oaStatus?: Promise<OpenAccessStatus | null>
+): HTMLElement {
     ensureInlinePillStyle();
     const wrapper = document.createElement("span");
     wrapper.className = DOI_LABEL_CLASS;
@@ -85,6 +101,40 @@ export function createDoiPill(doi: string, color: string, isAugmented = false): 
     } else {
         const checkSvg = `<svg width="12" height="12" viewBox="0 0 16 16" fill="white" style="display:inline-block;vertical-align:middle;"><path d="M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.75.75 0 0 1 1.06-1.06L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0Z"></path></svg>`;
         pill.innerHTML = `DOI ${checkSvg}`;
+    }
+
+    // Open Access affordance inside the pill — only surfaced when a free full
+    // text exists (a positive, tappable signal). Paywalled/unknown adds nothing.
+    if (oaStatus) {
+        const oaSlot = document.createElement("span");
+        oaSlot.style.cssText = "display:inline-flex;align-items:center;gap:5px;line-height:0;";
+        pill.appendChild(oaSlot);
+        void oaStatus.then((oa) => {
+            if (!oa || !oa.isOa) { oaSlot.remove(); return; }
+
+            // Thin divider so the lock reads as a separate action, not part of "DOI ✓".
+            const divider = document.createElement("span");
+            divider.style.cssText = "width:1px;height:11px;background:rgba(255,255,255,0.4);";
+
+            const el = oa.url ? document.createElement("a") : document.createElement("span");
+            el.title = "Open Access — view free full text";
+            el.style.cssText =
+                "display:inline-flex;align-items:center;gap:3px;line-height:1;color:#fff;" +
+                "font-size:11px;font-weight:600;letter-spacing:0.02em;text-decoration:none;" +
+                "opacity:0.9;transition:opacity 0.15s ease;";
+            if (oa.url && el instanceof HTMLAnchorElement) {
+                el.href = oa.url;
+                el.target = "_blank";
+                el.rel = "noopener noreferrer";
+                el.addEventListener("click", (e) => e.stopPropagation());
+                el.addEventListener("mouseenter", () => { el.style.opacity = "1"; });
+                el.addEventListener("mouseleave", () => { el.style.opacity = "0.9"; });
+            }
+            el.innerHTML = `${OA_UNLOCK_SVG}<span>Free</span>`;
+
+            oaSlot.appendChild(divider);
+            oaSlot.appendChild(el);
+        });
     }
 
     const popover = document.createElement("div");

--- a/src/shared/openaccess.ts
+++ b/src/shared/openaccess.ts
@@ -1,0 +1,63 @@
+// Open Access status for a DOI via Unpaywall, cached in chrome.storage.local.
+// Used to surface a lock/unlock icon next to the DOIs we inject on the page.
+
+import { getSettings } from "./settings";
+import { BlobCache } from "./blob-cache";
+
+export interface OpenAccessStatus {
+    /** True when Unpaywall reports a free full-text location. */
+    isOa: boolean;
+    /** Best free full-text URL (PDF preferred), or null. */
+    url: string | null;
+}
+
+const OA_CACHE = new BlobCache<OpenAccessStatus>({
+    storageKey: "flora_oa_blob",
+    ttlMs: 30 * 24 * 60 * 60 * 1000, // 30 days — OA status changes rarely
+});
+
+let _cachedEmail: string | null = null;
+async function getUserEmail(): Promise<string> {
+    if (_cachedEmail) return _cachedEmail;
+    const { email } = await getSettings();
+    _cachedEmail = email;
+    return email;
+}
+
+/**
+ * Resolve a DOI's Open Access status via Unpaywall (cached). Returns null when
+ * the lookup can't be performed (no email configured, or the request failed) so
+ * callers can choose to render nothing rather than a misleading "no access".
+ */
+export async function fetchOpenAccess(doi: string): Promise<OpenAccessStatus | null> {
+    const cached = await OA_CACHE.get(doi);
+    if (cached) return cached;
+
+    const email = await getUserEmail();
+    if (!email) return null;
+
+    try {
+        const resp = await fetch(
+            `https://api.unpaywall.org/v2/${encodeURIComponent(doi)}?email=${encodeURIComponent(email)}`
+        );
+        if (!resp.ok) return null;
+        const data = (await resp.json()) as {
+            is_oa?: boolean;
+            best_oa_location?: { url_for_pdf?: string | null; url?: string | null } | null;
+        };
+        const status: OpenAccessStatus = {
+            isOa: !!data.is_oa,
+            url: data.best_oa_location?.url_for_pdf ?? data.best_oa_location?.url ?? null,
+        };
+        void OA_CACHE.set(doi, status);
+        return status;
+    } catch {
+        return null;
+    }
+}
+
+/** Test-only: drop in-memory cache state so each case starts fresh. */
+export function _resetOpenAccessCacheForTesting(): void {
+    OA_CACHE.resetForTesting();
+    _cachedEmail = null;
+}

--- a/src/walkthrough/index.html
+++ b/src/walkthrough/index.html
@@ -64,7 +64,7 @@
                     </svg>
                     Google Scholar
                   </span>
-                  <span class="wt-step-num">1 of 5</span>
+                  <span class="wt-step-num">1 of 6</span>
                 </div>
                 <h2 class="wt-title">Confirmed DOI</h2>
                 <p class="wt-desc">
@@ -218,7 +218,7 @@
                     </svg>
                     Google Scholar
                   </span>
-                  <span class="wt-step-num">2 of 5</span>
+                  <span class="wt-step-num">2 of 6</span>
                 </div>
                 <h2 class="wt-title">Unconfirmed DOI</h2>
                 <p class="wt-desc">
@@ -372,7 +372,7 @@
                     </svg>
                     Google Sheets
                   </span>
-                  <span class="wt-step-num">3 of 5</span>
+                  <span class="wt-step-num">3 of 6</span>
                 </div>
                 <h2 class="wt-title">Spreadsheet Detection</h2>
                 <p class="wt-desc">
@@ -718,14 +718,15 @@
                     </svg>
                     Journal &amp; Article Pages
                   </span>
-                  <span class="wt-step-num">4 of 5</span>
+                  <span class="wt-step-num">4 of 6</span>
                 </div>
                 <h2 class="wt-title">Replication Badges</h2>
                 <p class="wt-desc">
                   On journal pages, FLoRA injects inline badges next to DOI
-                  links and adds a draggable <strong>FLoRA tab</strong> to the
-                  right edge of the page. Click it to open the full Meta Report
-                  panel.
+                  links, flags retractions right beside the title, adds an Open
+                  Access "Free" link to reference DOIs when a free copy exists,
+                  and adds a draggable <strong>FLoRA tab</strong> to the right
+                  edge of the page. Click it to open the full Meta Report panel.
                 </p>
                 <div class="wt-callouts">
                   <div class="wt-callout callout-confirmed">
@@ -864,13 +865,16 @@
                     </svg>
                     Journal &amp; Article Pages
                   </span>
-                  <span class="wt-step-num">5 of 5</span>
+                  <span class="wt-step-num">5 of 6</span>
                 </div>
                 <h2 class="wt-title">Meta Report Panel</h2>
                 <p class="wt-desc">
                   Click the FLoRA tab to open the Meta Report panel. It lists
-                  every known replication and reproduction study, color-coded by
-                  outcome, plus references with PubPeer comment counts.
+                  every known replication and reproduction study color-coded by
+                  outcome, flags retractions and expressions of concern, links to
+                  free full text where available, and shows references with
+                  PubPeer comments. If the paper is itself a replication, it
+                  shows the <strong>original study</strong> instead.
                 </p>
                 <div class="wt-callouts">
                   <div class="wt-callout callout-confirmed">
@@ -894,6 +898,57 @@
                       </div>
                     </div>
                   </div>
+                  <div class="wt-callout callout-unconfirmed">
+                    <div class="wt-callout-icon icon-unconfirmed">
+                      <svg
+                        width="11"
+                        height="11"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="white"
+                        stroke-width="2.5"
+                      >
+                        <path
+                          d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"
+                        />
+                        <line x1="12" y1="9" x2="12" y2="13" />
+                        <line x1="12" y1="17" x2="12.01" y2="17" />
+                      </svg>
+                    </div>
+                    <div class="wt-callout-body">
+                      <div class="wt-callout-title">
+                        Retraction &amp; concern flags
+                      </div>
+                      <div class="wt-callout-text">
+                        A red "Retracted" or "Concern" tag appears beside the
+                        title and any affected reference. Click to read the
+                        notice.
+                      </div>
+                    </div>
+                  </div>
+                  <div class="wt-callout callout-confirmed">
+                    <div class="wt-callout-icon icon-confirmed">
+                      <svg
+                        width="11"
+                        height="11"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="white"
+                        stroke-width="2.5"
+                      >
+                        <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+                        <path d="M7 11V7a5 5 0 0 1 9.9-1" />
+                      </svg>
+                    </div>
+                    <div class="wt-callout-body">
+                      <div class="wt-callout-title">Open Access links</div>
+                      <div class="wt-callout-text">
+                        When a free full text exists (via Unpaywall), a green
+                        "Free" link is added to the DOI — one click to the open
+                        copy.
+                      </div>
+                    </div>
+                  </div>
                   <div class="wt-callout callout-neutral">
                     <div class="wt-callout-icon icon-neutral">
                       <svg
@@ -910,10 +965,11 @@
                       </svg>
                     </div>
                     <div class="wt-callout-body">
-                      <div class="wt-callout-title">PubPeer comment counts</div>
+                      <div class="wt-callout-title">PubPeer comments</div>
                       <div class="wt-callout-text">
-                        References in the paper that have PubPeer comments are
-                        listed below the replications. Click to open the thread.
+                        References discussed on PubPeer show a teal comment pill
+                        with the count. The article's thread loads inline — if it
+                        can't be embedded, a link to open it on PubPeer is shown.
                       </div>
                     </div>
                   </div>
@@ -1229,24 +1285,69 @@
                             style="
                               font-size: 11.5px;
                               color: #202124;
-                              margin-bottom: 3px;
+                              margin-bottom: 4px;
                               line-height: 1.3;
                             "
                           >
                             Nonverbal behavior and the vertical dimension of
                             social relations
                           </div>
-                          <span
+                          <div
                             style="
-                              font-size: 10px;
-                              font-weight: 500;
-                              padding: 2px 6px;
-                              border-radius: 10px;
-                              background: #e8f0fe;
-                              color: #1967d2;
+                              display: flex;
+                              align-items: center;
+                              flex-wrap: wrap;
+                              gap: 4px;
                             "
-                            >1 comment</span
                           >
+                            <span
+                              style="
+                                font-size: 10px;
+                                font-weight: 600;
+                                padding: 2px 6px;
+                                border-radius: 10px;
+                                background: #fef9c3;
+                                color: #854d0e;
+                                border: 1px solid #fde047;
+                              "
+                              >View in Atlas</span
+                            >
+                            <span
+                              style="
+                                display: inline-flex;
+                                align-items: center;
+                                gap: 4px;
+                                font-size: 10px;
+                                font-weight: 600;
+                                padding: 1px 7px;
+                                border-radius: 10px;
+                                background: #e9f3f1;
+                                color: #446058;
+                                border: 1px solid #7accc8;
+                              "
+                            >
+                              <svg
+                                width="9"
+                                height="13"
+                                viewBox="0 0 98.5 146.5"
+                                fill="none"
+                                stroke="#446058"
+                                stroke-width="7"
+                                stroke-linecap="round"
+                              >
+                                <circle cx="13.667" cy="34.833" r="10.167" />
+                                <circle cx="86.302" cy="80.344" r="10.167" />
+                                <circle cx="86.302" cy="12.741" r="10.167" />
+                                <circle cx="13.04" cy="133.811" r="10.166" />
+                                <line x1="13.04" y1="45" x2="13.04" y2="123.645" />
+                                <line x1="23.44" y1="32.04" x2="76.554" y2="15.626" />
+                                <line x1="86.303" y1="22.907" x2="86.303" y2="70.177" />
+                                <line x1="18.027" y1="124.955" x2="80.772" y2="21.267" />
+                                <line x1="76.136" y1="80.344" x2="45.023" y2="80.344" />
+                              </svg>
+                              1 comment
+                            </span>
+                          </div>
                         </div>
                         <div
                           style="
@@ -1258,23 +1359,68 @@
                             style="
                               font-size: 11.5px;
                               color: #202124;
-                              margin-bottom: 3px;
+                              margin-bottom: 4px;
                               line-height: 1.3;
                             "
                           >
                             Inhibiting the facial feedback hypothesis
                           </div>
-                          <span
+                          <div
                             style="
-                              font-size: 10px;
-                              font-weight: 500;
-                              padding: 2px 6px;
-                              border-radius: 10px;
-                              background: #e8f0fe;
-                              color: #1967d2;
+                              display: flex;
+                              align-items: center;
+                              flex-wrap: wrap;
+                              gap: 4px;
                             "
-                            >2 comments</span
                           >
+                            <span
+                              style="
+                                font-size: 10px;
+                                font-weight: 600;
+                                padding: 2px 6px;
+                                border-radius: 10px;
+                                background: #ff1744;
+                                color: #fff;
+                                border: 1px solid #ff1744;
+                              "
+                              >Retracted</span
+                            >
+                            <span
+                              style="
+                                display: inline-flex;
+                                align-items: center;
+                                gap: 4px;
+                                font-size: 10px;
+                                font-weight: 600;
+                                padding: 1px 7px;
+                                border-radius: 10px;
+                                background: #e9f3f1;
+                                color: #446058;
+                                border: 1px solid #7accc8;
+                              "
+                            >
+                              <svg
+                                width="9"
+                                height="13"
+                                viewBox="0 0 98.5 146.5"
+                                fill="none"
+                                stroke="#446058"
+                                stroke-width="7"
+                                stroke-linecap="round"
+                              >
+                                <circle cx="13.667" cy="34.833" r="10.167" />
+                                <circle cx="86.302" cy="80.344" r="10.167" />
+                                <circle cx="86.302" cy="12.741" r="10.167" />
+                                <circle cx="13.04" cy="133.811" r="10.166" />
+                                <line x1="13.04" y1="45" x2="13.04" y2="123.645" />
+                                <line x1="23.44" y1="32.04" x2="76.554" y2="15.626" />
+                                <line x1="86.303" y1="22.907" x2="86.303" y2="70.177" />
+                                <line x1="18.027" y1="124.955" x2="80.772" y2="21.267" />
+                                <line x1="76.136" y1="80.344" x2="45.023" y2="80.344" />
+                              </svg>
+                              2 comments
+                            </span>
+                          </div>
                         </div>
                         <!-- Open in FLoRA Atlas button -->
                         <div
@@ -1312,6 +1458,328 @@
           </div>
           <!-- /step-4 -->
 
+          <!-- ─────────────────────────────────
+               STEP 5 — Open Access & Retractions
+               ───────────────────────────────── -->
+          <div class="wt-step" id="step-5">
+            <div class="wt-step-inner wider">
+              <div class="wt-info">
+                <div class="wt-context">
+                  <span class="wt-context-tag tag-pages">
+                    <svg
+                      width="11"
+                      height="11"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="2.5"
+                    >
+                      <path
+                        d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"
+                      />
+                      <polyline points="14 2 14 8 20 8" />
+                      <line x1="16" y1="13" x2="8" y2="13" />
+                      <line x1="16" y1="17" x2="8" y2="17" />
+                    </svg>
+                    Journal &amp; Article Pages
+                  </span>
+                  <span class="wt-step-num">6 of 6</span>
+                </div>
+                <h2 class="wt-title">Open Access &amp; Retractions</h2>
+                <p class="wt-desc">
+                  As FLoRA scans a page it flags retracted papers and surfaces
+                  free full text. A small toast shows while it works, and it only
+                  runs on the tab you're actually viewing.
+                </p>
+                <div class="wt-callouts">
+                  <div class="wt-callout callout-confirmed">
+                    <div class="wt-callout-icon icon-confirmed">
+                      <svg
+                        width="11"
+                        height="11"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="white"
+                        stroke-width="2.5"
+                      >
+                        <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+                        <path d="M7 11V7a5 5 0 0 1 9.9-1" />
+                      </svg>
+                    </div>
+                    <div class="wt-callout-body">
+                      <div class="wt-callout-title">"Free" Open Access link</div>
+                      <div class="wt-callout-text">
+                        Reference DOIs with a free full text (via Unpaywall) get
+                        a green "Free" link inside the pill — one click to the
+                        open copy.
+                      </div>
+                    </div>
+                  </div>
+                  <div class="wt-callout callout-unconfirmed">
+                    <div class="wt-callout-icon icon-unconfirmed">
+                      <svg
+                        width="11"
+                        height="11"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="white"
+                        stroke-width="2.5"
+                      >
+                        <path
+                          d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"
+                        />
+                        <line x1="12" y1="9" x2="12" y2="13" />
+                        <line x1="12" y1="17" x2="12.01" y2="17" />
+                      </svg>
+                    </div>
+                    <div class="wt-callout-body">
+                      <div class="wt-callout-title">Retraction flags</div>
+                      <div class="wt-callout-text">
+                        Retracted papers and expressions of concern are flagged
+                        with a red tag beside the title and DOIs. Click to read
+                        the notice.
+                      </div>
+                    </div>
+                  </div>
+                  <div class="wt-callout callout-neutral">
+                    <div class="wt-callout-icon icon-neutral">
+                      <svg
+                        width="11"
+                        height="11"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="white"
+                        stroke-width="2.5"
+                      >
+                        <polyline points="23 4 23 10 17 10" />
+                        <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10" />
+                      </svg>
+                    </div>
+                    <div class="wt-callout-body">
+                      <div class="wt-callout-title">Scanning indicator</div>
+                      <div class="wt-callout-text">
+                        A small toast in the corner appears while FLoRA is
+                        scanning the page, then disappears when it's done.
+                      </div>
+                    </div>
+                  </div>
+                  <div class="wt-callout callout-neutral">
+                    <div class="wt-callout-icon icon-neutral">
+                      <svg
+                        width="11"
+                        height="11"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="white"
+                        stroke-width="2.5"
+                      >
+                        <path
+                          d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7z"
+                        />
+                        <circle cx="12" cy="12" r="3" />
+                      </svg>
+                    </div>
+                    <div class="wt-callout-body">
+                      <div class="wt-callout-title">Active tab only</div>
+                      <div class="wt-callout-text">
+                        FLoRA only works on the tab you're viewing — background
+                        tabs stay idle until you switch to them.
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <!-- Demo: article with retraction flag + reference OA "Free" + scanning toast -->
+              <div class="step-demo" id="demo-5">
+                <button class="replay-btn">
+                  <svg
+                    width="11"
+                    height="11"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                  >
+                    <polyline points="1 4 1 10 7 10" />
+                    <path d="M3.51 15a9 9 0 1 0 .49-4" />
+                  </svg>
+                  Replay
+                </button>
+                <div class="mock-browser">
+                  <div class="mock-browser-bar">
+                    <div class="mock-browser-dots">
+                      <span></span><span></span><span></span>
+                    </div>
+                    <div class="mock-url">
+                      journals.example.org/doi/10.1037/0033-2909.131.6.803
+                    </div>
+                  </div>
+                  <div class="mock-pages-single">
+                    <div class="mock-article-body">
+                      <div class="mock-journal-name">Psychological Bulletin</div>
+                      <h3 class="mock-article-title">
+                        Mood and the Endowment Effect: A Reassessment
+                        <span
+                          class="anim-badge"
+                          style="
+                            display: inline-flex;
+                            align-items: center;
+                            gap: 4px;
+                            vertical-align: middle;
+                            margin-left: 8px;
+                            font-size: 11px;
+                            font-weight: 600;
+                            color: #fff;
+                            background: #ff1744;
+                            padding: 2px 9px;
+                            border-radius: 11px;
+                          "
+                        >
+                          <svg
+                            width="11"
+                            height="11"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="#fff"
+                            stroke-width="2.5"
+                          >
+                            <path
+                              d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"
+                            />
+                            <line x1="12" y1="9" x2="12" y2="13" />
+                            <line x1="12" y1="17" x2="12.01" y2="17" />
+                          </svg>
+                          Retracted
+                        </span>
+                      </h3>
+                      <div class="mock-article-authors">
+                        J. Researcher, A. Coauthor &mdash; 2005
+                      </div>
+                      <div
+                        style="
+                          margin-top: 16px;
+                          font-size: 11px;
+                          font-weight: 600;
+                          color: #5f6368;
+                          text-transform: uppercase;
+                          letter-spacing: 0.5px;
+                        "
+                      >
+                        References
+                      </div>
+                      <div
+                        style="
+                          font-size: 12.5px;
+                          color: #3c4043;
+                          line-height: 1.6;
+                          padding: 8px 0;
+                          border-bottom: 1px solid #eee;
+                        "
+                      >
+                        Kahneman, D., Knetsch, J. L., &amp; Thaler, R. (1990).
+                        Experimental tests of the endowment effect.
+                        <em>Journal of Political Economy</em>.
+                        <span
+                          class="anim-badge"
+                          style="
+                            display: inline-flex;
+                            align-items: center;
+                            gap: 4px;
+                            vertical-align: middle;
+                            margin-left: 4px;
+                            font-size: 11px;
+                            font-weight: 500;
+                            color: #fff;
+                            background: #853953;
+                            opacity: 0.85;
+                            padding: 2px 9px;
+                            border-radius: 20px;
+                          "
+                        >
+                          DOI
+                          <svg
+                            width="11"
+                            height="11"
+                            viewBox="0 0 16 16"
+                            fill="white"
+                          >
+                            <path
+                              d="M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.75.75 0 0 1 1.06-1.06L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0Z"
+                            />
+                          </svg>
+                          <span
+                            style="
+                              width: 1px;
+                              height: 11px;
+                              background: rgba(255, 255, 255, 0.4);
+                            "
+                          ></span>
+                          <span
+                            style="display: inline-flex; align-items: center; gap: 3px"
+                          >
+                            <svg
+                              width="12"
+                              height="12"
+                              viewBox="0 0 24 24"
+                              fill="none"
+                              stroke="#fff"
+                              stroke-width="2.2"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                            >
+                              <rect
+                                x="3"
+                                y="11"
+                                width="18"
+                                height="11"
+                                rx="2"
+                                ry="2"
+                              />
+                              <path d="M7 11V7a5 5 0 0 1 9.9-1" />
+                            </svg>
+                            Free
+                          </span>
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                  <!-- Scanning toast — bottom-right, matches injector.ts output -->
+                  <div
+                    class="anim-badge"
+                    style="
+                      position: absolute;
+                      bottom: 14px;
+                      right: 14px;
+                      display: flex;
+                      align-items: center;
+                      gap: 8px;
+                      background: linear-gradient(135deg, #853953, #612d53);
+                      color: #fff;
+                      font-size: 12px;
+                      font-weight: 500;
+                      padding: 8px 12px;
+                      border-radius: 8px;
+                      box-shadow: 0 4px 16px rgba(0, 0, 0, 0.18);
+                    "
+                  >
+                    <span
+                      style="
+                        width: 12px;
+                        height: 12px;
+                        border-radius: 50%;
+                        border: 2px solid rgba(255, 255, 255, 0.35);
+                        border-top-color: #fff;
+                      "
+                    ></span>
+                    FLoRA is scanning this page…
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <!-- /step-5 -->
+
           <!-- ═══ NAVIGATION ═══ -->
           <div class="wt-nav">
             <button class="wt-nav-btn" id="prev-btn" disabled>
@@ -1339,6 +1807,8 @@
                 <button class="wt-dot" data-step="3"></button>
                 <div class="wt-dot-line"></div>
                 <button class="wt-dot" data-step="4"></button>
+                <div class="wt-dot-line"></div>
+                <button class="wt-dot" data-step="5"></button>
               </div>
             </div>
 

--- a/src/walkthrough/walkthrough.ts
+++ b/src/walkthrough/walkthrough.ts
@@ -1,4 +1,4 @@
-const TOTAL = 5;
+const TOTAL = 6;
 let current = 0;
 
 function activate(n: number): void {

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -46,6 +46,16 @@ Object.defineProperty(globalThis, "chrome", {
       },
       openOptionsPage: vi.fn(),
     },
+    tabs: {
+      create: vi.fn(),
+      onUpdated: {
+        addListener: vi.fn(),
+      },
+    },
+    action: {
+      setIcon: vi.fn().mockResolvedValue(undefined),
+      setTitle: vi.fn().mockResolvedValue(undefined),
+    },
   },
   writable: true,
 });


### PR DESCRIPTION
Draw a dynamic toolbar icon in the service worker and toggle it per-tab via a new FLORA_ACTIVE_STATE message from content scripts; reset icon on navigation. Defer content work to the visible/active tab and skip DOM processing while hidden, plus re-scan on visibility changes. Add a ref‑counted "working" toast (beginWorkIndicator/endWorkIndicator) shown during DOI validation and lookup and suppressed when UI is hidden. Integrate Unpaywall lookups with caching (shared/openaccess.ts) and surface a "Free" OA link inside DOI pills (shared/doi-label.ts + references). Improve PubPeer panel behavior and UI: better title selection, iframe fallback when embedding is blocked, updated comment pill styling, and suppress replication lists when the article itself is a replication. Update walkthrough copy/steps to document OA/retraction behavior and other UI tweaks.