### PR TITLE
Move retraction lookups into the service worker

### DIFF
--- a/esbuild.config.ts
+++ b/esbuild.config.ts
@@ -59,6 +59,9 @@ function copyStaticAssets() {
   copyFileSync("src/walkthrough/index.html", "dist/walkthrough.html");
   copyFileSync("src/walkthrough/walkthrough.css", "dist/walkthrough.css");
   copyFileSync("assets/forrt-logo.svg", "dist/forrt-logo.svg");
+  // The service worker fetches this at runtime as the retraction fallback, so
+  // it ships as a static asset instead of being bundled into any script.
+  copyFileSync("src/retractions.json", "dist/retractions.json");
 }
 
 async function build() {

--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -1,9 +1,9 @@
 import {LocalCache} from "@shared/cache";
 import {lookupDOIs} from "@shared/flora-api";
-import {RET_MAP_KEY, storageSync} from "@shared/data-extract";
-import type {DoiString, ReplicationResult} from "@shared/types";
-import {LookupResponse, SheetFetchResponse} from "@shared/messages";
-import {isLookupRequest, isSheetFetchRequest} from "@shared/messages";
+import {RET_MAP_KEY, storageSync, type RetractionMaps} from "@shared/data-extract";
+import type {DoiString, ReplicationResult, RetractionResponse} from "@shared/types";
+import {LookupResponse, RetractionCheckResponse, SheetFetchResponse} from "@shared/messages";
+import {isLookupRequest, isRetractionCheckRequest, isSheetFetchRequest} from "@shared/messages";
 import {getSettings, isSetupComplete} from "@shared/settings";
 
 const cache = new LocalCache<ReplicationResult>("flora");
@@ -13,13 +13,17 @@ getSettings().then(({ cacheQuotaMb }) => {
     cache.setQuota(cacheQuotaMb === 0 ? 0 : cacheQuotaMb * 1024 * 1024);
 }).catch();
 
-// Keep quota in sync when the user changes the setting.
+// Keep quota in sync when the user changes the setting; drop the cached
+// retraction source whenever a fresh map is synced into local storage.
 chrome.storage.onChanged.addListener((changes, area) => {
     if (area === "sync" && "flora_settings" in changes) {
         const next = (changes["flora_settings"].newValue as { cacheQuotaMb?: number } | undefined);
         if (next?.cacheQuotaMb != null) {
             cache.setQuota(next.cacheQuotaMb === 0 ? 0 : next.cacheQuotaMb * 1024 * 1024);
         }
+    }
+    if (area === "local" && RET_MAP_KEY in changes) {
+        cachedRetractionSource = null;
     }
 });
 
@@ -108,6 +112,19 @@ chrome.runtime.onMessage.addListener(
                             message.dois.map((d) => [d, "Service worker error"])
                         ),
                     } satisfies LookupResponse)
+                );
+            return true;
+        }
+
+        if (isRetractionCheckRequest(message)) {
+            handleRetractionCheck(message.dois)
+                .then(sendResponse)
+                .catch(() =>
+                    sendResponse({
+                        type: "FLORA_RET_CHECK_RESULT",
+                        results: [],
+                        error: "Service worker error",
+                    } satisfies RetractionCheckResponse)
                 );
             return true;
         }
@@ -247,6 +264,106 @@ async function handleSheetFetch(
     }
 }
 
+// ── Retraction lookups ──────────────────────────────────────────────────────
+// Retraction data lives in the service worker so the multi-megabyte
+// `retractions.json` never ships inside content bundles. Content scripts ask
+// for a verdict via FLORA_RET_CHECK; the worker reads the synced map (falling
+// back to the bundled JSON), tags each hit as a retraction or concern, and
+// returns the notice DOIs.
+
+/**
+ * Retraction Watch publishes DOIs in their original publisher case (SICI-style
+ * Elsevier identifiers, NEJM, ASCE, etc. carry uppercase letters), but every
+ * DOI we look up has been through normaliseDOI() which lowercases it. Without
+ * normalising the source keys too, ~12.7k of the ~58.6k retractions would
+ * never match.
+ */
+function lowercaseKeys(obj: Record<string, string> | undefined): Record<string, string> {
+    const out: Record<string, string> = {};
+    if (!obj) return out;
+    for (const k in obj) out[k.toLowerCase()] = obj[k];
+    return out;
+}
+
+// Normalised retraction source, cached so lowercaseKeys runs once per sync
+// rather than once per lookup. Invalidated by the storage.onChanged listener
+// above whenever a fresh map is written.
+let cachedRetractionSource: RetractionMaps | null = null;
+
+// The bundled fallback is fetched lazily (not statically imported) so it stays
+// out of the worker bundle until the very first install before any sync.
+let bundledRetractionMapPromise: Promise<RetractionMaps> | null = null;
+
+async function loadBundledRetractionMap(): Promise<RetractionMaps> {
+    if (!bundledRetractionMapPromise) {
+        bundledRetractionMapPromise = (async () => {
+            const response = await fetch(chrome.runtime.getURL("dist/retractions.json"));
+            if (!response.ok) {
+                throw new Error(`Failed to load bundled retractions: ${response.status}`);
+            }
+            const data = await response.json() as RetractionMaps;
+            return {
+                retractions: lowercaseKeys(data.retractions),
+                concerns: lowercaseKeys(data.concerns),
+            };
+        })();
+    }
+    try {
+        return await bundledRetractionMapPromise;
+    } catch (error) {
+        bundledRetractionMapPromise = null; // allow a retry on the next call
+        throw error;
+    }
+}
+
+async function getRetractionSource(): Promise<RetractionMaps> {
+    if (cachedRetractionSource) return cachedRetractionSource;
+
+    const storageResult = await chrome.storage.local.get([RET_MAP_KEY]);
+    const stored = storageResult[RET_MAP_KEY] as RetractionMaps | undefined;
+    const hasStoredData = !!stored && (
+        Object.keys(stored.retractions || {}).length > 0 ||
+        Object.keys(stored.concerns || {}).length > 0
+    );
+
+    if (hasStoredData) {
+        cachedRetractionSource = {
+            retractions: lowercaseKeys(stored!.retractions),
+            concerns: lowercaseKeys(stored!.concerns),
+        };
+        return cachedRetractionSource;
+    }
+
+    // Nothing synced yet: kick off a sync for next time and answer from the
+    // bundled JSON now. Don't cache the fallback — onChanged will pick up the
+    // synced map, but until then we re-read so an in-flight sync is noticed.
+    syncRetractionsInfo().then().catch();
+    return loadBundledRetractionMap();
+}
+
+async function handleRetractionCheck(dois: DoiString[]): Promise<RetractionCheckResponse> {
+    let source: RetractionMaps;
+    try {
+        source = await getRetractionSource();
+    } catch {
+        return {type: "FLORA_RET_CHECK_RESULT", results: [], error: "Retraction data unavailable"};
+    }
+
+    const results: RetractionResponse[] = [];
+    for (const doi of dois) {
+        const retractionDoi = source.retractions[doi];
+        if (retractionDoi) {
+            results.push({originDoi: doi, doi: retractionDoi, kind: "retraction"});
+            continue;
+        }
+        const concernDoi = source.concerns?.[doi];
+        if (concernDoi) {
+            results.push({originDoi: doi, doi: concernDoi, kind: "concern"});
+        }
+    }
+    return {type: "FLORA_RET_CHECK_RESULT", results};
+}
+
 export async function syncRetractionsInfo() {
     const minInterval = 1000 * 60 * 60 * 24 * 7; // weekly
     const currentTime = Date.now();
@@ -254,8 +371,13 @@ export async function syncRetractionsInfo() {
     const lastSync = previous.synctime || 0;
     const nextUpdate = lastSync + minInterval;
     const storageResult = await chrome.storage.local.get(RET_MAP_KEY);
-    if (Object.keys(storageResult).length === 0 || currentTime > nextUpdate) {
-        await storageSync();
-        await chrome.storage.local.set({synctime: currentTime});
+    const map = storageResult[RET_MAP_KEY] as RetractionMaps | undefined;
+    const isEmpty = !map || (
+        Object.keys(map.retractions || {}).length === 0 &&
+        Object.keys(map.concerns || {}).length === 0
+    );
+    if (isEmpty || currentTime > nextUpdate) {
+        const synced = await storageSync();
+        if (synced) await chrome.storage.local.set({synctime: currentTime});
     }
 }

--- a/src/shared/data-extract.ts
+++ b/src/shared/data-extract.ts
@@ -36,8 +36,9 @@ export async function fetchRetractionMap(): Promise<RetractionMaps | undefined> 
     }
 }
 
-export async function storageSync() {
+export async function storageSync(): Promise<boolean> {
     const map = await fetchRetractionMap();
-    if (!map) return;
+    if (!map) return false;
     await chrome.storage.local.set({[RET_MAP_KEY]: map});
+    return true;
 }

--- a/src/shared/doi-retraction.ts
+++ b/src/shared/doi-retraction.ts
@@ -1,14 +1,13 @@
-import {RET_MAP_KEY, RetractionMaps} from "@shared/data-extract"
-import {normaliseDOI} from "@shared/doi-normalise";
 import {extractDoiFromHref} from "@shared/doi-extractor";
 import {FLORA_NOTICE_PILL_CLASS} from "@shared/doi-label";
-import retractionData from '../retractions.json';
-import {DoiString} from "@shared/types";
-import { debugLog } from "./debug";
+import type {DoiString, NoticeKind, RetractionResponse} from "@shared/types";
+import type {RetractionCheckResponse} from "@shared/messages";
 
 export const FLORA_RET_CHECK_KEY = "flora-ret-checked";
 
-export type NoticeKind = "retraction" | "concern";
+// Re-exported so existing content imports (injector, references, index, the
+// Scholar observer) keep importing notice types from here.
+export type {NoticeKind, RetractionResponse} from "@shared/types";
 
 // Warning-triangle artwork for the "Concern" pill and the EoC banner —
 // same path as the existing banner triangle, exported once so the pill
@@ -94,81 +93,18 @@ export function noticePresentation(kind: NoticeKind): NoticePresentation {
     };
 }
 
-export interface RetractionResponse {
-    originDoi: DoiString;
-    doi: string;
-    kind: NoticeKind;
-}
-
 /**
- * Retraction Watch publishes DOIs in their original publisher case (SICI-style
- * Elsevier identifiers, NEJM, ASCE, etc. carry uppercase letters), but every
- * DOI we look up has been through normaliseDOI() which lowercases it. Without
- * normalising the source keys too, ~12.7k of the ~58.6k bundled retractions
- * would never match.
+ * Request retraction status from the background service worker. The worker
+ * owns the retraction data (storage, weekly sync, and the bundled fallback)
+ * so the multi-megabyte `retractions.json` never ships inside content bundles.
  */
-function lowercaseKeys(obj: Record<string, string> | undefined): Record<string, string> {
-    const out: Record<string, string> = {};
-    if (!obj) return out;
-    for (const k in obj) out[k.toLowerCase()] = obj[k];
-    return out;
-}
-
-// Bundled data is imported at module load and never changes — normalise once.
-const NORMALISED_BUNDLED: RetractionMaps = {
-    retractions: lowercaseKeys((retractionData as RetractionMaps).retractions),
-    concerns: lowercaseKeys((retractionData as RetractionMaps).concerns),
-};
-
-// Normalized retraction source, cached so lowercaseKeys runs once per sync,
-// not once per retractionCheck call. Invalidated when storage changes.
-let cachedSource: RetractionMaps | null = null;
-
-chrome.storage.onChanged.addListener((changes, area) => {
-    if (area === "local" && RET_MAP_KEY in changes) {
-        cachedSource = null;
-    }
-});
-
-async function getRetractionSource(): Promise<RetractionMaps> {
-    if (cachedSource) return cachedSource;
-
-    const storageResult = await chrome.storage.local.get([RET_MAP_KEY]);
-    const stored = storageResult[RET_MAP_KEY] as RetractionMaps | undefined;
-
-    const hasCachedData = !!stored && (
-        Object.keys(stored.retractions || {}).length > 0 ||
-        Object.keys(stored.concerns || {}).length > 0
-    );
-
-    cachedSource = hasCachedData
-        ? { retractions: lowercaseKeys(stored!.retractions), concerns: lowercaseKeys(stored!.concerns) }
-        : NORMALISED_BUNDLED;
-
-    return cachedSource;
-}
-
-/**
- * Request retraction status. Due to CORS policies, the request
- * must execute in the background context.
- */
-// @ts-ignore
 export async function retractionCheck(dois: DoiString[]): Promise<RetractionResponse[]> {
-    const source = await getRetractionSource();
-    const result: RetractionResponse[] = [];
-    for (const doi of dois) {
-        const retractionDOI = source.retractions[doi];
-        if (retractionDOI) {
-            result.push({ originDoi: doi, doi: retractionDOI, kind: "retraction" });
-            continue;
-        }
-        const concernDOI = source.concerns?.[doi];
-        if (concernDOI) {
-            result.push({ originDoi: doi, doi: concernDOI, kind: "concern" });
-        }
-    }
-    debugLog("Retraction check for DOIs", dois, "result", result);
-    return result;
+    const response = await chrome.runtime.sendMessage({
+        type: "FLORA_RET_CHECK",
+        dois,
+    }) as RetractionCheckResponse | undefined;
+
+    return response?.type === "FLORA_RET_CHECK_RESULT" ? response.results : [];
 }
 
 // Retracted DOIs that already have a pill on the page — the "Retracted" pill
@@ -178,11 +114,6 @@ const pilledRetractionDois = new Set<string>();
 /** Clear per-DOI retraction-pill tracking — call on SPA navigation. */
 export function resetRetractionPills(): void {
     pilledRetractionDois.clear();
-}
-
-/** Reset the in-memory retraction source cache — for use in tests only. */
-export function resetRetractionCache(): void {
-    cachedSource = null;
 }
 
 export interface InjectRetractionOptions {

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -1,4 +1,4 @@
-import type {DoiString, ReplicationResult} from "./types";
+import type {DoiString, ReplicationResult, RetractionResponse} from "./types";
 
 /** Content script → service worker: request DOI lookups */
 export interface LookupRequest {
@@ -11,6 +11,19 @@ export interface LookupResponse {
     type: "FLORA_LOOKUP_RESULT";
     results: Record<string, ReplicationResult>;
     errors: Record<string, string>;
+}
+
+/** Content script → service worker: request retraction status for DOI(s) */
+export interface RetractionCheckRequest {
+    type: "FLORA_RET_CHECK";
+    dois: DoiString[];
+}
+
+/** Service worker → content script: retraction lookup results */
+export interface RetractionCheckResponse {
+    type: "FLORA_RET_CHECK_RESULT";
+    results: RetractionResponse[];
+    error?: string;
 }
 
 /** Content script → service worker: fetch Google Sheet CSV for DOI extraction */
@@ -32,6 +45,14 @@ export function isLookupRequest(msg: unknown): msg is LookupRequest {
         typeof msg === "object" &&
         msg !== null &&
         (msg as Record<string, unknown>).type === "FLORA_LOOKUP"
+    );
+}
+
+export function isRetractionCheckRequest(msg: unknown): msg is RetractionCheckRequest {
+    return (
+        typeof msg === "object" &&
+        msg !== null &&
+        (msg as Record<string, unknown>).type === "FLORA_RET_CHECK"
     );
 }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -102,6 +102,16 @@ export interface CachedEntry<T> {
 /** How a DOI was classified on the page */
 export type DoiContext = "article" | "reference" | "other" | "retracted";
 
+/** Whether a notice is a retraction or an expression of concern */
+export type NoticeKind = "retraction" | "concern";
+
+/** A matched retraction/concern notice for an original paper's DOI */
+export interface RetractionResponse {
+  originDoi: DoiString;
+  doi: string;
+  kind: NoticeKind;
+}
+
 /** What kind of page we're on */
 export type PageType = "article" | "listing" | "unknown";
 

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -29,6 +29,7 @@ Object.defineProperty(globalThis, "chrome", {
     },
     runtime: {
       id: "test-extension-id",
+      getURL: vi.fn((path: string) => `chrome-extension://test-extension-id/${path}`),
       sendMessage: vi.fn().mockResolvedValue({
         type: "FLORA_LOOKUP_RESULT",
         results: {},

--- a/tests/unit/content-bundle-size.test.ts
+++ b/tests/unit/content-bundle-size.test.ts
@@ -1,0 +1,49 @@
+import {describe, expect, it} from "vitest";
+import {execFile} from "node:child_process";
+import {promisify} from "node:util";
+
+const contentEntries = [
+    "src/content-general/index.ts",
+    "src/content-scholar/index.ts",
+];
+const execFileAsync = promisify(execFile);
+
+describe("content bundle composition", () => {
+    it("does not bundle the retraction fallback JSON into content scripts", async () => {
+        const script = `
+            import * as esbuild from "esbuild";
+            const entries = ${JSON.stringify(contentEntries)};
+            const results = [];
+            for (const entryPoint of entries) {
+                const result = await esbuild.build({
+                    entryPoints: [entryPoint],
+                    bundle: true,
+                    write: false,
+                    metafile: true,
+                    minify: true,
+                    target: "chrome116",
+                    loader: {".css": "text"},
+                    logLevel: "silent",
+                });
+                const output = Object.values(result.metafile.outputs)[0];
+                results.push({
+                    entryPoint,
+                    bytes: output.bytes,
+                    hasRetractionsJson: Object.hasOwn(output.inputs, "src/retractions.json"),
+                });
+            }
+            console.log(JSON.stringify(results));
+        `;
+        const {stdout} = await execFileAsync(process.execPath, ["--input-type=module", "-e", script]);
+        const results = JSON.parse(stdout) as {
+            entryPoint: string;
+            bytes: number;
+            hasRetractionsJson: boolean;
+        }[];
+
+        for (const result of results) {
+            expect(result.hasRetractionsJson, result.entryPoint).toBe(false);
+            expect(result.bytes, result.entryPoint).toBeLessThan(300_000);
+        }
+    });
+});

--- a/tests/unit/doi-retraction.test.ts
+++ b/tests/unit/doi-retraction.test.ts
@@ -1,153 +1,56 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import {describe, it, expect, vi, beforeEach} from "vitest";
+import {doi} from "../helpers";
 
-import { retractionCheck, resetRetractionCache } from "../../src/shared/doi-retraction";
-import { RET_MAP_KEY } from "../../src/shared/data-extract";
-import type { DoiString } from "../../src/shared/types";
-
-const doi = (s: string) => s.toLowerCase() as DoiString;
-
-// A retraction known to exist in the bundled src/retractions.json. Used to
-// exercise the static-fallback path without coupling the test to any one
-// specific DOI's notice value.
-const BUNDLED_RETRACTED_DOI = "10.1007/s00500-023-09262-x";
-const BUNDLED_RETRACTION_NOTICE = "10.1007/s00500-025-11130-9";
-
-describe("retractionCheck", () => {
-  beforeEach(() => {
-    resetRetractionCache();
-    (chrome.storage.local.get as ReturnType<typeof vi.fn>).mockReset();
-  });
-
-  it("returns the notice DOI for a retracted paper found in the synced map", async () => {
-    (chrome.storage.local.get as ReturnType<typeof vi.fn>).mockResolvedValue({
-      [RET_MAP_KEY]: {
-        retractions: { "10.1234/paper": "10.1234/notice" },
-        concerns: {},
-      },
+// retractionCheck now runs in the content scripts purely as a thin client: it
+// asks the background service worker (which owns the data) for a verdict. These
+// tests pin that message contract; the lookup logic itself is covered by the
+// service-worker tests.
+describe("doi retraction content helper", () => {
+    beforeEach(() => {
+        vi.resetModules();
+        (chrome.runtime.sendMessage as ReturnType<typeof vi.fn>).mockReset();
     });
 
-    const result = await retractionCheck([doi("10.1234/paper")]);
-    expect(result).toEqual([
-      { originDoi: "10.1234/paper", doi: "10.1234/notice", kind: "retraction" },
-    ]);
-  });
+    it("requests retraction checks from the background service worker", async () => {
+        const originalDoi = doi("10.1038/nature12373");
+        (chrome.runtime.sendMessage as ReturnType<typeof vi.fn>).mockResolvedValue({
+            type: "FLORA_RET_CHECK_RESULT",
+            results: [{originDoi: originalDoi, doi: "10.1038/retraction", kind: "retraction"}],
+        });
 
-  it("returns expressions of concern tagged as 'concern'", async () => {
-    (chrome.storage.local.get as ReturnType<typeof vi.fn>).mockResolvedValue({
-      [RET_MAP_KEY]: {
-        retractions: {},
-        concerns: { "10.5678/eoc-paper": "10.5678/eoc-notice" },
-      },
+        const {retractionCheck} = await import("../../src/shared/doi-retraction");
+        const result = await retractionCheck([originalDoi]);
+
+        expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({
+            type: "FLORA_RET_CHECK",
+            dois: [originalDoi],
+        });
+        expect(result).toEqual([
+            {originDoi: originalDoi, doi: "10.1038/retraction", kind: "retraction"},
+        ]);
     });
 
-    const result = await retractionCheck([doi("10.5678/eoc-paper")]);
-    expect(result).toEqual([
-      { originDoi: "10.5678/eoc-paper", doi: "10.5678/eoc-notice", kind: "concern" },
-    ]);
-  });
+    it("passes expression-of-concern verdicts through unchanged", async () => {
+        const originalDoi = doi("10.5678/eoc-paper");
+        (chrome.runtime.sendMessage as ReturnType<typeof vi.fn>).mockResolvedValue({
+            type: "FLORA_RET_CHECK_RESULT",
+            results: [{originDoi: originalDoi, doi: "10.5678/eoc-notice", kind: "concern"}],
+        });
 
-  it("prefers retraction over concern when a DOI is present in both maps", async () => {
-    // Defensive: the updater's "latest event wins" rule means this shouldn't
-    // happen in production data, but the lookup loop is a one-line invariant
-    // worth pinning down.
-    (chrome.storage.local.get as ReturnType<typeof vi.fn>).mockResolvedValue({
-      [RET_MAP_KEY]: {
-        retractions: { "10.1234/dual": "10.1234/dual-retraction" },
-        concerns:    { "10.1234/dual": "10.1234/dual-concern" },
-      },
+        const {retractionCheck} = await import("../../src/shared/doi-retraction");
+        await expect(retractionCheck([originalDoi])).resolves.toEqual([
+            {originDoi: originalDoi, doi: "10.5678/eoc-notice", kind: "concern"},
+        ]);
     });
 
-    const result = await retractionCheck([doi("10.1234/dual")]);
-    expect(result).toEqual([
-      { originDoi: "10.1234/dual", doi: "10.1234/dual-retraction", kind: "retraction" },
-    ]);
-  });
+    it("returns no retractions for unexpected responses", async () => {
+        (chrome.runtime.sendMessage as ReturnType<typeof vi.fn>).mockResolvedValue({
+            type: "FLORA_LOOKUP_RESULT",
+            results: {},
+            errors: {},
+        });
 
-  it("falls back to the bundled static JSON when storage is empty", async () => {
-    (chrome.storage.local.get as ReturnType<typeof vi.fn>).mockResolvedValue({});
-    const result = await retractionCheck([doi(BUNDLED_RETRACTED_DOI)]);
-    expect(result).toEqual([
-      { originDoi: BUNDLED_RETRACTED_DOI, doi: BUNDLED_RETRACTION_NOTICE, kind: "retraction" },
-    ]);
-  });
-
-  it("falls back to bundled data when the cached retractions map is empty", async () => {
-    // Cached payload is present but the retractions map is empty (e.g. a
-    // partial sync). The bundled JSON must still answer the lookup.
-    (chrome.storage.local.get as ReturnType<typeof vi.fn>).mockResolvedValue({
-      [RET_MAP_KEY]: { retractions: {}, concerns: {} },
+        const {retractionCheck} = await import("../../src/shared/doi-retraction");
+        await expect(retractionCheck([doi("10.1038/nature12373")])).resolves.toEqual([]);
     });
-    const result = await retractionCheck([doi(BUNDLED_RETRACTED_DOI)]);
-    expect(result).toHaveLength(1);
-    expect(result[0].originDoi).toBe(BUNDLED_RETRACTED_DOI);
-    expect(result[0].kind).toBe("retraction");
-  });
-
-  it("returns nothing for a DOI that is in neither map", async () => {
-    (chrome.storage.local.get as ReturnType<typeof vi.fn>).mockResolvedValue({
-      [RET_MAP_KEY]: {
-        retractions: { "10.1234/keep": "10.1234/retraction" },
-        concerns: {},
-      },
-    });
-
-    const result = await retractionCheck([doi("10.9999/not-there")]);
-    expect(result).toEqual([]);
-  });
-
-  it("matches mixed-case source keys against lowercased DOI input", async () => {
-    // Retraction Watch publishes DOIs in their original publisher case
-    // (SICI/NEJM/ASCE identifiers carry uppercase letters), but normaliseDOI
-    // lowercases every DOI before lookup. retractionCheck must close the gap.
-    (chrome.storage.local.get as ReturnType<typeof vi.fn>).mockResolvedValue({
-      [RET_MAP_KEY]: {
-        retractions: { "10.1016/S0140-6736(20)32656-8": "10.1016/S0140-6736(22)02370-4" },
-        concerns: { "10.1056/NEJMicm2518379": "10.1056/NEJMicm9999999" },
-      },
-    });
-
-    const retracted = await retractionCheck([doi("10.1016/S0140-6736(20)32656-8")]);
-    expect(retracted).toEqual([
-      {
-        originDoi: "10.1016/s0140-6736(20)32656-8",
-        doi: "10.1016/S0140-6736(22)02370-4",
-        kind: "retraction",
-      },
-    ]);
-
-    const concerned = await retractionCheck([doi("10.1056/NEJMicm2518379")]);
-    expect(concerned).toEqual([
-      {
-        originDoi: "10.1056/nejmicm2518379",
-        doi: "10.1056/NEJMicm9999999",
-        kind: "concern",
-      },
-    ]);
-  });
-
-  it("processes a mixed batch, tagging each entry by its source map", async () => {
-    (chrome.storage.local.get as ReturnType<typeof vi.fn>).mockResolvedValue({
-      [RET_MAP_KEY]: {
-        retractions: {
-          "10.1234/a": "10.1234/a-notice",
-          "10.1234/c": "10.1234/c-notice",
-        },
-        concerns: {
-          "10.1234/d": "10.1234/d-notice",
-        },
-      },
-    });
-
-    const result = await retractionCheck([
-      doi("10.1234/a"),
-      doi("10.1234/b"),
-      doi("10.1234/c"),
-      doi("10.1234/d"),
-    ]);
-    expect(result).toEqual([
-      { originDoi: "10.1234/a", doi: "10.1234/a-notice", kind: "retraction" },
-      { originDoi: "10.1234/c", doi: "10.1234/c-notice", kind: "retraction" },
-      { originDoi: "10.1234/d", doi: "10.1234/d-notice", kind: "concern" },
-    ]);
-  });
 });

--- a/tests/unit/service-worker.test.ts
+++ b/tests/unit/service-worker.test.ts
@@ -1,5 +1,11 @@
 import {describe, it, expect, vi, beforeEach} from "vitest";
-import type {LookupRequest, LookupResponse} from "../../src/shared/messages";
+import type {
+    LookupRequest,
+    LookupResponse,
+    RetractionCheckResponse,
+} from "../../src/shared/messages";
+import type {RetractionMaps} from "../../src/shared/data-extract";
+import {RET_MAP_KEY} from "../../src/shared/data-extract";
 import {doi, mockResult} from "../helpers";
 
 
@@ -46,12 +52,13 @@ describe("service-worker", () => {
     let messageHandler: (
         message: unknown,
         sender: unknown,
-        sendResponse: (response: LookupResponse) => void
+        sendResponse: (response: unknown) => void
     ) => boolean | undefined;
 
     beforeEach(async () => {
         cacheStore.clear();
         mockLookupDOIs.mockReset();
+        (chrome.storage.local.get as ReturnType<typeof vi.fn>).mockResolvedValue({});
 
 
         const addListenerMock = vi.fn();
@@ -66,8 +73,29 @@ describe("service-worker", () => {
 
     function sendMessage(request: LookupRequest): Promise<LookupResponse> {
         return new Promise((resolve) => {
-            messageHandler(request, {}, resolve);
+            messageHandler(request, {}, resolve as (r: unknown) => void);
         });
+    }
+
+    function sendRetractionCheck(dois: string[]): Promise<RetractionCheckResponse> {
+        return new Promise((resolve) => {
+            messageHandler(
+                {type: "FLORA_RET_CHECK", dois},
+                {},
+                resolve as (r: unknown) => void
+            );
+        });
+    }
+
+    function storeRetractionMap(map: RetractionMaps): void {
+        (chrome.storage.local.get as ReturnType<typeof vi.fn>).mockImplementation(
+            async (keys: unknown) => {
+                const wants = (key: string) =>
+                    keys === key || (Array.isArray(keys) && keys.includes(key));
+                if (wants(RET_MAP_KEY)) return {[RET_MAP_KEY]: map};
+                return {};
+            }
+        );
     }
 
     it("returns results for matched DOIs", async () => {
@@ -153,6 +181,121 @@ describe("service-worker", () => {
     it("ignores non-lookup messages", () => {
         const result = messageHandler({type: "UNKNOWN"}, {}, vi.fn());
         expect(result).toBe(false);
+    });
+
+    describe("retraction checks", () => {
+        it("returns the notice DOI for a retracted paper in the synced map", async () => {
+            storeRetractionMap({
+                retractions: {"10.1234/paper": "10.1234/notice"},
+                concerns: {},
+            });
+
+            const response = await sendRetractionCheck([doi("10.1234/paper")]);
+            expect(response.type).toBe("FLORA_RET_CHECK_RESULT");
+            expect(response.results).toEqual([
+                {originDoi: "10.1234/paper", doi: "10.1234/notice", kind: "retraction"},
+            ]);
+        });
+
+        it("tags expressions of concern as 'concern'", async () => {
+            storeRetractionMap({
+                retractions: {},
+                concerns: {"10.5678/eoc-paper": "10.5678/eoc-notice"},
+            });
+
+            const response = await sendRetractionCheck([doi("10.5678/eoc-paper")]);
+            expect(response.results).toEqual([
+                {originDoi: "10.5678/eoc-paper", doi: "10.5678/eoc-notice", kind: "concern"},
+            ]);
+        });
+
+        it("prefers retraction over concern when a DOI is in both maps", async () => {
+            storeRetractionMap({
+                retractions: {"10.1234/dual": "10.1234/dual-retraction"},
+                concerns: {"10.1234/dual": "10.1234/dual-concern"},
+            });
+
+            const response = await sendRetractionCheck([doi("10.1234/dual")]);
+            expect(response.results).toEqual([
+                {originDoi: "10.1234/dual", doi: "10.1234/dual-retraction", kind: "retraction"},
+            ]);
+        });
+
+        it("matches mixed-case source keys against lowercased DOI input", async () => {
+            // Retraction Watch publishes DOIs in publisher case; normaliseDOI
+            // lowercases lookups, so the worker must lowercase the source keys.
+            storeRetractionMap({
+                retractions: {"10.1016/S0140-6736(20)32656-8": "10.1016/S0140-6736(22)02370-4"},
+                concerns: {"10.1056/NEJMicm2518379": "10.1056/NEJMicm9999999"},
+            });
+
+            // Lookups arrive already lowercased (normaliseDOI runs before the
+            // message is sent); the source keys are in publisher case.
+            const retracted = await sendRetractionCheck([doi("10.1016/s0140-6736(20)32656-8")]);
+            expect(retracted.results).toEqual([
+                {
+                    originDoi: "10.1016/s0140-6736(20)32656-8",
+                    doi: "10.1016/S0140-6736(22)02370-4",
+                    kind: "retraction",
+                },
+            ]);
+
+            const concerned = await sendRetractionCheck([doi("10.1056/nejmicm2518379")]);
+            expect(concerned.results).toEqual([
+                {
+                    originDoi: "10.1056/nejmicm2518379",
+                    doi: "10.1056/NEJMicm9999999",
+                    kind: "concern",
+                },
+            ]);
+        });
+
+        it("returns nothing for a DOI in neither map", async () => {
+            storeRetractionMap({
+                retractions: {"10.1234/keep": "10.1234/retraction"},
+                concerns: {},
+            });
+
+            const response = await sendRetractionCheck([doi("10.9999/not-there")]);
+            expect(response.results).toEqual([]);
+        });
+
+        it("falls back to the bundled JSON when storage is empty", async () => {
+            // Storage empty (default mock); the worker fetches the packaged
+            // dist/retractions.json and lowercases its keys.
+            const bundled: RetractionMaps = {
+                retractions: {"10.1000/Bundled": "10.1000/bundled-notice"},
+                concerns: {},
+            };
+            const fetchMock = vi.fn(async (url: string) => ({
+                ok: true,
+                status: 200,
+                json: async () =>
+                    String(url).includes("retractions.json")
+                        ? bundled
+                        : {retractions: {}, concerns: {}},
+            }));
+            vi.stubGlobal("fetch", fetchMock);
+
+            const response = await sendRetractionCheck([doi("10.1000/bundled")]);
+            expect(response.results).toEqual([
+                {originDoi: "10.1000/bundled", doi: "10.1000/bundled-notice", kind: "retraction"},
+            ]);
+            expect(fetchMock).toHaveBeenCalledWith(
+                "chrome-extension://test-extension-id/dist/retractions.json"
+            );
+            vi.unstubAllGlobals();
+        });
+
+        it("reports an error when no data source is available", async () => {
+            const fetchMock = vi.fn(async () => ({ok: false, status: 404, json: async () => ({})}));
+            vi.stubGlobal("fetch", fetchMock);
+
+            const response = await sendRetractionCheck([doi("10.1234/paper")]);
+            expect(response.results).toEqual([]);
+            expect(response.error).toBeTruthy();
+            vi.unstubAllGlobals();
+        });
     });
 
     it("splits cached and uncached DOIs in one request", async () => {


### PR DESCRIPTION
## What

Retraction lookups previously ran inside the content scripts, which **statically imported `src/retractions.json` (~3.6 MB)** into every content bundle. This moves the retraction data, weekly sync, and lookup into the **background service worker**; content scripts request a verdict via a `FLORA_RET_CHECK` message. All pill/banner/`kind` rendering stays in content.

## Why

The bundled JSON dominated the content bundles. After this change:

| bundle | before (JSON inlined) | after |
|---|---|---|
| `content-general.js` | multi-MB | ~78 KB |
| `content-scholar.js` | multi-MB | ~34 KB |

The data now ships once as a static `dist/retractions.json` that only the service worker fetches.

## How

- **`doi-retraction.ts`** — `retractionCheck()` becomes a thin message client. The data/lookup internals (`lowercaseKeys`, cached source, storage read, bundled fallback) move to the worker. `NoticeKind`/`RetractionResponse` move to `types.ts` (re-exported here so existing imports keep compiling).
- **`service-worker.ts`** — `handleRetractionCheck` + `getRetractionSource` preserve `main`'s key-lowercasing (Retraction Watch publishes publisher-case DOIs; lookups are lowercased by `normaliseDOI`) and in-memory caching, fetch `dist/retractions.json` as the bundled fallback, and invalidate the cache on storage change. `storageSync()` now returns whether it stored a map, so `synctime` is only stamped on a successful sync.
- **`esbuild.config.ts`** — copies `src/retractions.json` → `dist/` for the worker's runtime fetch (no `web_accessible_resources` needed — the worker fetches its own packaged resource at the extension origin).

## Tests

- New `content-bundle-size.test.ts` asserts the content entries no longer bundle `src/retractions.json` and stay under 300 KB.
- The retraction lookup-logic coverage (storage map, bundled fallback, mixed-case key matching, retraction-vs-concern tagging) moved from `doi-retraction.test.ts` into `service-worker.test.ts`, where the logic now lives. `doi-retraction.test.ts` now pins the content→worker message contract.
- Full suite: 176 passing; `npm run build` clean.

## Manual verification note

The worker's `fetch(chrome.runtime.getURL("dist/retractions.json"))` fallback path is the one thing not covered by static tests — worth a quick load of the unpacked build to confirm the packaged resource resolves (it uses the same `dist/` URL convention as the existing `getURL("dist/walkthrough.html")`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)