### PR TITLE
Fix storage-quota time-bomb: unlimitedStorage + real eviction

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,6 +6,7 @@
   "minimum_chrome_version": "116",
   "permissions": [
     "storage",
+    "unlimitedStorage",
     "activeTab"
   ],
   "action": {

--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -1,4 +1,4 @@
-import {LocalCache} from "@shared/cache";
+import {LocalCache, MONTH_MS} from "@shared/cache";
 import {lookupDOIs} from "@shared/flora-api";
 import {RET_MAP_KEY, storageSync, type RetractionMaps} from "@shared/data-extract";
 import type {DoiString, ReplicationResult, RetractionResponse} from "@shared/types";
@@ -232,7 +232,16 @@ async function handleLookup(dois: DoiString[]): Promise<LookupResponse> {
             const r = apiResults.get(doi);
             if (r) {
                 results[doi] = r;
-                await cache.set(doi, r, null); // resolved — cache forever
+                // Cache the result with a finite TTL. A cache-WRITE failure
+                // (e.g. storage quota) must never demote a successful lookup to
+                // an error: the result is already in `results`, so we swallow
+                // the write error here rather than letting it hit the outer
+                // catch (which would mark the whole batch as failed).
+                try {
+                    await cache.set(doi, r, MONTH_MS);
+                } catch {
+                    // Non-fatal: the result stands; we just re-fetch next time.
+                }
             }
             // No result (no record yet, or a transient batch failure): do NOT
             // cache. We re-query every time so newly added FORRT data surfaces

--- a/src/options/index.html
+++ b/src/options/index.html
@@ -189,7 +189,7 @@
                   class="ab-input"
                   min="0"
                   step="50"
-                  placeholder="500"
+                  placeholder="50"
                   style="width: 120px;"
                 />
               </div>

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -59,7 +59,7 @@ getSettings().then(({ cacheQuotaMb }) => {
 
 cacheQuotaSaveBtn.addEventListener("click", async () => {
   const raw = parseInt(cacheQuotaInput.value, 10);
-  const cacheQuotaMb = isNaN(raw) || raw < 0 ? 500 : raw;
+  const cacheQuotaMb = isNaN(raw) || raw < 0 ? 50 : raw;
   cacheQuotaInput.value = String(cacheQuotaMb);
   cacheQuotaSaveBtn.disabled = true;
   try {

--- a/src/shared/blob-cache.ts
+++ b/src/shared/blob-cache.ts
@@ -2,6 +2,8 @@
 // Cross-context concurrent writes are last-writer-wins on the whole blob —
 // acceptable for a cache (lost write = re-fetch).
 
+import {debugLog} from "./debug";
+
 interface CacheEntry<T> {
     v: T;
     t: number;
@@ -108,7 +110,27 @@ export class BlobCache<T> {
         try {
             await chrome.storage.local.set({[this.opts.storageKey]: this.mem});
         } catch {
-            // non-fatal
+            // Likely storage quota. Attempt one recovery: evict the oldest half
+            // of this blob's entries (by timestamp) and retry the write once.
+            this.evictOldestHalf();
+            try {
+                await chrome.storage.local.set({[this.opts.storageKey]: this.mem});
+            } catch {
+                debugLog(
+                    `BlobCache(${this.opts.storageKey}): write failed after evicting oldest half; keeping in-memory copy only`
+                );
+            }
+        }
+    }
+
+    private evictOldestHalf(): void {
+        if (!this.mem) return;
+        const keys = Object.keys(this.mem);
+        if (keys.length <= 1) return;
+        keys.sort((a, b) => this.mem![a].t - this.mem![b].t);
+        const dropCount = Math.floor(keys.length / 2);
+        for (let i = 0; i < dropCount; i++) {
+            delete this.mem[keys[i]];
         }
     }
 

--- a/src/shared/cache.ts
+++ b/src/shared/cache.ts
@@ -5,14 +5,15 @@ export const MONTH_MS = 30 * 24 * 60 * 60 * 1000;
 /**
  * Persistent cache using chrome.storage.local.
  * Supports per-entry TTL or permanent storage (ttlMs = null).
- * Enforces a soft storage quota by evicting expired entries when approached.
+ * Enforces a soft storage quota: when usage approaches the limit it evicts
+ * expired entries first, then live entries oldest-first (LRU by createdAt).
  */
 export class LocalCache<T> {
   private quotaBytes: number;
 
   constructor(
     private readonly prefix: string,
-    quotaBytes: number = 500 * 1024 * 1024
+    quotaBytes: number = 50 * 1024 * 1024
   ) {
     this.quotaBytes = quotaBytes;
   }
@@ -49,8 +50,9 @@ export class LocalCache<T> {
    */
   async set(key: string, data: T | null, ttlMs: number | null): Promise<void> {
     await this.sweepIfOverQuota();
-    const expiresAt = ttlMs === null ? null : Date.now() + ttlMs;
-    const entry: CachedEntry<T> = { data, expiresAt };
+    const now = Date.now();
+    const expiresAt = ttlMs === null ? null : now + ttlMs;
+    const entry: CachedEntry<T> = { data, expiresAt, createdAt: now };
     await chrome.storage.local.set({ [this.storageKey(key)]: entry });
   }
 
@@ -59,18 +61,44 @@ export class LocalCache<T> {
     const used = await chrome.storage.local.getBytesInUse(null);
     if (used < this.quotaBytes) return;
 
-    // Evict all expired entries for this cache prefix to reclaim space
     const all = await chrome.storage.local.get(null);
     const now = Date.now();
-    const expired = Object.keys(all)
-      .filter(k => k.startsWith(`${this.prefix}:`))
-      .filter(k => {
-        const e = all[k] as CachedEntry<T> | undefined;
-        return e?.expiresAt != null && now > e.expiresAt;
-      });
+    const mine = Object.keys(all).filter(k => k.startsWith(`${this.prefix}:`));
 
+    // First reclaim any expired entries for this prefix.
+    const expired = mine.filter(k => {
+      const e = all[k] as CachedEntry<T> | undefined;
+      return e?.expiresAt != null && now > e.expiresAt;
+    });
     if (expired.length > 0) {
       await chrome.storage.local.remove(expired);
+    }
+
+    // Still over quota? Evict live entries oldest-first (LRU by createdAt) until
+    // under the limit. Entries written before createdAt existed sort first (0),
+    // so pre-existing entries without the field are evicted first.
+    const remainingBytes = await chrome.storage.local.getBytesInUse(null);
+    if (remainingBytes < this.quotaBytes) return;
+
+    const expiredSet = new Set(expired);
+    const live = mine
+      .filter(k => !expiredSet.has(k))
+      .map(k => ({ key: k, createdAt: (all[k] as CachedEntry<T> | undefined)?.createdAt ?? 0 }))
+      .sort((a, b) => a.createdAt - b.createdAt);
+
+    const toEvict: string[] = [];
+    let freed = 0;
+    const overBy = remainingBytes - this.quotaBytes;
+    for (const { key } of live) {
+      const bytes = await chrome.storage.local.getBytesInUse(key);
+      toEvict.push(key);
+      freed += bytes;
+      // Evict at least enough to drop back under quota, with a little headroom
+      // for the entry about to be written.
+      if (freed > overBy) break;
+    }
+    if (toEvict.length > 0) {
+      await chrome.storage.local.remove(toEvict);
     }
   }
 

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -10,8 +10,10 @@ export interface FloraSettings {
    */
   showDoiPillsOnAllReferences: boolean;
   /**
-   * Soft cap on chrome.storage.local usage in MB. 0 = unlimited.
-   * Expired cache entries are evicted when this limit is approached.
+   * Soft cap on chrome.storage.local usage in MB. 0 = unlimited. With the
+   * "unlimitedStorage" permission the browser lifts the ~10 MB hard cap, so
+   * this is a housekeeping bound: when it's approached, expired cache entries
+   * are evicted first, then live entries oldest-first (LRU).
    */
   cacheQuotaMb: number;
 }
@@ -21,7 +23,7 @@ const STORAGE_KEY = "flora_settings";
 const DEFAULTS: FloraSettings = {
   email: "",
   showDoiPillsOnAllReferences: false,
-  cacheQuotaMb: 500,
+  cacheQuotaMb: 50,
 };
 
 let cachedSettings: FloraSettings | null = null;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -97,6 +97,7 @@ export type ReplicationResult = z.infer<typeof ReplicationResultSchema>;
 export interface CachedEntry<T> {
   data: T | null; // null = cached no-match
   expiresAt: number | null; // null = never expires
+  createdAt?: number; // epoch ms when written; used for LRU eviction under quota
 }
 
 /** How a DOI was classified on the page */

--- a/tests/unit/cache.test.ts
+++ b/tests/unit/cache.test.ts
@@ -84,6 +84,78 @@ describe("LocalCache", () => {
     expect(await cache.get("key")).toBe("second");
   });
 
+  it("records createdAt on set", async () => {
+    const cache = new LocalCache<string>("test");
+    const before = Date.now();
+    await cache.set("key", "value", null);
+    const entry = store["test:key"] as { createdAt: number };
+    expect(entry.createdAt).toBeGreaterThanOrEqual(before);
+  });
+
+  it("evicts expired entries first when over quota", async () => {
+    const cache = new LocalCache<string>("test");
+    cache.setQuota(1000);
+
+    // Pre-load one expired and one live entry directly into the store.
+    store["test:old"] = { data: "old", expiresAt: Date.now() - 1000, createdAt: 1 };
+    store["test:live"] = { data: "live", expiresAt: Date.now() + 100000, createdAt: 2 };
+
+    // Report over-quota on the first check, then under-quota afterwards so the
+    // LRU pass is not needed once the expired entry is reclaimed.
+    let call = 0;
+    (chrome.storage.local.getBytesInUse as ReturnType<typeof vi.fn>).mockImplementation(
+      async () => (call++ === 0 ? 5000 : 0)
+    );
+
+    await cache.set("new", "new", null);
+
+    expect(store["test:old"]).toBeUndefined(); // expired -> evicted
+    expect(store["test:live"]).toBeDefined();  // live -> kept
+    expect(store["test:new"]).toBeDefined();
+  });
+
+  it("evicts live entries oldest-first (LRU) when still over quota", async () => {
+    const cache = new LocalCache<string>("test");
+    cache.setQuota(1000);
+
+    // Three live entries with increasing createdAt (oldest = a).
+    store["test:a"] = { data: "a", expiresAt: null, createdAt: 1 };
+    store["test:b"] = { data: "b", expiresAt: null, createdAt: 2 };
+    store["test:c"] = { data: "c", expiresAt: null, createdAt: 3 };
+
+    // Stay over quota through both getBytesInUse(null) checks so the LRU pass
+    // runs; per-key size reported large enough that one eviction suffices.
+    (chrome.storage.local.getBytesInUse as ReturnType<typeof vi.fn>).mockImplementation(
+      async (key: string | null) => (key === null ? 5000 : 4001)
+    );
+
+    await cache.set("d", "d", null);
+
+    // Oldest live entry (a) evicted; newer ones survive.
+    expect(store["test:a"]).toBeUndefined();
+    expect(store["test:b"]).toBeDefined();
+    expect(store["test:c"]).toBeDefined();
+    expect(store["test:d"]).toBeDefined();
+  });
+
+  it("evicts entries without createdAt before newer ones", async () => {
+    const cache = new LocalCache<string>("test");
+    cache.setQuota(1000);
+
+    // Legacy entry lacks createdAt (treated as 0 = oldest); newer has createdAt.
+    store["test:legacy"] = { data: "legacy", expiresAt: null };
+    store["test:fresh"] = { data: "fresh", expiresAt: null, createdAt: 100 };
+
+    (chrome.storage.local.getBytesInUse as ReturnType<typeof vi.fn>).mockImplementation(
+      async (key: string | null) => (key === null ? 5000 : 4001)
+    );
+
+    await cache.set("new", "new", null);
+
+    expect(store["test:legacy"]).toBeUndefined();
+    expect(store["test:fresh"]).toBeDefined();
+  });
+
   it("setQuota(0) disables quota enforcement", async () => {
     const cache = new LocalCache<string>("test");
     cache.setQuota(0);

--- a/tests/unit/service-worker.test.ts
+++ b/tests/unit/service-worker.test.ts
@@ -25,6 +25,10 @@ vi.mock("../../src/shared/settings", () => ({
 
 // Mock cache
 const cacheStore = new Map<string, unknown>();
+// Records every cache.set(key, data, ttlMs) so tests can assert TTL is applied.
+const cacheSetCalls: Array<{key: string; data: unknown; ttlMs: number | null}> = [];
+// When set, cache.set throws (simulates a storage-quota write failure).
+let cacheSetError: Error | null = null;
 vi.mock("../../src/shared/cache", () => ({
     MONTH_MS: 30 * 24 * 60 * 60 * 1000,
     LocalCache: class {
@@ -42,7 +46,9 @@ vi.mock("../../src/shared/cache", () => ({
                 : undefined;
         }
 
-        async set(key: string, data: unknown, _ttlMs: number | null) {
+        async set(key: string, data: unknown, ttlMs: number | null) {
+            cacheSetCalls.push({key, data, ttlMs});
+            if (cacheSetError) throw cacheSetError;
             cacheStore.set(`${this.prefix}:${key}`, data);
         }
     },
@@ -57,6 +63,8 @@ describe("service-worker", () => {
 
     beforeEach(async () => {
         cacheStore.clear();
+        cacheSetCalls.length = 0;
+        cacheSetError = null;
         mockLookupDOIs.mockReset();
         (chrome.storage.local.get as ReturnType<typeof vi.fn>).mockResolvedValue({});
 
@@ -176,6 +184,41 @@ describe("service-worker", () => {
         expect(response.errors["10.1038/nature12373"]).toBe(
             "FLoRA API error: 500"
         );
+    });
+
+    it("applies a finite TTL to lookup cache writes (not forever)", async () => {
+        mockLookupDOIs.mockResolvedValue(
+            new Map([[doi("10.1038/nature12373"), MOCK_RESULT]])
+        );
+
+        await sendMessage({
+            type: "FLORA_LOOKUP",
+            dois: [doi("10.1038/nature12373")],
+        });
+
+        expect(cacheSetCalls).toHaveLength(1);
+        // ~30 days, not null/forever — this is what makes eviction possible.
+        expect(cacheSetCalls[0].ttlMs).toBe(30 * 24 * 60 * 60 * 1000);
+    });
+
+    it("does not turn a cache-WRITE failure into a lookup error", async () => {
+        // The API returns a real result, but persisting it to storage fails
+        // (e.g. quota). The result must still be returned and NOT reported as an
+        // error — this is the storage-quota time-bomb regression.
+        mockLookupDOIs.mockResolvedValue(
+            new Map([[doi("10.1038/nature12373"), MOCK_RESULT]])
+        );
+        cacheSetError = new Error("QUOTA_BYTES quota exceeded");
+
+        const response = await sendMessage({
+            type: "FLORA_LOOKUP",
+            dois: [doi("10.1038/nature12373")],
+        });
+
+        expect(response.results["10.1038/nature12373"]).toEqual(MOCK_RESULT);
+        expect(Object.keys(response.errors)).toHaveLength(0);
+        // The write was attempted (and threw) but did not corrupt the response.
+        expect(cacheSetCalls).toHaveLength(1);
     });
 
     it("ignores non-lookup messages", () => {

--- a/tests/unit/settings-domains-cache.test.ts
+++ b/tests/unit/settings-domains-cache.test.ts
@@ -6,7 +6,7 @@ import {afterEach, describe, expect, it, vi} from "vitest";
 const FULL_SETTINGS = {
   email: "test@example.com",
   showDoiPillsOnAllReferences: false,
-  cacheQuotaMb: 500,
+  cacheQuotaMb: 50,
 };
 
 describe("settings/domain storage caches", () => {


### PR DESCRIPTION
## Problem

The extension had a verified storage-quota time-bomb. The manifest declared only `storage`, capping `chrome.storage.local` at ~10 MB, into which it wrote a 3.6 MB retraction map plus **every** lookup result cached forever (`cache.set(doi, r, null)`). The eviction sweep could never help: the default quota was 500 MB (50× the real cap, so `sweepIfOverQuota` never fired) and it only removed entries with an expiry — permanent entries were unreclaimable by design.

Once storage filled, `cache.set` threw inside the results loop of `handleLookup`; the surrounding catch then marked **every DOI in the batch** as errored even though the API had returned results, leaving users with a permanent "Failed to contact FLoRA service" banner. `BlobCache.flush` swallowed the same failure silently, so OA/PubPeer/title caches quietly stopped persisting and the weekly retraction sync stopped updating.

## Fix (four parts)

1. **`unlimitedStorage` permission** — removes the 10 MB hard cap on Chrome/Edge/Opera. Primary fix.
2. **Real eviction (defence in depth)** — lookup entries now carry a finite 30-day TTL; the sweep reclaims expired entries first, then evicts live entries oldest-first (LRU via a new `createdAt` timestamp) until back under quota. Default soft quota lowered to an honest 50 MB (`0 = unlimited` preserved). Entries written before `createdAt` existed sort as oldest and are evicted first — no migration shim.
3. **Cache-write failures isolated** — a failed `cache.set` can no longer demote a successful lookup batch to errors; results are returned regardless of persistence.
4. **BlobCache resilience** — on write failure, evict the oldest half of the blob and retry once; if still failing, log via `debugLog` and keep serving from memory.

## Testing

- `npm test`: 195 passing (was 189; new coverage: TTL applied to lookup writes, cache-write failure not producing lookup errors, expired-first then LRU eviction, `createdAt` recording, legacy-entry eviction ordering).
- `npx tsc --noEmit` clean; `npm run build` succeeds.
- No content-script code touched, so no visual-regression surface.

## Risk

Low. `unlimitedStorage` adds an install-time permission prompt but no runtime behaviour change. Eviction only activates near quota, and any cache loss is self-healing (re-fetch). The one behavioural change — lookup results expiring after 30 days — is intended and cheap (a re-query).

🤖 Generated with [Claude Code](https://claude.com/claude-code)