### PR TITLE
Minor correctness and efficiency cleanups

### DIFF
--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -7,13 +7,15 @@ import {isLookupRequest, isRetractionCheckRequest, isSheetFetchRequest, isAugmen
 import {augmentDOIs} from "@shared/doi-augment";
 import {handleProxyFetch} from "./proxy-fetch";
 import {getSettings, isSetupComplete} from "@shared/settings";
+import {fetchWithTimeout} from "@shared/fetch-timeout";
+import {debugError} from "@shared/debug";
 
 const cache = new LocalCache<ReplicationResult>("flora");
 
 // Initialise cache quota from persisted settings (service worker may restart).
 getSettings().then(({ cacheQuotaMb }) => {
     cache.setQuota(cacheQuotaMb === 0 ? 0 : cacheQuotaMb * 1024 * 1024);
-}).catch();
+}).catch((err) => debugError("Failed to init cache quota:", err));
 
 // Keep quota in sync when the user changes the setting; drop the cached
 // retraction source whenever a fresh map is synced into local storage.
@@ -78,12 +80,12 @@ chrome.runtime.onInstalled.addListener((details) => {
     if (details.reason === "install") {
         chrome.tabs.create({ url: chrome.runtime.getURL("dist/walkthrough.html") });
     }
-    syncRetractionsInfo().then().catch();
+    syncRetractionsInfo().catch((err) => debugError("Retraction sync failed:", err));
 });
 
 // Refresh retraction data once per browser session (weekly interval enforced inside).
 chrome.runtime.onStartup.addListener(() => {
-    syncRetractionsInfo().then().catch();
+    syncRetractionsInfo().catch((err) => debugError("Retraction sync failed:", err));
 });
 
 
@@ -145,9 +147,9 @@ chrome.runtime.onMessage.addListener(
             message !== null &&
             (message as { type?: string }).type === "FLORA_DISMISS_SETUP"
         ) {
-            chrome.storage.session.set({flora_setup_dismissed: true}).then(() => {
-                sendResponse({ok: true});
-            });
+            chrome.storage.session.set({flora_setup_dismissed: true})
+                .then(() => sendResponse({ok: true}))
+                .catch(() => sendResponse({ok: false}));
             return true;
         }
 
@@ -156,9 +158,9 @@ chrome.runtime.onMessage.addListener(
             message !== null &&
             (message as { type?: string }).type === "FLORA_IS_SETUP_DISMISSED"
         ) {
-            chrome.storage.session.get("flora_setup_dismissed").then((result) => {
-                sendResponse({dismissed: !!result.flora_setup_dismissed});
-            });
+            chrome.storage.session.get("flora_setup_dismissed")
+                .then((result) => sendResponse({dismissed: !!result.flora_setup_dismissed}))
+                .catch(() => sendResponse({dismissed: false}));
             return true;
         }
         if (isSheetFetchRequest(message)) {
@@ -207,36 +209,50 @@ async function handleLookup(dois: DoiString[]): Promise<LookupResponse> {
     const results: Record<string, ReplicationResult> = {};
     const errors: Record<string, string> = {};
     const toFetch: DoiString[] = [];
+    const awaitingInflight: DoiString[] = [];
 
-    // Check cache and in-flight requests. We only persist matched results, so a
+    // One batched cache read for every DOI (a single chrome.storage.local.get)
+    // instead of one round-trip per DOI. We only persist matched results, so a
     // truthy cache hit is a real result. A null entry (legacy negative cache) or
     // a miss both fall through to re-query, so newly added FORRT data surfaces.
+    const cachedMap = await cache.getMany(dois);
+
+    // Synchronous classification pass: no awaits interleave between reading the
+    // in-flight map and registering new entries below, so two lookups for the
+    // same DOI can't both slip past the check and each fire the API (stampede).
     for (const doi of dois) {
-        const cached = await cache.get(doi);
+        const cached = cachedMap.get(doi);
         if (cached) {
             results[doi] = cached;
         } else if (inflight.has(doi)) {
-            const r = await inflight.get(doi)!;
-            if (r) results[doi] = r;
+            awaitingInflight.push(doi);
         } else {
             toFetch.push(doi);
         }
     }
 
-    if (toFetch.length === 0) {
-        return {type: "FLORA_LOOKUP_RESULT", results, errors};
+    // Register every to-fetch DOI as in-flight BEFORE any further await, so a
+    // concurrent lookup arriving now sees them as in-flight rather than
+    // re-fetching. (catch prevents unhandled rejection — the try/catch below
+    // handles the actual error reporting.)
+    const batchPromise = toFetch.length > 0 ? lookupDOIs(toFetch) : null;
+    if (batchPromise) {
+        for (const doi of toFetch) {
+            inflight.set(
+                doi,
+                batchPromise.then((map) => map.get(doi) ?? null).catch(() => null)
+            );
+        }
     }
 
-    // Batch API call for uncached DOIs
-    const batchPromise = lookupDOIs(toFetch);
+    // Now it's safe to await: collect results for DOIs a prior call is fetching.
+    for (const doi of awaitingInflight) {
+        const r = await inflight.get(doi)!;
+        if (r) results[doi] = r;
+    }
 
-    // Register each DOI as in-flight (catch to prevent unhandled rejection —
-    // the main try/catch below handles the actual error reporting)
-    for (const doi of toFetch) {
-        inflight.set(
-            doi,
-            batchPromise.then((map) => map.get(doi) ?? null).catch(() => null)
-        );
+    if (!batchPromise) {
+        return {type: "FLORA_LOOKUP_RESULT", results, errors};
     }
 
     try {
@@ -290,7 +306,7 @@ async function handleSheetFetch(
 ): Promise<SheetFetchResponse> {
     const url = `https://docs.google.com/spreadsheets/d/${spreadsheetId}/gviz/tq?tqx=out:csv&gid=${gid}`;
     try {
-        const resp = await fetch(url, {credentials: "include"});
+        const resp = await fetchWithTimeout(url, {credentials: "include"});
         if (!resp.ok) {
             return {
                 type: "FLORA_SHEET_FETCH_RESULT",
@@ -382,7 +398,7 @@ async function getRetractionSource(): Promise<RetractionMaps> {
     // Nothing synced yet: kick off a sync for next time and answer from the
     // bundled JSON now. Don't cache the fallback — onChanged will pick up the
     // synced map, but until then we re-read so an in-flight sync is noticed.
-    syncRetractionsInfo().then().catch();
+    syncRetractionsInfo().catch((err) => debugError("Retraction sync failed:", err));
     return loadBundledRetractionMap();
 }
 
@@ -409,7 +425,21 @@ async function handleRetractionCheck(dois: DoiString[]): Promise<RetractionCheck
     return {type: "FLORA_RET_CHECK_RESULT", results};
 }
 
-export async function syncRetractionsInfo() {
+// A single in-flight sync shared across onInstalled/onStartup/getRetractionSource.
+// Without this, several triggers can each fetch + write the ~3.6MB retraction
+// map concurrently. While a sync is running, later callers await the same
+// promise instead of starting their own.
+let syncInFlight: Promise<void> | null = null;
+
+export function syncRetractionsInfo(): Promise<void> {
+    if (syncInFlight) return syncInFlight;
+    syncInFlight = runRetractionSync().finally(() => {
+        syncInFlight = null;
+    });
+    return syncInFlight;
+}
+
+async function runRetractionSync(): Promise<void> {
     const minInterval = 1000 * 60 * 60 * 24 * 7; // weekly
     const currentTime = Date.now();
     const previous = await chrome.storage.local.get(["synctime"]) ?? 0;

--- a/src/content-general/index.ts
+++ b/src/content-general/index.ts
@@ -231,7 +231,7 @@ async function pageRenderChangeHandler(): Promise<void> {
     // If no valid DOIs found, try augmenting from page title in the background
     if (newDois.length === 0 && dois.length === 0) {
         debugLog("No valid DOIs found on page, attempting title augmentation");
-        if (!isSheets) augmentFromTitle().then().catch();
+        if (!isSheets) augmentFromTitle().catch(() => {});
         if (!isSheets) void checkPubPeer();
         return;
     }
@@ -722,7 +722,7 @@ function startDomListener(callback: () => void) {
     reportActiveState(true);
     // Show setup prompt if email not configured (non-blocking — extension still runs)
     if (!(await isSetupComplete())) {
-        renderSetupPrompt().then().catch();
+        renderSetupPrompt().catch(() => {});
     }
     const startFlora = (): void => {
         if (isSheets) {
@@ -731,6 +731,11 @@ function startDomListener(callback: () => void) {
             // Poll for sheet tab switches — Sheets uses replaceState (no popstate).
             let lastGid = parseSheetsUrl(location.href)?.gid ?? "0";
             setInterval(() => {
+                // Skip the poll while the tab is hidden — background tabs don't
+                // need gid tracking, and this keeps the timer near-free until the
+                // user returns (the interval itself is left running so detection
+                // resumes immediately on re-focus).
+                if (document.hidden) return;
                 const nowGid = parseSheetsUrl(location.href)?.gid ?? "0";
                 if (nowGid !== lastGid) {
                     lastGid = nowGid;

--- a/src/content-scholar/observer.ts
+++ b/src/content-scholar/observer.ts
@@ -1,7 +1,7 @@
 import {normaliseDOI} from "@shared/doi-normalise";
 import {type DoiAugmentRequest} from "@shared/doi-augment";
 import {augmentDOIsViaWorker} from "@shared/messages";
-import {injectRetractionInfo, retractionCheck} from "@shared/doi-retraction"
+import {injectRetractionInfo, retractionCheck, type RetractionResponse} from "@shared/doi-retraction"
 import {validateDOI, validateDOIs} from "@shared/doi-validate";
 import type {DoiString, DoiSource} from "@shared/types";
 import type {LookupRequest, LookupResponse} from "@shared/messages";
@@ -54,6 +54,16 @@ export async function processScholarResults(doc: Document): Promise<void> {
         source: DoiSource
     }[] = [];
 
+    // Retraction-notice targets collected across the whole pass so we can issue
+    // ONE retractionCheck for every DOI instead of one per row, then place the
+    // pills. `append` drops the pill inside a row's FLoRA pill container
+    // (.gs_ggs); `afterend` inserts it beside a title element.
+    const pendingRetractions: {
+        doi: DoiString;
+        target: HTMLElement;
+        mode: "append" | "afterend";
+    }[] = [];
+
     // Phase 1: Extract DOIs from URLs and collect all titles for augmentation
     interface RowInfo {
         row: HTMLElement;
@@ -86,7 +96,7 @@ export async function processScholarResults(doc: Document): Promise<void> {
         if (extraction?.confident) {
             debugLog(`Scholar resolve [confident] "${title}" → ${extraction.doi}`);
             rowDois.push({row, doi: extraction.doi, source: "extracted"});
-            preInjectLabels(row, extraction.doi, "#853953", false);
+            preInjectLabels(row, extraction.doi, "#853953", false, pendingRetractions);
         } else {
             // Non-confident or no extraction — collect for augmentation cross-check
             rowInfos.push({
@@ -128,7 +138,7 @@ export async function processScholarResults(doc: Document): Promise<void> {
                     doi: info.extractedDoi,
                     source: "extracted"
                 });
-                preInjectLabels(info.row, info.extractedDoi, "#853953", false);
+                preInjectLabels(info.row, info.extractedDoi, "#853953", false, pendingRetractions);
             } else {
                 if (info.extractedDoi) {
                     debugLog(`Scholar: "${info.title}" — extracted ${info.extractedDoi} failed doi.org validation, falling back to augmentation`);
@@ -167,7 +177,7 @@ export async function processScholarResults(doc: Document): Promise<void> {
                         doi: info.extractedDoi,
                         source: "extracted"
                     });
-                    preInjectLabels(info.row, info.extractedDoi, "#853953", false);
+                    preInjectLabels(info.row, info.extractedDoi, "#853953", false, pendingRetractions);
                 } else if (info.extractedDoi && augmentedDoi && augmentedDoi !== info.extractedDoi) {
                     // Conflict: prefer augmented DOI → gray (augmented)
                     debugLog(`Scholar resolve [conflict] "${info.title}" → using augmented ${augmentedDoi} (extracted was ${info.extractedDoi})`);
@@ -176,7 +186,7 @@ export async function processScholarResults(doc: Document): Promise<void> {
                         doi: augmentedDoi,
                         source: "augmented"
                     });
-                    preInjectLabels(info.row, augmentedDoi, "#656d76", true);
+                    preInjectLabels(info.row, augmentedDoi, "#656d76", true, pendingRetractions);
                 } else if (info.extractedDoi && !augmentedDoi) {
                     // Extracted but augmentation found nothing — last-resort doi.org check
                     let valid = false;
@@ -192,7 +202,7 @@ export async function processScholarResults(doc: Document): Promise<void> {
                             doi: info.extractedDoi,
                             source: "extracted"
                         });
-                        preInjectLabels(info.row, info.extractedDoi, "#853953", false);
+                        preInjectLabels(info.row, info.extractedDoi, "#853953", false, pendingRetractions);
                     } else {
                         // Invalid DOI — no DOI pill, but still check for a
                         // retraction/concern notice (the static map is keyed
@@ -200,13 +210,14 @@ export async function processScholarResults(doc: Document): Promise<void> {
                         // next to the row title since there's no DOI pill to
                         // anchor against.
                         debugLog(`Scholar resolve [extracted-invalid] "${info.title}" → ${info.extractedDoi} rejected (doi.org says invalid)`);
-                        try {
-                            const notices = await retractionCheck([info.extractedDoi]);
-                            if (notices.length > 0) {
-                                const titleEl = info.row.querySelector<HTMLElement>(".gs_rt");
-                                if (titleEl) injectRetractionInfo(titleEl, notices[0], { afterend: true });
-                            }
-                        } catch { /* supplementary */ }
+                        const titleEl = info.row.querySelector<HTMLElement>(".gs_rt");
+                        if (titleEl) {
+                            pendingRetractions.push({
+                                doi: info.extractedDoi,
+                                target: titleEl,
+                                mode: "afterend",
+                            });
+                        }
                     }
                 } else if (!info.extractedDoi && augmentedDoi) {
                     // No extraction, only augmented → gray with dotted underline
@@ -216,10 +227,34 @@ export async function processScholarResults(doc: Document): Promise<void> {
                         doi: augmentedDoi,
                         source: "augmented"
                     });
-                    preInjectLabels(info.row, augmentedDoi, "#656d76", true);
+                    preInjectLabels(info.row, augmentedDoi, "#656d76", true, pendingRetractions);
                 } else {
                     debugLog(`Scholar resolve [no-doi] "${info.title}" → no DOI from extraction or augmentation`);
                 }
+            }
+        }
+    }
+
+    // One batched retraction check for the whole pass, then place each pill.
+    // Distributing by originDoi keeps behaviour identical to the previous
+    // per-row retractionCheck([doi]) calls, minus the redundant round-trips.
+    if (pendingRetractions.length > 0) {
+        const doisToCheck = [...new Set(pendingRetractions.map((p) => p.doi))];
+        let notices: RetractionResponse[] = [];
+        try {
+            notices = await retractionCheck(doisToCheck);
+        } catch {
+            // Retraction check failed — pills are supplementary, so skip them.
+        }
+        const noticeByDoi = new Map(notices.map((n) => [n.originDoi, n]));
+        for (const {doi, target, mode} of pendingRetractions) {
+            const notice = noticeByDoi.get(doi);
+            if (notice) {
+                injectRetractionInfo(
+                    target,
+                    notice,
+                    mode === "append" ? {append: true} : {afterend: true}
+                );
             }
         }
     }
@@ -256,21 +291,28 @@ export async function processScholarResults(doc: Document): Promise<void> {
     }
 }
 
-async function preInjectLabels(row: HTMLElement, doi: DoiString, color: string, isAugmented = false): Promise<void> {
+// Injects the DOI pill immediately and records a pending retraction-notice
+// target for the caller's single batched retractionCheck. The notice pill is
+// appended directly inside the FLoRA pill area (.gs_ggs gs_fl) — the default
+// smart placement would otherwise drop it into Scholar's nested .gs_or_ggsm
+// "All versions" submenu, since that contains the publisher links the
+// smart-placement heuristic matches against.
+function preInjectLabels(
+    row: HTMLElement,
+    doi: DoiString,
+    color: string,
+    isAugmented: boolean,
+    pending: {doi: DoiString; target: HTMLElement; mode: "append" | "afterend"}[]
+): void {
     injectDoiLabel(row, doi, color, isAugmented);
-    let target = row.querySelector(".gs_ggs");
+    let target = row.querySelector<HTMLElement>(".gs_ggs");
     if (!target) {
         target = document.createElement("div");
         target.className = "gs_ggs gs_fl";
         const gsRi = row.querySelector(".gs_ri");
         row.insertBefore(target, gsRi);
     }
-    let result = await retractionCheck([doi]);
-    // Append directly inside the FLoRA pill area (.gs_ggs gs_fl) — the default
-    // smart placement would otherwise drop the pill into Scholar's nested
-    // .gs_or_ggsm "All versions" submenu, since that contains the publisher
-    // links the smart-placement heuristic matches against.
-    if (result && result[0] != undefined) injectRetractionInfo(target, result[0], { append: true })
+    pending.push({doi, target, mode: "append"});
 }
 
 function injectDoiLabel(row: HTMLElement, doi: string, color: string, isAugmented = false): void {

--- a/src/shared/cache.ts
+++ b/src/shared/cache.ts
@@ -45,6 +45,37 @@ export class LocalCache<T> {
   }
 
   /**
+   * Batched read of many keys in ONE chrome.storage.local.get, instead of one
+   * round-trip per key. Only keys that are present and unexpired appear in the
+   * returned map (value `null` = cached negative result, `T` = cached match);
+   * missing/expired keys are simply absent. Expired entries are swept in a
+   * single remove call.
+   */
+  async getMany(keys: string[]): Promise<Map<string, T | null>> {
+    const out = new Map<string, T | null>();
+    if (keys.length === 0) return out;
+
+    const storageKeys = keys.map((k) => this.storageKey(k));
+    const result = await chrome.storage.local.get(storageKeys);
+
+    const now = Date.now();
+    const expired: string[] = [];
+    for (const key of keys) {
+      const storageKey = this.storageKey(key);
+      const entry = result[storageKey] as CachedEntry<T> | undefined;
+      if (!entry) continue;
+      if (entry.expiresAt !== null && now > entry.expiresAt) {
+        expired.push(storageKey);
+        continue;
+      }
+      out.set(key, entry.data);
+    }
+
+    if (expired.length > 0) await chrome.storage.local.remove(expired);
+    return out;
+  }
+
+  /**
    * @param data    The value to cache; pass `null` to record a negative result.
    * @param ttlMs   Milliseconds until expiry, or `null` to cache forever.
    */

--- a/src/shared/data-extract.ts
+++ b/src/shared/data-extract.ts
@@ -1,3 +1,5 @@
+import {fetchWithTimeout} from "./fetch-timeout";
+
 export const RET_MAP_KEY = "RetractionLookupLocal"
 
 /**
@@ -25,7 +27,7 @@ export interface RetractionMaps {
 
 export async function fetchRetractionMap(): Promise<RetractionMaps | undefined> {
     try {
-        const response = await fetch(PREBUILT_JSON_URL);
+        const response = await fetchWithTimeout(PREBUILT_JSON_URL);
         if (!response.ok) throw new Error(`HTTP ${response.status}`);
         const data = await response.json();
         if (data && typeof data === 'object' && data.retractions && data.concerns)

--- a/src/shared/doi-augment.ts
+++ b/src/shared/doi-augment.ts
@@ -3,6 +3,7 @@ import {normaliseDOI} from "./doi-normalise";
 import {getSettings} from "./settings";
 import {BlobCache} from "./blob-cache";
 import {isWorkerContext, proxyFetch} from "./messages";
+import {fetchWithTimeout} from "./fetch-timeout";
 
 const OPENALEX_BASE = "https://api.openalex.org/works";
 const CROSSREF_BASE = "https://api.crossref.org/works";
@@ -16,9 +17,6 @@ const DOI_AUGMENT_CACHE = new BlobCache<CachedDoiResult>({
     ttlMs: 30 * 24 * 60 * 60 * 1000, // 30 days
     legacyPrefixes: ["flora_doi:"],
 });
-
-/** Cached email — refreshed once per page/worker lifecycle. */
-let _cachedEmail: string | null = null;
 
 interface CachedDoiResult {
     found: boolean;
@@ -39,10 +37,11 @@ interface DoiCandidate {
     urls?: string[];
 }
 
+// getSettings() already caches settings in module state and invalidates that
+// cache via chrome.storage.onChanged, so it's cheap to call every time and
+// never goes stale — no second email cache of our own to keep in sync.
 async function getUserEmail(): Promise<string> {
-    if (_cachedEmail) return _cachedEmail;
     const {email} = await getSettings();
-    _cachedEmail = email;
     return email;
 }
 
@@ -257,7 +256,7 @@ async function queryCrossref(request: DoiAugmentRequest, email: string): Promise
     const {title} = request;
     const cleaned = cleanTitleForSearch(title);
     const url = `${CROSSREF_BASE}?query.title=${encodeURIComponent(cleaned)}&rows=5&select=DOI,title,author,issued,published-print,published-online,published,URL,link&mailto=${encodeURIComponent(email)}`;
-    const response = await fetch(url);
+    const response = await fetchWithTimeout(url);
     if (!response.ok) return [];
 
     const data = (await response.json()) as {
@@ -311,7 +310,7 @@ async function queryOpenAlex(request: DoiAugmentRequest, email: string): Promise
     const cleaned = cleanTitleForSearch(title);
     const url = `${OPENALEX_BASE}?filter=title.search:${encodeURIComponent(cleaned)}&select=id,doi,title,publication_year,authorships,primary_location,locations&per_page=5&mailto=${encodeURIComponent(email)}`;
 
-    const response = await fetch(url);
+    const response = await fetchWithTimeout(url);
     if (response.status === 429) {
         // Rate-limited — throw so Promise.allSettled marks this as rejected and
         // the caller falls back to Crossref results.
@@ -505,7 +504,7 @@ export async function fetchTitleByDoiRaw(doi: string): Promise<string | null> {
     try {
         const email = await getUserEmail();
         const mailto = email ? `?mailto=${encodeURIComponent(email)}` : "";
-        const response = await fetch(`${CROSSREF_BASE}/${doi}${mailto}`);
+        const response = await fetchWithTimeout(`${CROSSREF_BASE}/${doi}${mailto}`);
         if (response.ok) {
             const data = (await response.json()) as { message?: { title?: string[] } };
             title = data.message?.title?.[0] ?? null;
@@ -516,7 +515,7 @@ export async function fetchTitleByDoiRaw(doi: string): Promise<string | null> {
 
     if (!title) {
         try {
-            const response = await fetch(`${OPENALEX_BASE}/doi:${doi}?select=title`);
+            const response = await fetchWithTimeout(`${OPENALEX_BASE}/doi:${doi}?select=title`);
             if (response.ok) {
                 const data = (await response.json()) as { title?: string };
                 title = data.title ?? null;
@@ -533,5 +532,4 @@ export async function fetchTitleByDoiRaw(doi: string): Promise<string | null> {
 export function _resetAugmentCachesForTesting(): void {
     DOI_AUGMENT_CACHE.resetForTesting();
     TITLE_CACHE.resetForTesting();
-    _cachedEmail = null;
 }

--- a/src/shared/doi-validate.ts
+++ b/src/shared/doi-validate.ts
@@ -2,6 +2,7 @@ import type { DoiString } from "./types";
 import { debugLog } from "./debug";
 import { BlobCache } from "./blob-cache";
 import { isWorkerContext, proxyFetch } from "./messages";
+import { fetchWithTimeout } from "./fetch-timeout";
 
 /**
  * Validate DOIs by checking the doi.org Handle System API.
@@ -101,7 +102,7 @@ export async function validateDOIsRaw(
         // encodeURIComponent on the full DOI would collapse all '/' to %2F,
         // making the server see a single opaque segment instead of a path.
         const encodedHandle = doi.split("/").map(encodeURIComponent).join("/");
-        const response = await fetch(`${HANDLE_API}${encodedHandle}`);
+        const response = await fetchWithTimeout(`${HANDLE_API}${encodedHandle}`);
         if (!response.ok) {
           // 404 = the Handle System has no record of this DOI → invalid.
           // Any other non-OK status (429, 5xx) is transient — leave unknown.

--- a/src/shared/fetch-timeout.ts
+++ b/src/shared/fetch-timeout.ts
@@ -1,0 +1,20 @@
+// Small shared wrapper that aborts a fetch after a timeout so a stalled network
+// request can't hang a lookup forever. An abort surfaces as a rejected promise
+// (an AbortError DOMException), so callers' existing catch/try blocks treat a
+// timeout exactly like any other network failure.
+
+export const DEFAULT_FETCH_TIMEOUT_MS = 10_000;
+
+export async function fetchWithTimeout(
+  input: RequestInfo | URL,
+  init: RequestInit = {},
+  timeoutMs: number = DEFAULT_FETCH_TIMEOUT_MS
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(input, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/shared/flora-api.ts
+++ b/src/shared/flora-api.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import type { DoiString, ReplicationResult } from "./types";
 import { ReplicationResultSchema } from "./types";
 import { debugLog, debugError } from "./debug";
+import { fetchWithTimeout } from "./fetch-timeout";
 
 // Loose envelope — validate each result individually below so one malformed
 // entry can't fail the whole batch.
@@ -51,7 +52,7 @@ async function lookupBatch(
   dois: DoiString[]
 ): Promise<Map<DoiString, ReplicationResult>> {
   const doisParam = dois.join(",");
-  const response = await fetch(
+  const response = await fetchWithTimeout(
     `${API_BASE}/v1/original-lookup?dois=${encodeURIComponent(doisParam)}`
   );
 

--- a/src/shared/openaccess.ts
+++ b/src/shared/openaccess.ts
@@ -4,6 +4,7 @@
 import { getSettings } from "./settings";
 import { BlobCache } from "./blob-cache";
 import { isWorkerContext, proxyFetch } from "./messages";
+import { fetchWithTimeout } from "./fetch-timeout";
 
 export interface OpenAccessStatus {
     /** True when Unpaywall reports a free full-text location. */
@@ -17,11 +18,11 @@ const OA_CACHE = new BlobCache<OpenAccessStatus>({
     ttlMs: 30 * 24 * 60 * 60 * 1000, // 30 days — OA status changes rarely
 });
 
-let _cachedEmail: string | null = null;
+// getSettings() already caches settings in module state and invalidates that
+// cache via chrome.storage.onChanged, so it's cheap to call every time and
+// never goes stale — no second email cache of our own to keep in sync.
 async function getUserEmail(): Promise<string> {
-    if (_cachedEmail) return _cachedEmail;
     const { email } = await getSettings();
-    _cachedEmail = email;
     return email;
 }
 
@@ -60,7 +61,7 @@ export async function fetchOpenAccessRaw(
     doi: string,
     email: string
 ): Promise<OpenAccessStatus | null> {
-    const resp = await fetch(
+    const resp = await fetchWithTimeout(
         `https://api.unpaywall.org/v2/${encodeURIComponent(doi)}?email=${encodeURIComponent(email)}`
     );
     if (!resp.ok) return null;
@@ -77,5 +78,4 @@ export async function fetchOpenAccessRaw(
 /** Test-only: drop in-memory cache state so each case starts fresh. */
 export function _resetOpenAccessCacheForTesting(): void {
     OA_CACHE.resetForTesting();
-    _cachedEmail = null;
 }

--- a/src/shared/pubpeer-api.ts
+++ b/src/shared/pubpeer-api.ts
@@ -1,6 +1,7 @@
 import { debugLog } from "./debug";
 import { BlobCache } from "./blob-cache";
 import { isWorkerContext, proxyFetch, ProxyFetchError } from "./messages";
+import { fetchWithTimeout } from "./fetch-timeout";
 
 export interface PubPeerFeedback {
   id: string;
@@ -47,7 +48,7 @@ export async function lookupPubPeerRaw(
   dois: string[],
   urls: string[]
 ): Promise<PubPeerFeedback[]> {
-  const response = await fetch(
+  const response = await fetchWithTimeout(
     "https://pubpeer.com/v3/publications?devkey=PubMedChrome",
     {
       method: "POST",

--- a/tests/unit/cache.test.ts
+++ b/tests/unit/cache.test.ts
@@ -9,8 +9,10 @@ describe("LocalCache", () => {
 
     chrome.storage.local.get = vi.fn(async (key: string | string[] | null) => {
       if (key === null) return { ...store };
-      const k = Array.isArray(key) ? key[0] : key;
-      return k in store ? { [k]: store[k] } : {};
+      const keys = Array.isArray(key) ? key : [key];
+      const out: Record<string, unknown> = {};
+      for (const k of keys) if (k in store) out[k] = store[k];
+      return out;
     });
 
     chrome.storage.local.set = vi.fn(async (items: Record<string, unknown>) => {
@@ -154,6 +156,62 @@ describe("LocalCache", () => {
 
     expect(store["test:legacy"]).toBeUndefined();
     expect(store["test:fresh"]).toBeDefined();
+  });
+
+  describe("getMany", () => {
+    it("reads every key in a single chrome.storage.local.get", async () => {
+      const cache = new LocalCache<string>("test");
+      await cache.set("a", "A", null);
+      await cache.set("b", "B", null);
+      await cache.set("c", "C", null);
+
+      (chrome.storage.local.get as ReturnType<typeof vi.fn>).mockClear();
+      const out = await cache.getMany(["a", "b", "c", "missing"]);
+
+      expect(chrome.storage.local.get).toHaveBeenCalledOnce();
+      expect(chrome.storage.local.get).toHaveBeenCalledWith([
+        "test:a",
+        "test:b",
+        "test:c",
+        "test:missing",
+      ]);
+      expect(out.get("a")).toBe("A");
+      expect(out.get("b")).toBe("B");
+      expect(out.get("c")).toBe("C");
+      // Absent keys are simply not present in the returned map.
+      expect(out.has("missing")).toBe(false);
+    });
+
+    it("returns an empty map without touching storage for no keys", async () => {
+      const cache = new LocalCache<string>("test");
+      (chrome.storage.local.get as ReturnType<typeof vi.fn>).mockClear();
+      const out = await cache.getMany([]);
+      expect(out.size).toBe(0);
+      expect(chrome.storage.local.get).not.toHaveBeenCalled();
+    });
+
+    it("omits and sweeps expired entries", async () => {
+      const cache = new LocalCache<string>("test");
+      await cache.set("fresh", "still-good", null);
+      // Back-date an entry so it looks expired.
+      store["test:stale"] = { data: "old", expiresAt: Date.now() - 1000 };
+
+      const out = await cache.getMany(["fresh", "stale"]);
+      expect(out.get("fresh")).toBe("still-good");
+      expect(out.has("stale")).toBe(false);
+      // The expired entry is removed from storage.
+      expect(chrome.storage.local.remove).toHaveBeenCalledWith(["test:stale"]);
+      expect(store["test:stale"]).toBeUndefined();
+    });
+
+    it("preserves a cached negative result (null) distinctly from a miss", async () => {
+      const cache = new LocalCache<string>("test");
+      await cache.set("neg", null, 60_000);
+      const out = await cache.getMany(["neg", "gone"]);
+      expect(out.has("neg")).toBe(true);
+      expect(out.get("neg")).toBeNull();
+      expect(out.has("gone")).toBe(false);
+    });
   });
 
   it("setQuota(0) disables quota enforcement", async () => {

--- a/tests/unit/doi-augment.test.ts
+++ b/tests/unit/doi-augment.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, vi, beforeEach, beforeAll, afterAll, afterEach } from "vitest";
 import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";

--- a/tests/unit/doi-validate.test.ts
+++ b/tests/unit/doi-validate.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, vi, beforeEach, beforeAll, afterAll, afterEach } from "vitest";
 import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";

--- a/tests/unit/fetch-timeout.test.ts
+++ b/tests/unit/fetch-timeout.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from "vitest";
+import { fetchWithTimeout } from "../../src/shared/fetch-timeout";
+
+describe("fetchWithTimeout", () => {
+  it("aborts the underlying fetch once the timeout elapses and rejects", async () => {
+    vi.useFakeTimers();
+
+    // A fetch that never resolves on its own — it only settles when its
+    // AbortSignal fires, exactly like a stalled network request.
+    const fetchMock = vi.fn(
+      (_input: unknown, init: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init.signal!.addEventListener("abort", () =>
+            reject(new DOMException("The operation was aborted.", "AbortError"))
+          );
+        })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const promise = fetchWithTimeout("https://example.com", {}, 1000);
+    const settled = expect(promise).rejects.toThrow(/abort/i);
+
+    await vi.advanceTimersByTimeAsync(1000);
+    await settled;
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const passedSignal = (fetchMock.mock.calls[0][1] as RequestInit).signal!;
+    expect(passedSignal.aborted).toBe(true);
+
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it("passes the response through and clears the timer when fetch resolves in time", async () => {
+    vi.useFakeTimers();
+
+    const response = { ok: true, status: 200 } as Response;
+    const fetchMock = vi.fn(async () => response);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await fetchWithTimeout("https://example.com", {}, 1000);
+    expect(result).toBe(response);
+    // The abort timer must be cleared so it can't fire after a successful fetch.
+    expect(vi.getTimerCount()).toBe(0);
+
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it("forwards init options (method, headers) alongside the injected signal", async () => {
+    const response = { ok: true } as Response;
+    const fetchMock = vi.fn(async () => response);
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchWithTimeout("https://example.com", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+    });
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(init.method).toBe("POST");
+    expect(init.headers).toEqual({ "Content-Type": "application/json" });
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+
+    vi.unstubAllGlobals();
+  });
+});

--- a/tests/unit/flora-api.test.ts
+++ b/tests/unit/flora-api.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
 import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";

--- a/tests/unit/proxy-fetch.test.ts
+++ b/tests/unit/proxy-fetch.test.ts
@@ -1,6 +1,13 @@
+// @vitest-environment node
+// Runs under the node environment (jsdom's AbortSignal is rejected by Node's
+// undici fetch, which the worker-side raw fetches now use via fetchWithTimeout).
+// A stubbed `window` global preserves what jsdom provided for this suite: the
+// content-script context signal that isWorkerContext() keys on.
 import { describe, it, expect, vi, beforeEach, beforeAll, afterAll, afterEach } from "vitest";
 import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
+
+vi.stubGlobal("window", {});
 
 // getUserEmail() must return a configured email for the Unpaywall lookup.
 vi.mock("../../src/shared/settings", () => ({

--- a/tests/unit/scholar-observer.test.ts
+++ b/tests/unit/scholar-observer.test.ts
@@ -63,6 +63,30 @@ describe("scholar observer", () => {
         expect(call).to.not.be.undefined;
         if (call) expect(call.dois).toContain("10.1126/science.9999999");
     });
+
+    it("batches all retraction checks into a single FLORA_RET_CHECK for the pass", async () => {
+        // Fresh pass over fresh rows so we count only this run's messages.
+        const html = readFileSync(
+            join(__dirname, "..", "fixtures", "scholar-results.html"),
+            "utf-8"
+        );
+        const dom = new JSDOM(html);
+        document.body.innerHTML = dom.window.document.body.innerHTML;
+        (chrome.runtime.sendMessage as ReturnType<typeof vi.fn>).mockClear();
+
+        const {processScholarResults} = await import("../../src/content-scholar/observer");
+        await processScholarResults(document);
+
+        const retCalls = (chrome.runtime.sendMessage as ReturnType<typeof vi.fn>).mock.calls
+            .filter(args => args[0]?.type === "FLORA_RET_CHECK");
+        // One request for the whole pass rather than one per row.
+        expect(retCalls).toHaveLength(1);
+        // It carries every collected DOI, so results can be distributed per row.
+        expect(retCalls[0][0].dois.length).toBeGreaterThanOrEqual(2);
+        expect(retCalls[0][0].dois).toEqual(
+            expect.arrayContaining(["10.1038/nature12373", "10.1126/science.9999999"])
+        );
+    });
 });
 
 describe("Scholar row metadata extraction", () => {

--- a/tests/unit/service-worker.test.ts
+++ b/tests/unit/service-worker.test.ts
@@ -29,6 +29,8 @@ const cacheStore = new Map<string, unknown>();
 const cacheSetCalls: Array<{key: string; data: unknown; ttlMs: number | null}> = [];
 // When set, cache.set throws (simulates a storage-quota write failure).
 let cacheSetError: Error | null = null;
+const getSpy = vi.fn();
+const getManySpy = vi.fn();
 vi.mock("../../src/shared/cache", () => ({
     MONTH_MS: 30 * 24 * 60 * 60 * 1000,
     LocalCache: class {
@@ -41,9 +43,20 @@ vi.mock("../../src/shared/cache", () => ({
         setQuota(_bytes: number) {}
 
         async get(key: string) {
+            getSpy(key);
             return cacheStore.has(`${this.prefix}:${key}`)
                 ? cacheStore.get(`${this.prefix}:${key}`)
                 : undefined;
+        }
+
+        async getMany(keys: string[]) {
+            getManySpy(keys);
+            const out = new Map<string, unknown>();
+            for (const key of keys) {
+                const storageKey = `${this.prefix}:${key}`;
+                if (cacheStore.has(storageKey)) out.set(key, cacheStore.get(storageKey));
+            }
+            return out;
         }
 
         async set(key: string, data: unknown, ttlMs: number | null) {
@@ -65,6 +78,8 @@ describe("service-worker", () => {
         cacheStore.clear();
         cacheSetCalls.length = 0;
         cacheSetError = null;
+        getSpy.mockClear();
+        getManySpy.mockClear();
         mockLookupDOIs.mockReset();
         (chrome.storage.local.get as ReturnType<typeof vi.fn>).mockResolvedValue({});
 
@@ -359,5 +374,75 @@ describe("service-worker", () => {
         ]);
         expect(response.results["10.1038/nature12373"]).toEqual(MOCK_RESULT);
         expect(response.results["10.1126/science.9999999"]).toEqual(otherResult);
+    });
+
+    it("reads the cache with one batched getMany, not per-DOI get()", async () => {
+        mockLookupDOIs.mockResolvedValue(new Map());
+
+        await sendMessage({
+            type: "FLORA_LOOKUP",
+            dois: [
+                doi("10.1038/nature12373"),
+                doi("10.1126/science.9999999"),
+                doi("10.1000/third"),
+            ],
+        });
+
+        // One batched read covering every DOI; no per-DOI cache.get() round-trips.
+        expect(getManySpy).toHaveBeenCalledOnce();
+        expect(getManySpy).toHaveBeenCalledWith([
+            "10.1038/nature12373",
+            "10.1126/science.9999999",
+            "10.1000/third",
+        ]);
+        expect(getSpy).not.toHaveBeenCalled();
+    });
+
+    describe("setup-dismissed handlers respond even when storage rejects", () => {
+        it("FLORA_DISMISS_SETUP responds {ok:false} on a session.set rejection", async () => {
+            (chrome.storage.session.set as ReturnType<typeof vi.fn>)
+                .mockRejectedValueOnce(new Error("storage unavailable"));
+
+            const response = await new Promise((resolve) => {
+                messageHandler({type: "FLORA_DISMISS_SETUP"}, {}, resolve as (r: unknown) => void);
+            });
+            expect(response).toEqual({ok: false});
+        });
+
+        it("FLORA_IS_SETUP_DISMISSED responds {dismissed:false} on a session.get rejection", async () => {
+            (chrome.storage.session.get as ReturnType<typeof vi.fn>)
+                .mockRejectedValueOnce(new Error("storage unavailable"));
+
+            const response = await new Promise((resolve) => {
+                messageHandler({type: "FLORA_IS_SETUP_DISMISSED"}, {}, resolve as (r: unknown) => void);
+            });
+            expect(response).toEqual({dismissed: false});
+        });
+    });
+
+    it("deduplicates concurrent retraction syncs into a single fetch", async () => {
+        // Storage is empty (default mock) → isEmpty → each call would otherwise
+        // fetch + write the full map. The in-flight guard collapses them to one.
+        const fetchMock = vi.fn(async () => ({
+            ok: true,
+            status: 200,
+            json: async () => ({retractions: {}, concerns: {}}),
+        }));
+        vi.stubGlobal("fetch", fetchMock);
+
+        const {syncRetractionsInfo} = await import("../../src/background/service-worker");
+        await Promise.all([
+            syncRetractionsInfo(),
+            syncRetractionsInfo(),
+            syncRetractionsInfo(),
+        ]);
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+
+        // After the batch settles the guard clears, so a later call syncs again.
+        await syncRetractionsInfo();
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+
+        vi.unstubAllGlobals();
     });
 });


### PR DESCRIPTION
**Stacks on #96** (which stacks on #95) — merge order #95 → #96 → this.

A batch of small, independently verified fixes. No content scan/placement or injector core logic changed beyond two named narrow spots (Scholar retraction batching; a `document.hidden` check in the Sheets poll).

## Correctness

- **Empty `.catch()` / `.then().catch()` handlers don't suppress rejections** — `catch(undefined)` passes the rejection through. All instances replaced with real handlers (worker: `debugError` logging; content: swallow).
- **Setup-dismissed message handlers could hang the sender**: `FLORA_DISMISS_SETUP` / `FLORA_IS_SETUP_DISMISSED` now `sendResponse` even when `chrome.storage.session` rejects.
- **`syncRetractionsInfo` deduplicated** behind an in-flight promise guard — `onInstalled`/`onStartup`/`getRetractionSource` no longer each fetch and write the ~3.6 MB retraction map concurrently.

## Efficiency

- **`handleLookup` cache read is one batched `getMany`** (single `chrome.storage.local.get`) instead of an `await` per DOI, and in-flight registration now happens before any interleaving `await`, closing the cache-stampede window where two tabs looking up the same DOI both hit the API. Preserves #95's finite-TTL, write-failure-isolated cache writes.
- **Scholar observer batches `retractionCheck`** — one call per pass instead of one per result row.
- **Google Sheets gid-poll pauses while the tab is hidden.**
- Dropped a redundant, never-invalidated module-level email cache in two modules (`getSettings` already caches with `onChanged` invalidation).

## Robustness

- **All network fetches now use a shared `fetchWithTimeout`** (10s AbortController) — applied inside the `*Raw` helpers from #96, so proxied calls time out worker-side. A timeout surfaces exactly like today's network errors.

## Testing

`npm test` (211 passing), `npx tsc --noEmit`, `npm run build` all green. New coverage: `getMany`, batched lookup classification, sync dedupe, storage-rejection responses, Scholar batching, timeout abort behaviour. Test-env note: the MSW-based network suites (and `proxy-fetch.test.ts`) run under the node vitest environment because undici rejects jsdom's `AbortSignal` (realm mismatch, test-only — the browser has one realm); the proxy suite keeps content-script semantics via a stubbed `window`.

## Risk

Low — behaviour-preserving; changes are localized. The one user-visible improvement: a stalled network request can no longer wedge a lookup forever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)