### PR TITLE
Route all content-script cross-origin fetches through the service worker

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -17,6 +17,7 @@
     "https://api.openalex.org/*",
     "https://api.crossref.org/*",
     "https://api.unpaywall.org/*",
+    "https://doi.org/*",
     "https://docs.google.com/*",
     "https://pubpeer.com/*",
     "https://raw.githubusercontent.com/*"

--- a/src/background/proxy-fetch.ts
+++ b/src/background/proxy-fetch.ts
@@ -1,0 +1,65 @@
+// Service-worker handler for FLORA_PROXY_FETCH. MV3 content scripts get no
+// host-permission CORS bypass, so every cross-origin fetch is routed here and
+// executed in the background context (see the context branch in each shared
+// module: openaccess, pubpeer-api, doi-validate, doi-augment).
+
+import type {DoiString} from "@shared/types";
+import type {ProxyFetchRequest, ProxyFetchResponse} from "@shared/messages";
+import {fetchOpenAccessRaw} from "@shared/openaccess";
+import {lookupPubPeerRaw, PubPeerRateLimitError} from "@shared/pubpeer-api";
+import {validateDOIsRaw} from "@shared/doi-validate";
+import {fetchTitleByDoiRaw} from "@shared/doi-augment";
+
+/** Run the requested cross-origin fetch and return a serializable result. */
+export async function handleProxyFetch(
+    request: ProxyFetchRequest
+): Promise<ProxyFetchResponse> {
+    try {
+        switch (request.fetcher) {
+            case "openAccess": {
+                const [doi, email] = request.args as [string, string];
+                const data = await fetchOpenAccessRaw(doi, email);
+                return {type: "FLORA_PROXY_FETCH_RESULT", ok: true, data};
+            }
+            case "pubpeer": {
+                const [dois, urls] = request.args as [string[], string[]];
+                try {
+                    const data = await lookupPubPeerRaw(dois, urls);
+                    return {type: "FLORA_PROXY_FETCH_RESULT", ok: true, data};
+                } catch (err) {
+                    if (err instanceof PubPeerRateLimitError) {
+                        return {
+                            type: "FLORA_PROXY_FETCH_RESULT",
+                            ok: false,
+                            error: err.message,
+                            rateLimitMs: err.retryAfterMs,
+                        };
+                    }
+                    throw err;
+                }
+            }
+            case "validateDois": {
+                const [dois] = request.args as [DoiString[]];
+                const data = await validateDOIsRaw(dois);
+                return {type: "FLORA_PROXY_FETCH_RESULT", ok: true, data};
+            }
+            case "titleByDoi": {
+                const [doi] = request.args as [string];
+                const data = await fetchTitleByDoiRaw(doi);
+                return {type: "FLORA_PROXY_FETCH_RESULT", ok: true, data};
+            }
+            default:
+                return {
+                    type: "FLORA_PROXY_FETCH_RESULT",
+                    ok: false,
+                    error: `Unknown proxy fetcher: ${(request as {fetcher?: string}).fetcher}`,
+                };
+        }
+    } catch (err) {
+        return {
+            type: "FLORA_PROXY_FETCH_RESULT",
+            ok: false,
+            error: err instanceof Error ? err.message : "Proxy fetch failed",
+        };
+    }
+}

--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -3,8 +3,9 @@ import {lookupDOIs} from "@shared/flora-api";
 import {RET_MAP_KEY, storageSync, type RetractionMaps} from "@shared/data-extract";
 import type {DoiString, ReplicationResult, RetractionResponse} from "@shared/types";
 import {LookupResponse, RetractionCheckResponse, SheetFetchResponse, AugmentResponse, AugmentRequest} from "@shared/messages";
-import {isLookupRequest, isRetractionCheckRequest, isSheetFetchRequest, isAugmentRequest} from "@shared/messages";
+import {isLookupRequest, isRetractionCheckRequest, isSheetFetchRequest, isAugmentRequest, isProxyFetchRequest} from "@shared/messages";
 import {augmentDOIs} from "@shared/doi-augment";
+import {handleProxyFetch} from "./proxy-fetch";
 import {getSettings, isSetupComplete} from "@shared/settings";
 
 const cache = new LocalCache<ReplicationResult>("flora");
@@ -181,6 +182,19 @@ chrome.runtime.onMessage.addListener(
                         type: "FLORA_AUGMENT_RESULT",
                         results: {},
                     } satisfies AugmentResponse)
+                );
+            return true;
+        }
+
+        if (isProxyFetchRequest(message)) {
+            handleProxyFetch(message)
+                .then(sendResponse)
+                .catch(() =>
+                    sendResponse({
+                        type: "FLORA_PROXY_FETCH_RESULT",
+                        ok: false,
+                        error: "Service worker error",
+                    })
                 );
             return true;
         }

--- a/src/content-general/injector.ts
+++ b/src/content-general/injector.ts
@@ -4,6 +4,7 @@ import { extractDoiOccurrences, type DoiOccurrence } from "../shared/doi-extract
 import { debugLog } from "../shared/debug";
 import { getSettings } from "../shared/settings";
 import { safeSendMessage } from "../shared/messages";
+import { fetchOpenAccess } from "../shared/openaccess";
 import styles from "./styles.css";
 import {RetractionResponse, noticePresentation} from "@shared/doi-retraction";
 
@@ -1279,16 +1280,12 @@ export function renderSidePanel(
     if (!email) return;
     for (const [doi, placeholder] of oaPlaceholders) {
       try {
-        const resp = await fetch(
-          `https://api.unpaywall.org/v2/${encodeURIComponent(doi)}?email=${encodeURIComponent(email)}`
-        );
-        if (!resp.ok) continue;
-        const data = await resp.json() as {
-          is_oa?: boolean;
-          best_oa_location?: { url_for_pdf?: string | null; url?: string | null } | null;
-        };
-        if (!data.is_oa) continue;
-        const oaUrl = data.best_oa_location?.url_for_pdf ?? data.best_oa_location?.url;
+        // Open Access status is fetched via fetchOpenAccess, which proxies the
+        // Unpaywall request through the service worker (content-script
+        // cross-origin fetches have no CORS bypass).
+        const status = await fetchOpenAccess(doi);
+        if (!status?.isOa) continue;
+        const oaUrl = status.url;
         if (!oaUrl) continue;
         const icon = document.createElement("a");
         icon.href = oaUrl;

--- a/src/shared/doi-augment.ts
+++ b/src/shared/doi-augment.ts
@@ -2,6 +2,7 @@ import type {DoiString, DoiAugmentRequest} from "./types";
 import {normaliseDOI} from "./doi-normalise";
 import {getSettings} from "./settings";
 import {BlobCache} from "./blob-cache";
+import {isWorkerContext, proxyFetch} from "./messages";
 
 const OPENALEX_BASE = "https://api.openalex.org/works";
 const CROSSREF_BASE = "https://api.crossref.org/works";
@@ -477,6 +478,28 @@ export async function fetchTitleByDoi(doi: string): Promise<string | null> {
     const cached = await TITLE_CACHE.get(doi);
     if (cached) return cached.title;
 
+    // Direct fetch in the worker; proxy through it from content scripts, where
+    // the Crossref/OpenAlex requests have no CORS bypass. A proxy failure
+    // (e.g. an invalidated extension context) is transient — return null
+    // without caching so a later call can retry.
+    let title: string | null;
+    try {
+        title = isWorkerContext()
+            ? await fetchTitleByDoiRaw(doi)
+            : await proxyFetch<string | null>("titleByDoi", [doi]);
+    } catch {
+        return null;
+    }
+
+    void TITLE_CACHE.set(doi, {title});
+    return title;
+}
+
+/**
+ * Resolve a title from Crossref (then OpenAlex) with no caching. Runs in the
+ * service worker. Returns null when neither service has the DOI.
+ */
+export async function fetchTitleByDoiRaw(doi: string): Promise<string | null> {
     let title: string | null = null;
 
     try {
@@ -503,7 +526,6 @@ export async function fetchTitleByDoi(doi: string): Promise<string | null> {
         }
     }
 
-    void TITLE_CACHE.set(doi, {title});
     return title;
 }
 

--- a/src/shared/doi-validate.ts
+++ b/src/shared/doi-validate.ts
@@ -1,6 +1,7 @@
 import type { DoiString } from "./types";
 import { debugLog } from "./debug";
 import { BlobCache } from "./blob-cache";
+import { isWorkerContext, proxyFetch } from "./messages";
 
 /**
  * Validate DOIs by checking the doi.org Handle System API.
@@ -56,19 +57,44 @@ export async function validateDOIs(
 
   debugLog(`DOI validation: ${uncached.length} uncached DOI(s) to check`);
 
-  // Validate uncached DOIs in parallel. A DOI is recorded `false` only when
-  // doi.org *definitively* reports it absent (HTTP 404, or responseCode ≠ 1).
-  // Transient failures — network errors, rate limits, 5xx — leave the DOI out
-  // of the result map entirely so callers treat it as "unknown" and don't drop
-  // a possibly-valid DOI. (Marking it invalid here permanently strands the
-  // reference: processReferenceDois sets its processed-marker before this
-  // check, so a falsely-invalid DOI never gets a second chance at a pill.)
-  // Accumulate cache writes and flush the blob once at the end rather than once
-  // per resolved DOI (each VALIDATION_CACHE.set is a full chrome.storage.local
-  // write of the whole blob).
+  // Fetch the doi.org verdicts for uncached DOIs: directly in the worker, or
+  // proxied through it from a content script (doi.org sends no CORS headers, so
+  // a page-context request cannot read the response). A proxy failure (e.g. an
+  // invalidated extension context) leaves every DOI unknown, matching the
+  // transient-error semantics below.
+  const entries = isWorkerContext()
+    ? await validateDOIsRaw(uncached)
+    : await proxyFetch<Array<[DoiString, boolean]>>("validateDois", [uncached]).catch(() => []);
+
+  // Accumulate cache writes and flush the blob once for the whole batch rather
+  // than once per resolved DOI (each VALIDATION_CACHE.set is a full
+  // chrome.storage.local write of the whole blob).
   const updates: Array<[DoiString, { valid: boolean }]> = [];
+  for (const [doi, valid] of entries) {
+    results.set(doi, valid);
+    updates.push([doi, { valid }]);
+  }
+
+  if (updates.length > 0) await VALIDATION_CACHE.setMany(updates);
+  return results;
+}
+
+/**
+ * Query doi.org's Handle System for a batch of DOIs (no caching). Runs in the
+ * service worker. Returns only the DOIs doi.org answers *definitively* for:
+ * a DOI is `true` when responseCode is 1, `false` on a 404 or responseCode ≠ 1.
+ * Transient failures — network errors, rate limits, 5xx — are omitted entirely
+ * so callers treat them as "unknown" and don't drop a possibly-valid DOI.
+ * (Marking it invalid permanently strands the reference: processReferenceDois
+ * sets its processed-marker before this check, so a falsely-invalid DOI never
+ * gets a second chance at a pill.)
+ */
+export async function validateDOIsRaw(
+  dois: DoiString[]
+): Promise<Array<[DoiString, boolean]>> {
+  const entries: Array<[DoiString, boolean]> = [];
   await Promise.allSettled(
-    uncached.map(async (doi) => {
+    dois.map(async (doi) => {
       try {
         // Preserve slashes as URL path separators so multi-slash DOIs
         // (e.g. 10.6338/JDA.202212/SP_17(4).0000) route correctly on doi.org.
@@ -79,26 +105,20 @@ export async function validateDOIs(
         if (!response.ok) {
           // 404 = the Handle System has no record of this DOI → invalid.
           // Any other non-OK status (429, 5xx) is transient — leave unknown.
-          if (response.status === 404) {
-            results.set(doi, false);
-            updates.push([doi, { valid: false }]);
-          }
+          if (response.status === 404) entries.push([doi, false]);
           return;
         }
         const data = (await response.json()) as { responseCode?: number };
         // responseCode 1 = success (handle exists)
         const valid = data.responseCode === 1;
-        results.set(doi, valid);
-        updates.push([doi, { valid }]);
+        entries.push([doi, valid]);
         debugLog(`DOI validation: ${doi} → ${valid ? "valid" : "invalid"}`);
       } catch {
-        // Network error — leave unknown (absent from map); don't cache.
+        // Network error — leave unknown (absent from result); don't cache.
       }
     })
   );
-
-  if (updates.length > 0) await VALIDATION_CACHE.setMany(updates);
-  return results;
+  return entries;
 }
 
 /** Test-only: drop in-memory cache state so each case starts fresh. */

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -52,6 +52,79 @@ export interface AugmentResponse {
     results: Record<string, string | null>;
 }
 
+/**
+ * Identifies which cross-origin fetch a proxy request should perform in the
+ * service worker. MV3 content scripts get no host-permission CORS bypass, so
+ * every remote fetch below runs in the background context (see proxy-fetch.ts).
+ */
+export type ProxyFetcherId = "openAccess" | "pubpeer" | "validateDois" | "titleByDoi";
+
+/** Content script → service worker: run a cross-origin fetch in the worker. */
+export interface ProxyFetchRequest {
+    type: "FLORA_PROXY_FETCH";
+    fetcher: ProxyFetcherId;
+    /** Fetcher-specific arguments, forwarded verbatim to the worker handler. */
+    args: unknown[];
+}
+
+/** Service worker → content script: proxied fetch result (structured-clone-safe). */
+export interface ProxyFetchResponse {
+    type: "FLORA_PROXY_FETCH_RESULT";
+    ok: boolean;
+    /** Serializable payload on success. */
+    data?: unknown;
+    /** Human-readable error on failure. */
+    error?: string;
+    /** PubPeer 429 back-off signal, propagated so the caller can re-throw. */
+    rateLimitMs?: number;
+}
+
+export function isProxyFetchRequest(msg: unknown): msg is ProxyFetchRequest {
+    return (
+        typeof msg === "object" &&
+        msg !== null &&
+        (msg as Record<string, unknown>).type === "FLORA_PROXY_FETCH"
+    );
+}
+
+/**
+ * True when running in the extension service worker (no DOM / `window`).
+ * Shared modules bundled into both content scripts and the worker use this to
+ * decide whether to fetch directly (worker) or proxy through the worker
+ * (content script), where cross-origin fetches would otherwise be CORS-bound.
+ */
+export function isWorkerContext(): boolean {
+    return typeof window === "undefined";
+}
+
+/** Error thrown by {@link proxyFetch}; carries a rate-limit hint when present. */
+export class ProxyFetchError extends Error {
+    constructor(message: string, public rateLimitMs?: number) {
+        super(message);
+    }
+}
+
+/**
+ * Content-script side: ask the service worker to perform a cross-origin fetch
+ * and return its serializable result. Throws {@link ProxyFetchError} on
+ * failure (including when the extension context has been invalidated).
+ */
+export async function proxyFetch<R>(fetcher: ProxyFetcherId, args: unknown[]): Promise<R> {
+    const resp = await safeSendMessage<ProxyFetchResponse>({
+        type: "FLORA_PROXY_FETCH",
+        fetcher,
+        args,
+    });
+    if (!resp) {
+        // safeSendMessage swallowed an "Extension context invalidated" reject.
+        throw new ProxyFetchError("Extension context invalidated");
+    }
+    if (!resp.ok) {
+        throw new ProxyFetchError(resp.error ?? `proxy fetch (${fetcher}) failed`, resp.rateLimitMs);
+    }
+    return resp.data as R;
+}
+
 export function isAugmentRequest(msg: unknown): msg is AugmentRequest {
     return (
         typeof msg === "object" &&

--- a/src/shared/openaccess.ts
+++ b/src/shared/openaccess.ts
@@ -3,6 +3,7 @@
 
 import { getSettings } from "./settings";
 import { BlobCache } from "./blob-cache";
+import { isWorkerContext, proxyFetch } from "./messages";
 
 export interface OpenAccessStatus {
     /** True when Unpaywall reports a free full-text location. */
@@ -37,23 +38,40 @@ export async function fetchOpenAccess(doi: string): Promise<OpenAccessStatus | n
     if (!email) return null;
 
     try {
-        const resp = await fetch(
-            `https://api.unpaywall.org/v2/${encodeURIComponent(doi)}?email=${encodeURIComponent(email)}`
-        );
-        if (!resp.ok) return null;
-        const data = (await resp.json()) as {
-            is_oa?: boolean;
-            best_oa_location?: { url_for_pdf?: string | null; url?: string | null } | null;
-        };
-        const status: OpenAccessStatus = {
-            isOa: !!data.is_oa,
-            url: data.best_oa_location?.url_for_pdf ?? data.best_oa_location?.url ?? null,
-        };
-        void OA_CACHE.set(doi, status);
+        // Direct fetch in the worker; proxy through it from content scripts,
+        // where a page-context cross-origin request has no CORS bypass (and is
+        // dropped by Opera's built-in ad/tracker blocker).
+        const status = isWorkerContext()
+            ? await fetchOpenAccessRaw(doi, email)
+            : await proxyFetch<OpenAccessStatus | null>("openAccess", [doi, email]);
+        if (status) void OA_CACHE.set(doi, status);
         return status;
     } catch {
         return null;
     }
+}
+
+/**
+ * Perform the Unpaywall network request (no caching). Runs in the service
+ * worker — either directly for worker-side callers or via the proxy handler on
+ * behalf of a content script. Returns null when the lookup fails.
+ */
+export async function fetchOpenAccessRaw(
+    doi: string,
+    email: string
+): Promise<OpenAccessStatus | null> {
+    const resp = await fetch(
+        `https://api.unpaywall.org/v2/${encodeURIComponent(doi)}?email=${encodeURIComponent(email)}`
+    );
+    if (!resp.ok) return null;
+    const data = (await resp.json()) as {
+        is_oa?: boolean;
+        best_oa_location?: { url_for_pdf?: string | null; url?: string | null } | null;
+    };
+    return {
+        isOa: !!data.is_oa,
+        url: data.best_oa_location?.url_for_pdf ?? data.best_oa_location?.url ?? null,
+    };
 }
 
 /** Test-only: drop in-memory cache state so each case starts fresh. */

--- a/src/shared/pubpeer-api.ts
+++ b/src/shared/pubpeer-api.ts
@@ -1,5 +1,6 @@
 import { debugLog } from "./debug";
 import { BlobCache } from "./blob-cache";
+import { isWorkerContext, proxyFetch, ProxyFetchError } from "./messages";
 
 export interface PubPeerFeedback {
   id: string;
@@ -18,6 +19,31 @@ export class PubPeerRateLimitError extends Error {
 }
 
 export async function lookupPubPeer(
+  dois: string[],
+  urls: string[]
+): Promise<PubPeerFeedback[]> {
+  // Direct fetch in the worker; proxy through it from content scripts. The
+  // /v3/publications call is a POST with a JSON content-type (a preflighted
+  // cross-origin request) — it has no CORS bypass in page context and is
+  // dropped by Opera's built-in ad/tracker blocker.
+  if (isWorkerContext()) return lookupPubPeerRaw(dois, urls);
+  try {
+    return await proxyFetch<PubPeerFeedback[]>("pubpeer", [dois, urls]);
+  } catch (err) {
+    // Re-materialise the worker's 429 back-off as a rate-limit error so
+    // lookupPubPeerForDois's existing handling applies unchanged.
+    if (err instanceof ProxyFetchError && err.rateLimitMs != null) {
+      throw new PubPeerRateLimitError(err.rateLimitMs);
+    }
+    throw err;
+  }
+}
+
+/**
+ * Perform the PubPeer network request (no caching). Runs in the service worker.
+ * Throws PubPeerRateLimitError on 429 so callers can back off.
+ */
+export async function lookupPubPeerRaw(
   dois: string[],
   urls: string[]
 ): Promise<PubPeerFeedback[]> {

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -30,10 +30,21 @@ Object.defineProperty(globalThis, "chrome", {
     runtime: {
       id: "test-extension-id",
       getURL: vi.fn((path: string) => `chrome-extension://test-extension-id/${path}`),
-      sendMessage: vi.fn().mockResolvedValue({
-        type: "FLORA_LOOKUP_RESULT",
-        results: {},
-        errors: {},
+      // Default: content-script proxy fetches (FLORA_PROXY_FETCH) round-trip to
+      // the real worker handler so the shared modules' worker-side fetch runs
+      // (msw intercepts it). Any other message resolves to an empty lookup. The
+      // worker handler is imported lazily so per-test vi.mock() of the shared
+      // modules (e.g. settings) still applies to its module graph.
+      sendMessage: vi.fn(async (message: unknown) => {
+        if (
+          typeof message === "object" &&
+          message !== null &&
+          (message as { type?: string }).type === "FLORA_PROXY_FETCH"
+        ) {
+          const { handleProxyFetch } = await import("../src/background/proxy-fetch");
+          return handleProxyFetch(message as never);
+        }
+        return { type: "FLORA_LOOKUP_RESULT", results: {}, errors: {} };
       }),
       onMessage: {
         addListener: vi.fn(),

--- a/tests/unit/proxy-fetch.test.ts
+++ b/tests/unit/proxy-fetch.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach, beforeAll, afterAll, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+
+// getUserEmail() must return a configured email for the Unpaywall lookup.
+vi.mock("../../src/shared/settings", () => ({
+  getSettings: vi.fn().mockResolvedValue({ email: "test@example.com" }),
+  isSetupComplete: vi.fn().mockResolvedValue(true),
+}));
+
+import { validateDOIs, _resetValidationCacheForTesting } from "../../src/shared/doi-validate";
+import { fetchOpenAccess, _resetOpenAccessCacheForTesting } from "../../src/shared/openaccess";
+import { handleProxyFetch } from "../../src/background/proxy-fetch";
+import { isWorkerContext } from "../../src/shared/messages";
+import type { DoiString } from "../../src/shared/types";
+
+const server = setupServer();
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+const doi = (s: string) => s as DoiString;
+
+describe("cross-origin fetch proxying", () => {
+  beforeEach(() => {
+    (chrome.storage.local.get as ReturnType<typeof vi.fn>).mockResolvedValue({});
+    (chrome.storage.local.set as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+    _resetValidationCacheForTesting();
+    _resetOpenAccessCacheForTesting();
+  });
+
+  it("runs in a window (content-script) context under jsdom", () => {
+    // The whole point of proxying is that content scripts have a DOM/window and
+    // therefore no host-permission CORS bypass.
+    expect(isWorkerContext()).toBe(false);
+    expect(typeof window).not.toBe("undefined");
+  });
+
+  it("validateDOIs routes doi.org through chrome.runtime.sendMessage, and the worker handler performs the fetch", async () => {
+    let handleFetched = 0;
+    server.use(
+      http.get("https://doi.org/api/handles/*", () => {
+        handleFetched += 1;
+        return HttpResponse.json({ responseCode: 1 });
+      })
+    );
+
+    const results = await validateDOIs([doi("10.1038/nature12373")]);
+
+    // Transport: the content-script call proxied via a FLORA_PROXY_FETCH message.
+    expect(chrome.runtime.sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "FLORA_PROXY_FETCH", fetcher: "validateDois" })
+    );
+    // The doi.org fetch actually ran (in the worker handler), not the content script.
+    expect(handleFetched).toBe(1);
+    expect(results.get(doi("10.1038/nature12373"))).toBe(true);
+  });
+
+  it("fetchOpenAccess routes Unpaywall through chrome.runtime.sendMessage, and the worker handler performs the fetch", async () => {
+    let oaFetched = 0;
+    server.use(
+      http.get("https://api.unpaywall.org/v2/:doi", () => {
+        oaFetched += 1;
+        return HttpResponse.json({
+          is_oa: true,
+          best_oa_location: { url_for_pdf: "https://example.org/paper.pdf" },
+        });
+      })
+    );
+
+    const status = await fetchOpenAccess("10.1038/nature12373");
+
+    expect(chrome.runtime.sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "FLORA_PROXY_FETCH", fetcher: "openAccess" })
+    );
+    expect(oaFetched).toBe(1);
+    expect(status).toEqual({ isOa: true, url: "https://example.org/paper.pdf" });
+  });
+
+  it("handleProxyFetch performs the fetch directly and returns a serializable payload", async () => {
+    server.use(
+      http.get("https://doi.org/api/handles/*", () => HttpResponse.json({ responseCode: 1 }))
+    );
+
+    const resp = await handleProxyFetch({
+      type: "FLORA_PROXY_FETCH",
+      fetcher: "validateDois",
+      args: [[doi("10.1038/nature12373")]],
+    });
+
+    expect(resp.ok).toBe(true);
+    // Entries are plain [doi, boolean] tuples — structured-clone-safe across sendMessage.
+    expect(resp.data).toEqual([["10.1038/nature12373", true]]);
+  });
+});


### PR DESCRIPTION
## Problem

MV3 content scripts get **no** host-permission CORS bypass: a cross-origin fetch from page context succeeds only while the remote server returns permissive `Access-Control-Allow-Origin` headers. Two consequences:

1. Any endpoint that tightens its CORS policy silently breaks the feature that depends on it.
2. **Opera's built-in ad/tracker blocker drops these page-context requests to third-party APIs** — the likely cause of the recurring "works in Chrome, broken in Opera" reports.

The extension already proxies its main lookups (`FLORA_LOOKUP`, `FLORA_AUGMENT`, `FLORA_SHEET_FETCH`) through the background worker, where host permissions do grant a CORS bypass — but four paths still fetched directly from content scripts:

- **Unpaywall** (`openaccess.ts` + an inline fetch in `injector.ts`)
- **PubPeer** (`pubpeer-api.ts` — a preflighted JSON POST, doubly likely to be blocked)
- **doi.org Handle API** (`doi-validate.ts`; doi.org was not even in `host_permissions`)
- **Crossref/OpenAlex title lookup** (`fetchTitleByDoi` in `doi-augment.ts`)

## Fix

One consistent pattern: `messages.ts` gains `isWorkerContext()`, a generic `FLORA_PROXY_FETCH` message, and `proxyFetch()`. Each shared module keeps its exported signature and its caching layer, factors the bare network call into a `*Raw` helper, and branches — fetch directly in the worker, otherwise proxy through it. The worker dispatches in `src/background/proxy-fetch.ts` by fetcher ID (a fixed whitelist — the worker is not an open URL proxy) and calls the same `*Raw` helpers.

Payloads are structured-clone-safe (Maps serialised to entry tuples; PubPeer's 429 back-off carried as `rateLimitMs` and re-thrown as `PubPeerRateLimitError`, so existing rate-limit handling is unchanged). Cache checks stay content-side, so only a cache miss round-trips. `manifest.json` adds `https://doi.org/*`.

Grep proof: no cross-origin `fetch(` remains in any `content-*` module; remaining fetches in `src/shared/*` are worker-only `*Raw` helpers.

## Testing

- `npm test`: 193 passing; the test harness now round-trips `FLORA_PROXY_FETCH` to the real worker handler, so existing suites exercise the proxy path; new `proxy-fetch.test.ts` asserts content-side routing via `chrome.runtime.sendMessage` and worker-side fetch execution.
- `npx tsc --noEmit` clean; `npm run build` succeeds (bundle-size test within limits).
- Transport-only: no scan/placement/matching logic changed, so no visual surface.

## Risk

Low. Content-script fetches now depend on the worker being alive; a failed proxy call degrades exactly like the previous network-error paths (OA badge/title omitted, DOIs treated as "unknown" rather than falsely invalid, PubPeer fails silently). Recommend a manual smoke test in Opera to confirm OA badges, the PubPeer panel, and reference titles now populate with the ad blocker enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)