### PR TITLE
Perf: gate, memoize, and single-scan the per-mutation extraction pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test:watch": "vitest",
     "test:visual": "tsx tests/visual/run.ts",
     "test:visual:update": "tsx tests/visual/run.ts --update",
+    "bench:scan-gating": "tsx scripts/bench-scan-gating.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/scripts/bench-scan-gating.ts
+++ b/scripts/bench-scan-gating.ts
@@ -1,0 +1,348 @@
+// Benchmark for the per-mutation scan gating (perf-scan-gating branch).
+//
+// Compares the REAL before and after builds:
+//   BEFORE — a temporary worktree of the base branch (origin/fix-editable-guard,
+//            the pre-optimisation pipeline), patched with the same tiny
+//            `flora-perf-pass` timing hook and built.
+//   AFTER  — this repo's current build (run `npm run build` first).
+//
+// Each build is loaded as a Chrome-for-Testing extension (same bootstrap as the
+// visual harness, with the same hermetic storage seed + fetch blocking). The
+// driver renders a large "Gmail-like" page (~2 MB DOM, thousands of elements,
+// NO DOIs) and fires N synthetic mutations at a fixed interval, summing the
+// time spent inside pageRenderChangeHandler per pass. A DOI-bearing article
+// fixture is also measured on the AFTER build to show relevant pages still
+// scan and badge correctly.
+//
+// Timing crosses out of the content script's isolated world via a
+// `flora-perf-pass` DOM event, enabled only when <html data-flora-perf> is set
+// (the benchmark sets it after load; production pages never have it).
+//
+// Run:  npm run build && npx tsx scripts/bench-scan-gating.ts
+
+import {
+  Browser as BrowserName,
+  computeExecutablePath,
+  detectBrowserPlatform,
+  install,
+  resolveBuildId,
+} from "@puppeteer/browsers";
+import puppeteer, { type Browser, type Page, type Target } from "puppeteer-core";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, symlinkSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { startServer } from "../tests/visual/server.js";
+import {
+  buildLocalSeed,
+  buildSyncSeed,
+  classifyPageRequest,
+  isBlockedWorkerHost,
+} from "../tests/visual/mocks.js";
+
+declare const chrome: any;
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..");
+const BASE_REF = "origin/fix-editable-guard";
+
+const N_MUTATIONS = 20;
+const MUTATION_INTERVAL_MS = 400;
+
+// ── Large DOI-free "Gmail-like" fixture (~2 MB, thousands of elements) ───────
+function buildGmailLikeHtml(): string {
+  const rows: string[] = [];
+  for (let i = 0; i < 3500; i++) {
+    rows.push(
+      `<div class="zA" role="listitem" id="row-${i}">` +
+        `<div class="yW"><span class="yP">Sender Name ${i}</span></div>` +
+        `<div class="xY"><div class="y6"><span class="bog">Subject line ${i}: quarterly sync notes and action items</span>` +
+        `<span class="y2"> — Body preview number ${i}, meeting at 9:30 about budget v10.2 and the $10.50 refund; ` +
+        `see attachment and reply by Friday. Reference ${i} lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod.</span></div></div>` +
+        `<div class="xW"><span class="xS">10:${(i % 60).toString().padStart(2, "0")} AM</span></div>` +
+        `</div>`,
+    );
+  }
+  return (
+    `<!DOCTYPE html><html><head><meta charset="utf-8"><title>Inbox</title></head>` +
+    `<body><div id="app" role="main"><div class="Cp"><div class="ae4">${rows.join("")}</div></div></div></body></html>`
+  );
+}
+
+// Page-context driver: collects flora-perf-pass events; fires synthetic
+// mutations; waits for the debounced passes; reports totals.
+const DRIVER = `
+window.__floraPerf = { passes: [], kinds: [], total: 0 };
+document.addEventListener('flora-perf-pass', (e) => {
+  const d = e.detail || {};
+  window.__floraPerf.passes.push(typeof d.ms === 'number' ? d.ms : 0);
+  window.__floraPerf.kinds.push(d.kind || 'full');
+  window.__floraPerf.total++;
+});
+// Readiness probe: add one throwaway node and wait until the extension's
+// handler emits a perf event for it — proves observer + perf bridge are live.
+window.__waitReady = async (timeoutMs) => {
+  const start = Date.now();
+  const probe = document.createElement('div');
+  probe.textContent = 'probe node with no identifiers';
+  document.body.appendChild(probe);
+  while (window.__floraPerf.total === 0 && Date.now() - start < timeoutMs) {
+    await new Promise(r => setTimeout(r, 100));
+  }
+  return window.__floraPerf.total > 0;
+};
+window.__runBurst = async (n, interval) => {
+  window.__floraPerf.passes = [];
+  window.__floraPerf.kinds = [];
+  const container = document.querySelector('.ae4') || document.body;
+  for (let i = 0; i < n; i++) {
+    const row = document.createElement('div');
+    row.className = 'zA';
+    row.innerHTML = '<div class="yW"><span class="yP">Late sender ' + i + '</span></div>' +
+      '<div class="xY"><span class="y2">Newly streamed message ' + i +
+      ', no identifiers here, just chatter about lunch and the 10:45 standup.</span></div>';
+    container.appendChild(row);
+    await new Promise(r => setTimeout(r, interval));
+  }
+  // Allow the final debounced (300ms) pass plus slow passes to finish.
+  await new Promise(r => setTimeout(r, 1500));
+  const p = window.__floraPerf.passes;
+  const sum = p.reduce((a, b) => a + b, 0);
+  return { count: p.length, sum, max: p.length ? Math.max(...p) : 0, each: p, kinds: window.__floraPerf.kinds };
+};
+`;
+
+// ── BEFORE build: temp worktree of the base ref + the same timing hook ───────
+function prepareBaseExtension(): string {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "flora-bench-base-"));
+  execFileSync("git", ["worktree", "add", "--detach", "--force", dir, BASE_REF], { cwd: REPO_ROOT });
+  // Resolve the REAL node_modules (a git worktree's own may be empty — Node
+  // resolves deps by walking up to the main checkout) and expose it in the
+  // temp worktree, which sits in /tmp with nothing up-tree.
+  const require = createRequire(import.meta.url);
+  const nodeModules = path.resolve(path.dirname(require.resolve("esbuild/package.json")), "..");
+  symlinkSync(nodeModules, path.join(dir, "node_modules"));
+
+  // Patch the base content script with the identical instrumentation wrapper.
+  const idx = path.join(dir, "src", "content-general", "index.ts");
+  const src = readFileSync(idx, "utf-8");
+  const anchor = "async function pageRenderChangeHandler(): Promise<void> {";
+  if (!src.includes(anchor)) throw new Error("base index.ts anchor not found — update the bench patch");
+  const patched = src.replace(
+    anchor,
+    [
+      "async function pageRenderChangeHandler(): Promise<void> {",
+      '    if (!(document.documentElement?.hasAttribute?.("data-flora-perf") ?? false)) return __origRenderPass();',
+      "    const __t0 = performance.now();",
+      "    try { await __origRenderPass(); } finally {",
+      '        document.dispatchEvent(new CustomEvent("flora-perf-pass", { detail: { ms: performance.now() - __t0, kind: "full" } }));',
+      "    }",
+      "}",
+      "async function __origRenderPass(): Promise<void> {",
+    ].join("\n"),
+  );
+  writeFileSync(idx, patched);
+  const tsxCli = require.resolve("tsx/cli");
+  execFileSync(process.execPath, [tsxCli, "esbuild.config.ts"], { cwd: dir, stdio: "inherit" });
+  return dir;
+}
+
+function removeBaseExtension(dir: string): void {
+  try {
+    execFileSync("git", ["worktree", "remove", "--force", dir], { cwd: REPO_ROOT });
+  } catch {
+    /* best effort */
+  }
+}
+
+// ── Chrome bootstrap + hermetic seeding (mirrors tests/visual/run.ts) ────────
+async function ensureChrome(): Promise<string> {
+  const platform = detectBrowserPlatform();
+  if (!platform) throw new Error("Unsupported platform for Chrome for Testing");
+  const cacheDir = path.join(os.homedir(), ".cache", "puppeteer");
+  const buildId = await resolveBuildId(BrowserName.CHROME, platform, "stable");
+  const execPath = computeExecutablePath({ browser: BrowserName.CHROME, buildId, cacheDir });
+  if (!existsSync(execPath)) await install({ browser: BrowserName.CHROME, buildId, cacheDir });
+  return execPath;
+}
+
+async function launchWithExtension(execPath: string, extDir: string): Promise<Browser> {
+  const browser = await puppeteer.launch({
+    executablePath: execPath,
+    headless: false,
+    args: [
+      `--disable-extensions-except=${extDir}`,
+      `--load-extension=${extDir}`,
+      "--disable-gpu",
+      "--no-first-run",
+      "--no-default-browser-check",
+      "--disable-features=DisableLoadExtensionCommandLineSwitch",
+    ],
+  });
+  const swTarget = await browser.waitForTarget((t) => t.type() === "service_worker", {
+    timeout: 20000,
+  });
+  await blockWorkerFetches(swTarget);
+  const worker = await swTarget.worker();
+  if (!worker) throw new Error("service worker unavailable");
+  await worker.evaluate(
+    async (local: Record<string, unknown>, sync: Record<string, unknown>) => {
+      await chrome.storage.local.set(local);
+      await chrome.storage.sync.set(sync);
+    },
+    buildLocalSeed(),
+    buildSyncSeed(),
+  );
+  return browser;
+}
+
+async function blockWorkerFetches(target: Target): Promise<void> {
+  const cdp = await target.createCDPSession();
+  await cdp.send("Fetch.enable", { patterns: [{ urlPattern: "*" }] });
+  cdp.on("Fetch.requestPaused", (event) => {
+    const { requestId, request } = event as { requestId: string; request: { url: string } };
+    if (isBlockedWorkerHost(request.url)) {
+      cdp.send("Fetch.failRequest", { requestId, errorReason: "Failed" }).catch(() => {});
+    } else {
+      cdp.send("Fetch.continueRequest", { requestId }).catch(() => {});
+    }
+  });
+}
+
+async function interceptPageRequests(page: Page): Promise<void> {
+  await page.setRequestInterception(true);
+  page.on("request", (req) => {
+    const verdict = classifyPageRequest(req.url());
+    if (verdict === "allow") req.continue().catch(() => {});
+    else if (verdict === "abort") req.abort().catch(() => {});
+    else
+      req
+        .respond({ status: verdict.status, contentType: verdict.contentType, body: verdict.body })
+        .catch(() => {});
+  });
+}
+
+// ── Measure one page in one build ─────────────────────────────────────────────
+interface BurstResult {
+  count: number;
+  sum: number;
+  max: number;
+  each: number[];
+  kinds: string[];
+}
+
+async function measure(browser: Browser, url: string): Promise<{ burst: BurstResult; badges: number }> {
+  const page: Page = await browser.newPage();
+  try {
+    await page.setViewport({ width: 1280, height: 900 });
+    await interceptPageRequests(page);
+    await page.evaluateOnNewDocument(DRIVER);
+    await page.bringToFront();
+    await page.goto(url, { waitUntil: "load", timeout: 60000 });
+    await page.bringToFront();
+    // Enable the perf hook AFTER parse (an attribute set pre-parse on the
+    // provisional documentElement is discarded when the real <html> lands).
+    // The hook is checked per-pass at runtime, so post-load is early enough.
+    await page.evaluate(() => document.documentElement.setAttribute("data-flora-perf", ""));
+    const ready = await page.evaluate(() => (window as any).__waitReady(15000));
+    if (!ready) throw new Error(`extension never ran an observed pass on ${url}`);
+    const burst = (await page.evaluate(
+      (n, interval) => (window as any).__runBurst(n, interval),
+      N_MUTATIONS,
+      MUTATION_INTERVAL_MS,
+    )) as BurstResult;
+    const badges = await page.evaluate(
+      () =>
+        document.querySelectorAll(".flora-inline-badge, .flora-doi-label, .flora-notice-pill")
+          .length,
+    );
+    return { burst, badges };
+  } finally {
+    await page.close().catch(() => {});
+  }
+}
+
+function fmt(r: BurstResult): string {
+  const avg = r.count ? r.sum / r.count : 0;
+  const byKind = r.kinds.reduce<Record<string, number>>((acc, k) => {
+    acc[k] = (acc[k] ?? 0) + 1;
+    return acc;
+  }, {});
+  const kinds = Object.entries(byKind)
+    .map(([k, n]) => `${n}x ${k}`)
+    .join(", ");
+  return (
+    `passes=${r.count}  total=${r.sum.toFixed(1)}ms  avg=${avg.toFixed(2)}ms/pass  ` +
+    `max=${r.max.toFixed(2)}ms  [${kinds}]`
+  );
+}
+
+async function main(): Promise<void> {
+  if (!existsSync(path.join(REPO_ROOT, "dist", "background.js"))) {
+    throw new Error("dist/ missing — run `npm run build` first");
+  }
+
+  const tmp = mkdtempSync(path.join(os.tmpdir(), "flora-bench-fixtures-"));
+  const gmailHtml = buildGmailLikeHtml();
+  writeFileSync(path.join(tmp, "gmail-like.html"), gmailHtml);
+  const server = await startServer([tmp, path.join(REPO_ROOT, "tests", "fixtures")]);
+  const gmailUrl = `${server.origin}/gmail-like.html`;
+  const articleUrl = `${server.origin}/article-with-dois.html`;
+
+  console.log(`\nGmail-like fixture: ${(Buffer.byteLength(gmailHtml) / 1_000_000).toFixed(2)} MB HTML, ~3500 rows, 0 DOIs`);
+  console.log(`Driver: ${N_MUTATIONS} mutations @ ${MUTATION_INTERVAL_MS}ms, 300ms handler debounce\n`);
+
+  const execPath = await ensureChrome();
+
+  console.log(`Building BEFORE extension from ${BASE_REF} …`);
+  const baseDir = prepareBaseExtension();
+  let beforeSum = 0;
+  try {
+    // BEFORE — base branch pipeline, every mutation runs the full scan.
+    {
+      const browser = await launchWithExtension(execPath, baseDir);
+      try {
+        const before = await measure(browser, gmailUrl);
+        console.log(`BEFORE (${BASE_REF})`);
+        console.log(`  gmail-like: ${fmt(before.burst)}`);
+        beforeSum = before.burst.sum;
+      } finally {
+        await browser.close().catch(() => {});
+      }
+    }
+
+    // AFTER — this branch's build.
+    {
+      const browser = await launchWithExtension(execPath, REPO_ROOT);
+      try {
+        const after = await measure(browser, gmailUrl);
+        console.log(`AFTER  (perf-scan-gating)`);
+        console.log(`  gmail-like: ${fmt(after.burst)}`);
+        const saved = beforeSum - after.burst.sum;
+        const factor = after.burst.sum > 0 ? beforeSum / after.burst.sum : Infinity;
+        console.log(
+          `\nMain-thread time in render passes over the burst: ` +
+            `${beforeSum.toFixed(1)}ms → ${after.burst.sum.toFixed(1)}ms ` +
+            `(${saved.toFixed(1)}ms saved, ${factor.toFixed(1)}x less)\n`,
+        );
+
+        // Relevant page still scans + badges correctly on the AFTER build.
+        const article = await measure(browser, articleUrl);
+        console.log(`AFTER, DOI-bearing article fixture:`);
+        console.log(`  article-with-dois: ${fmt(article.burst)}  → FLoRA elements on page: ${article.badges}`);
+      } finally {
+        await browser.close().catch(() => {});
+      }
+    }
+  } finally {
+    removeBaseExtension(baseDir);
+    await server.close().catch(() => {});
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/content-general/index.ts
+++ b/src/content-general/index.ts
@@ -37,6 +37,7 @@ import {isSetupComplete} from "@shared/settings";
 import {isDomainBlocked} from "@shared/domains";
 import {injectRetractionInfo, resetRetractionPills, retractionCheck, RetractionResponse} from "@shared/doi-retraction"
 import {resolveReferenceDois, renderResolvedReferences, type ResolvedReference} from "./references";
+import {couldNodeIntroduceDoi, scanFingerprint} from "./scan-gate";
 
 // PubPeer commenter IDs whose comments are hidden in the embedded iframe.
 // Add any bot/org account ID here to suppress its annotations from the panel.
@@ -58,6 +59,14 @@ let lastRefFeedbackByDoi: Map<DoiString, PubPeerFeedback> = new Map();
 // Monotonically increments when FORRT lookup results land in pageState.
 let pageStateVersion = 0;
 let lastRenderedPageStateVersion = -1;
+// Perf gating (see startDomListener / pageRenderChangeHandler):
+//  - `everYieldedDoi` latches true the first time this page URL surfaces ANY
+//    DOI. Until then, an irrelevant, non-scholarly page is scanned only by a
+//    cheap per-mutation probe rather than the full pipeline.
+//  - `lastScanFingerprint` memoises the last-scanned page state so a pass whose
+//    inputs are unchanged skips the full pipeline entirely.
+let everYieldedDoi = false;
+let lastScanFingerprint: string | null = null;
 // In-flight reference resolution, shared across one render pass.
 let resolvedRefsPromise: Promise<ResolvedReference[]> | null = null;
 
@@ -106,7 +115,32 @@ chrome.runtime.onMessage.addListener((message: unknown, _sender, sendResponse) =
     }
 });
 
-async function pageRenderChangeHandler(): Promise<void> {
+// Benchmark-only instrumentation, inert in normal use. When the page carries
+// `data-flora-perf` on <html>, each render pass dispatches a `flora-perf-pass`
+// DOM event with its duration and how the pass resolved (a content script and
+// the page share the DOM but not JS globals, so a DOM event is how timing
+// crosses out). See scripts/bench-scan-gating.ts.
+function perfEnabled(): boolean {
+    return document.documentElement?.hasAttribute?.("data-flora-perf") ?? false;
+}
+
+let _lastPassKind = "";
+async function pageRenderChangeHandler(hint?: ScanHint): Promise<void> {
+    if (!perfEnabled()) return runRenderPass(hint);
+    const t0 = performance.now();
+    _lastPassKind = "full";
+    try {
+        await runRenderPass(hint);
+    } finally {
+        document.dispatchEvent(
+            new CustomEvent("flora-perf-pass", {
+                detail: { ms: performance.now() - t0, kind: _lastPassKind },
+            }),
+        );
+    }
+}
+
+async function runRenderPass(hint?: ScanHint): Promise<void> {
     // Detect full URL change (SPA navigation) — clear state
     const currentUrl = location.href;
     if (currentUrl !== lastUrl) {
@@ -121,6 +155,9 @@ async function pageRenderChangeHandler(): Promise<void> {
         resolvedRefsPromise = null;
         pageState.clear();
         augmentAttempted = false;
+        // New page — reset the relevance latch and the skip-unchanged memo.
+        everYieldedDoi = false;
+        lastScanFingerprint = null;
         resetRetractionPills();
         if (isSheets) {
             removeSheetsModal();
@@ -128,13 +165,61 @@ async function pageRenderChangeHandler(): Promise<void> {
             removeSidePanel();
         }
     }
+
+    // ── Cheap gating before any full-DOM scan (non-Sheets only). ──────────────
+    // Sheets uses a canvas-backed grid + CSV export and its own paths, so these
+    // DOM-text gates don't apply there.
+    if (!isSheets) {
+        // (1) Relevance pre-gate. A page that has never yielded a DOI and is not
+        // a scholarly article gets only a cheap probe: `hint.couldBeRelevant` is
+        // true iff a node added in THIS mutation batch contains the literal
+        // "10.<4+ digits>" registrant that begins every serialised DOI (in text,
+        // an href, or a meta value — see startDomListener). If nothing DOI-like
+        // was added, this pass cannot surface a new DOI, so bail without reading
+        // the DOM. Invariant preserved: (a) DOIs present at the initial full scan
+        // are caught by it (that pass carries no hint); (b) any DOI introduced
+        // later arrives inside an added subtree whose markup contains that
+        // registrant substring, flipping couldBeRelevant true; (c) once ANY DOI
+        // is found, `everYieldedDoi` latches and this gate is disabled for the
+        // rest of the page's life; (d) a tab re-show re-runs with no hint (full
+        // scan). So no DOI-bearing content can permanently escape detection.
+        if (hint && !hint.couldBeRelevant && !everYieldedDoi && !isScholarlyArticlePage()) {
+            debugLog("General: pre-gate skip — no DOI-like content added to an irrelevant page");
+            _lastPassKind = "pregate-bail";
+            return;
+        }
+
+        // (2) Skip-unchanged memo. If the scanned text (and our own placed-UI
+        // count) is identical to the last pass, nothing to do. textContent does
+        // NOT force layout (unlike innerText), so this fingerprint is cheap
+        // relative to the full pipeline it guards.
+        const fp = scanFingerprint();
+        if (fp === lastScanFingerprint) {
+            debugLog("General: fingerprint unchanged — skipping full scan");
+            _lastPassKind = "fingerprint-skip";
+            return;
+        }
+        lastScanFingerprint = fp;
+    }
+
     // Fresh DOM scan pass — resets the per-pass findReferenceContainers memo.
     beginDomScanPass();
 
     // Resolve reference-list DOIs in parallel with the FORRT lookup below.
     resolvedRefsPromise = resolveReferenceDois();
+    // A page whose only DOIs come from reference augmentation (entries with no
+    // on-page DOI) still counts as relevant — latch the pre-gate open so later
+    // mutations (e.g. more citations streaming in) keep getting full scans.
+    resolvedRefsPromise.then((refs) => {
+        if (refs.length > 0) everYieldedDoi = true;
+    }).catch(() => {});
 
-    // Non-Sheets: one classification scan (allDois). Sheets: canvas extractDOIs + CSV.
+    // Single position-aware scan for this pass — reused for classification,
+    // badge placement, and the post-lookup "still in DOM" recheck.
+    const occurrences = extractDoiOccurrences(document);
+
+    // Non-Sheets: one classification scan (allDois), reusing `occurrences` so no
+    // extra a[href] sweep or body-text read. Sheets: canvas extractDOIs + CSV.
     let dois: DoiString[];
     let classified: ClassifiedDois | null = null;
     if (isSheets) {
@@ -143,12 +228,12 @@ async function pageRenderChangeHandler(): Promise<void> {
             dois = [...new Set([...dois, ...sheetCsvDois])];
         }
     } else {
-        classified = classifyPageDois(document);
+        classified = classifyPageDois(document, occurrences);
         dois = classified.allDois;
     }
 
-    // DOI occurrences with source + anchor, so badges place without re-scanning.
-    const occurrences = extractDoiOccurrences(document);
+    // Latch the relevance gate open the moment this page surfaces any DOI.
+    if (dois.length > 0) everYieldedDoi = true;
 
     const hasDoiChange = processedDois.size !== dois.length ||
         !dois.every(doi => processedDois.has(doi));
@@ -285,9 +370,20 @@ async function pageRenderChangeHandler(): Promise<void> {
         }
         pageStateVersion++; // signal that replication data is now available
 
-        // Collect matched DOIs for display
-        // On Sheets, skip the "still in DOM" re-check — the canvas DOM is unreliable
-        const currentDois = isSheets ? null : new Set(extractDOIs(document));
+        // Collect matched DOIs for display.
+        // "Still in DOM" recheck WITHOUT a second full scan: reuse this pass's
+        // shared artifact. Authoritative DOIs (URL/meta/JSON-LD) never leave via
+        // a DOM mutation; every other DOI is "still present" iff one of its
+        // occurrence anchors is still connected to the live document (an anchor
+        // wiped by a concurrent SPA re-render reports isConnected === false).
+        // On Sheets, skip the recheck — the canvas DOM is unreliable.
+        const currentDois = isSheets ? null : (() => {
+            const present = new Set<DoiString>(classified!.articleDois);
+            for (const occ of occurrences) {
+                if (occ.anchor.isConnected) present.add(occ.doi);
+            }
+            return present;
+        })();
         const matched = [...pageState.entries()]
             .filter(([doi, s]) => {
                 if (s.status !== "matched") return false;
@@ -376,6 +472,7 @@ async function augmentFromTitle(): Promise<void> {
         const resolvedDoi = augmented.get(pageTitle);
         debugLog("Title augmentation:", resolvedDoi ? `resolved to ${resolvedDoi}` : "no match", `(title: "${pageTitle}")`);
         if (resolvedDoi) {
+            everYieldedDoi = true; // page produced a DOI — disable the relevance pre-gate
             processedDois.add(resolvedDoi);
             const request: LookupRequest = {
                 type: "FLORA_LOOKUP",
@@ -625,29 +722,51 @@ function isFloraOwnedNode(node: Node): boolean {
     return false;
 }
 
-function startDomListener(callback: () => void) {
+/** Hint passed from the mutation observer to the render handler. */
+interface ScanHint {
+    /**
+     * True when a node added in this mutation batch could carry a DOI — used by
+     * the relevance pre-gate to cheaply skip passes on irrelevant pages. Absent
+     * hint (initial run, tab re-show) always forces a full scan.
+     */
+    couldBeRelevant: boolean;
+}
+
+function startDomListener(callback: (hint?: ScanHint) => void) {
     let debounceTimer: number;
+    // Whether any external node added since the last fired callback could carry
+    // a DOI. Accumulated across debounced mutation batches, reset when fired.
+    let pendingCouldBeRelevant = false;
     const observer = new MutationObserver((mutations) => {
         // Do no work while this tab is in the background.
         if (document.hidden) return;
-        const hasExternalChange = mutations.some(m => {
-            if (m.addedNodes.length === 0) return false;
+        let hasExternalChange = false;
+        for (const m of mutations) {
+            if (m.addedNodes.length === 0) continue;
             // Skip mutations inside FLoRA's own injected containers.
-            if ((m.target as Element).closest?.('[id^="flora-"]')) return false;
-            // Skip if every added node is a FLoRA-owned element (badges, pills, panel, etc.).
+            if ((m.target as Element).closest?.('[id^="flora-"]')) continue;
             for (const node of m.addedNodes) {
-                if (!isFloraOwnedNode(node)) return true;
+                // Skip FLoRA-owned elements (badges, pills, panel, etc.).
+                if (isFloraOwnedNode(node)) continue;
+                hasExternalChange = true;
+                if (!pendingCouldBeRelevant && couldNodeIntroduceDoi(node)) {
+                    pendingCouldBeRelevant = true;
+                }
             }
-            return false;
-        });
+        }
         if (hasExternalChange) {
             clearTimeout(debounceTimer);
-            debounceTimer = window.setTimeout(callback, 300);
+            debounceTimer = window.setTimeout(() => {
+                const couldBeRelevant = pendingCouldBeRelevant;
+                pendingCouldBeRelevant = false;
+                callback({ couldBeRelevant });
+            }, 300);
         }
     });
     observer.observe(document.body, { childList: true, subtree: true });
     // Re-scan when the tab becomes active again — mutations that happened while
-    // it was hidden were ignored above.
+    // it was hidden were ignored above. No hint → full scan (can't localise what
+    // changed while hidden).
     document.addEventListener("visibilitychange", () => {
         if (!document.hidden) callback();
     });

--- a/src/content-general/injector.ts
+++ b/src/content-general/injector.ts
@@ -237,17 +237,44 @@ function ensureBannerHost(): HTMLElement {
     return host;
 }
 
-// Track elements we've modified so we can restore them on removal
-const modifiedElements = new Set<HTMLElement>();
+// Track elements we've modified, remembering each one's ORIGINAL inline top /
+// padding-top so removeBanner can restore them exactly. `null` = the property
+// was not set inline before we touched it (must be removed, not zeroed).
+interface OriginalInline {
+    top: string | null;
+    paddingTop: string | null;
+}
+const modifiedElements = new Map<HTMLElement, OriginalInline>();
+
+/** Remember an element's original inline top/padding-top once, before writing. */
+function rememberOriginal(el: HTMLElement): void {
+    if (modifiedElements.has(el)) return;
+    modifiedElements.set(el, {
+        top: el.style.getPropertyValue("top") || null,
+        paddingTop: el.style.getPropertyValue("padding-top") || null,
+    });
+}
+
+/** Restore one saved inline property, removing it if it had no inline value. */
+function restoreInline(el: HTMLElement, prop: "top" | "padding-top", saved: string | null): void {
+    if (saved === null || saved === "") {
+        el.style.removeProperty(prop);
+    } else {
+        el.style.setProperty(prop, saved);
+    }
+}
 
 export function removeBanner(): void {
     const host = document.getElementById(BANNER_HOST_ID);
     if (host) {
         host.remove();
-        document.body.style.removeProperty("padding-top");
-        for (const el of modifiedElements) {
-            el.style.removeProperty("padding-top");
-            el.style.removeProperty("top");
+        // Restore every modified element (incl. <body>) to its ORIGINAL inline
+        // values instead of blindly removing them — blind removeProperty
+        // destroyed page-authored inline top/padding-top and left the layout
+        // corrupted after the banner closed.
+        for (const [el, saved] of modifiedElements) {
+            restoreInline(el, "top", saved.top);
+            restoreInline(el, "padding-top", saved.paddingTop);
         }
         modifiedElements.clear();
     }
@@ -258,46 +285,46 @@ function adjustPageForBanner(): void {
     if (!banner) return;
     const inner = banner.firstElementChild as HTMLElement | null;
     const bannerHeight = inner?.offsetHeight || 35;
+    const setupPrompt = document.getElementById(SETUP_HOST_ID);
 
-    // Make space for the banner at the top of the body
+    // The body padding-top must be applied BEFORE measuring sticky elements:
+    // their getBoundingClientRect().top depends on it (fixed-element writes,
+    // below, do not — fixed boxes are out of flow). So we write body padding
+    // first, then do a single batched READ pass, then a single batched WRITE
+    // pass. This yields two layout flushes total instead of the per-element
+    // read/write thrash the old sticky loop caused.
+    rememberOriginal(document.body);
     document.body.style.setProperty("padding-top", `${bannerHeight}px`, "important");
 
-    // Gather fixed elements and push them down (skip our own UI elements)
-    const setupPrompt = document.getElementById(SETUP_HOST_ID);
-    const fixedElements = Array.from(document.querySelectorAll<HTMLElement>("*")).filter(
-        (el) =>
-            el !== banner &&
-            el !== inner &&
-            !setupPrompt?.contains(el) &&
-            window.getComputedStyle(el).position === "fixed"
-    );
-    for (const el of fixedElements) {
-        if (isSheets) {
-            // Only shift top-anchored elements; skip bottom-anchored ones (sheet tabs bar)
-            const cs = window.getComputedStyle(el);
-            const hasBottom = cs.bottom !== "auto" && parseInt(cs.bottom) >= 0;
-            if (hasBottom && parseInt(cs.bottom) < 50) continue;
-            const currentTop = parseInt(cs.top) || 0;
-            el.style.setProperty("top", `${currentTop + bannerHeight}px`, "important");
-        } else {
-            el.style.setProperty("padding-top", `${bannerHeight}px`, "important");
+    // ── READ phase: one querySelectorAll("*"); classify + measure, no writes. ──
+    interface Adjustment { el: HTMLElement; prop: "top" | "padding-top"; value: string; }
+    const adjustments: Adjustment[] = [];
+    for (const el of document.querySelectorAll<HTMLElement>("*")) {
+        if (el === banner || el === inner || setupPrompt?.contains(el)) continue;
+        const cs = window.getComputedStyle(el);
+        const position = cs.position;
+        if (position === "fixed") {
+            if (isSheets) {
+                // Only shift top-anchored elements; skip bottom-anchored ones (sheet tabs bar)
+                const hasBottom = cs.bottom !== "auto" && parseInt(cs.bottom) >= 0;
+                if (hasBottom && parseInt(cs.bottom) < 50) continue;
+                const currentTop = parseInt(cs.top) || 0;
+                adjustments.push({ el, prop: "top", value: `${currentTop + bannerHeight}px` });
+            } else {
+                adjustments.push({ el, prop: "padding-top", value: `${bannerHeight}px` });
+            }
+        } else if (position === "sticky") {
+            const top = el.getBoundingClientRect().top;
+            const threshold = parseInt(cs.top);
+            const value = (top < bannerHeight || top <= threshold) ? `${bannerHeight}px` : "0px";
+            adjustments.push({ el, prop: "padding-top", value });
         }
-        modifiedElements.add(el);
     }
 
-    // Gather sticky elements and conditionally push them down
-    const stickyElements = Array.from(document.querySelectorAll<HTMLElement>("*")).filter(
-        (el) => el !== banner && el !== inner && window.getComputedStyle(el).position === "sticky"
-    );
-    for (const el of stickyElements) {
-        const position = el.getBoundingClientRect().top;
-        const threshold = parseInt(window.getComputedStyle(el).top);
-        if (position < bannerHeight || position <= threshold) {
-            el.style.setProperty("padding-top", `${bannerHeight}px`, "important");
-        } else {
-            el.style.setProperty("padding-top", "0px", "important");
-        }
-        modifiedElements.add(el);
+    // ── WRITE phase: remember originals, then apply. No interleaved reads. ──────
+    for (const { el, prop, value } of adjustments) {
+        rememberOriginal(el);
+        el.style.setProperty(prop, value, "important");
     }
 }
 
@@ -872,6 +899,17 @@ function attachTabDrag(tab: HTMLElement): void {
   };
 }
 
+/** A node FLoRA itself injected (badge, pill, panel, tab, …) — id/class flora-*. */
+function isFloraOwnedNode(node: Node): boolean {
+  if (node.nodeType !== Node.ELEMENT_NODE) return true; // text/comment — not layout-relevant here
+  const el = node as Element;
+  if (el.id.startsWith("flora-")) return true;
+  for (const c of el.classList) {
+    if (c.startsWith("flora-")) return true;
+  }
+  return false;
+}
+
 function setupTabPositioning(tab: HTMLElement): void {
   cleanupTabPositioning();
   positionTabOnRightEdge(tab);
@@ -884,8 +922,27 @@ function setupTabPositioning(tab: HTMLElement): void {
     debounceTimer = setTimeout(() => positionTabOnRightEdge(tab), 200);
   };
 
+  // The reposition sweep (querySelectorAll("*") + geometry per element) is
+  // expensive, so only run it for mutations that can actually change the
+  // right-edge layout: EXTERNAL, non-FLoRA nodes being added/removed. Without
+  // this filter every FLoRA injection (and our own badge churn) retriggered the
+  // whole sweep. Placement is idempotent, so running it less often yields the
+  // identical final position.
+  const onMutations = (mutations: MutationRecord[]): void => {
+    if (_customTabTop !== null) return;
+    if (!tab.isConnected) return;
+    const relevant = mutations.some((m) => {
+      // Ignore mutations that happen inside a FLoRA container.
+      if ((m.target as Element).closest?.('[id^="flora-"]')) return false;
+      for (const n of m.addedNodes) if (!isFloraOwnedNode(n)) return true;
+      for (const n of m.removedNodes) if (!isFloraOwnedNode(n)) return true;
+      return false;
+    });
+    if (relevant) reposition();
+  };
+
   // subtree:true catches plugins that inject into nested containers
-  _tabPositionObserver = new MutationObserver(reposition);
+  _tabPositionObserver = new MutationObserver(onMutations);
   _tabPositionObserver.observe(document.body, { childList: true, subtree: true });
 
   _tabResizeHandler = reposition;

--- a/src/content-general/references.ts
+++ b/src/content-general/references.ts
@@ -31,11 +31,16 @@ import type {DoiString} from "@shared/types";
  * right after the entry's last link so it sits inline with that row. Falls
  * back to the entry end only when the entry has no links at all.
  */
+// textContent throughout (never innerText): these run per reference entry on
+// every mutation pass, and innerText forces a layout reflow for every
+// descendant of every entry. textContent yields the same relative lengths for
+// selecting the container, without the reflow.
 function findSmallestTextContainer(root: HTMLElement, needle: string): HTMLElement | null {
     let best: HTMLElement | null = null;
     let bestLen = Infinity;
     for (const el of root.querySelectorAll<HTMLElement>("*")) {
-        const t = el.innerText ?? el.textContent ?? "";
+        const t = el.textContent ?? "";
+        // Cheap bound: skip descendants that cannot host the needle.
         if (!t.includes(needle)) continue;
         if (t.length < bestLen) {
             best = el;
@@ -48,13 +53,17 @@ function findSmallestTextContainer(root: HTMLElement, needle: string): HTMLEleme
 // Descendant with ≥50% but <100% of the entry's text — the citation body,
 // excluding trailing action-link rows ("Article | Google Scholar").
 function findCitationBody(entry: HTMLElement): HTMLElement | null {
-    const entryText = (entry.innerText ?? entry.textContent ?? "").trim();
+    const entryText = (entry.textContent ?? "").trim();
     if (entryText.length < 40) return null;
     const floor = Math.floor(entryText.length * 0.5);
     let best: HTMLElement | null = null;
     let bestLen = 0;
     for (const el of entry.querySelectorAll<HTMLElement>("*")) {
-        const t = (el.innerText ?? el.textContent ?? "").trim();
+        const raw = el.textContent ?? "";
+        // Cheap bound: an element shorter than the floor (untrimmed length is an
+        // upper bound after trimming) can never qualify — skip before trimming.
+        if (raw.length < floor) continue;
+        const t = raw.trim();
         if (t.length >= floor && t.length < entryText.length && t.length > bestLen) {
             best = el;
             bestLen = t.length;

--- a/src/content-general/scan-gate.ts
+++ b/src/content-general/scan-gate.ts
@@ -1,0 +1,58 @@
+// Cheap per-mutation gating for the general content script's render handler.
+//
+// The general content script runs on <all_urls> and its full extraction
+// pipeline is expensive. These pure helpers let the handler decide, without
+// touching the whole DOM, whether a mutation pass is worth a full scan:
+//
+//  - `couldNodeIntroduceDoi` — a sound, cheap probe over a freshly-added node:
+//    could it have brought a DOI onto the page? Used by the relevance pre-gate.
+//  - `scanFingerprint` — a cheap fingerprint of the scanned page state, used to
+//    skip a pass whose inputs are unchanged since the last one.
+
+// Word-break characters some sites inject *inside* tokens (a DOI wrapped across
+// a line). Stripped before probing so "10.​1234…" still matches.
+const WORD_BREAK = /[\u200B\u200C\u200D\u00AD\u2060]/g;
+
+// "10." + 4+ digits is the registrant prefix that begins every serialised DOI,
+// whether it appears in visible text, an href, or a meta value. It is therefore
+// a *necessary* substring of any DOI occurrence, while having far fewer false
+// positives than a bare "doi" search. That makes it a sound relevance probe:
+// if a DOI was added, this matches; if this does not match, no DOI was added.
+export const DOI_HINT_RE = /10\.\d{4}/;
+
+/**
+ * Could this freshly-added node have introduced a DOI anywhere within it?
+ *
+ * Sound (never a false negative for a real DOI): for element nodes it tests the
+ * subtree's `outerHTML`, which contains all descendant text, href attributes,
+ * and meta `content` values — every place a DOI can be serialised. The cost is
+ * bounded by the size of what was added, never the whole page.
+ */
+export function couldNodeIntroduceDoi(node: Node): boolean {
+  if (node.nodeType === Node.TEXT_NODE) {
+    return DOI_HINT_RE.test((node.nodeValue ?? "").replace(WORD_BREAK, ""));
+  }
+  if (node.nodeType !== Node.ELEMENT_NODE) return false;
+  return DOI_HINT_RE.test((node as Element).outerHTML.replace(WORD_BREAK, ""));
+}
+
+/**
+ * Cheap fingerprint of the page's scanned state.
+ *
+ * `body.textContent` does NOT force a layout reflow (unlike `innerText`), so
+ * this is cheap relative to the full pipeline it guards. The placed-UI count is
+ * folded in so that a mutation which merely wipes a FLoRA badge — leaving the
+ * light-DOM text unchanged — still changes the fingerprint and triggers a
+ * restoring pass instead of being memo-skipped.
+ */
+export function scanFingerprint(doc: Document = document): string {
+  const text = doc.body?.textContent ?? "";
+  let h = 5381;
+  for (let i = 0; i < text.length; i++) {
+    h = (((h << 5) + h) ^ text.charCodeAt(i)) | 0;
+  }
+  const floraCount = doc.querySelectorAll(
+    ".flora-inline-badge,.flora-doi-label,.flora-notice-pill",
+  ).length;
+  return `${text.length}:${h}:${floraCount}`;
+}

--- a/src/shared/doi-extractor.ts
+++ b/src/shared/doi-extractor.ts
@@ -14,9 +14,9 @@ const SUFFIX_CHARS = `[^\\s,/\\]}>'"<#?&\\\\]`;
 const EXTRA_SLASH = `(?:\\/(?![a-zA-Z-]+(?:[/\\s,#?&<>{}\\[\\]]|$))${SUFFIX_CHARS}+)*`;
 const DOI_REGEX = new RegExp(`(10\\.\\d{4,}(?:\\.\\d+)*\\/${SUFFIX_CHARS}+${EXTRA_SLASH})`, "g");
 
-// For visible body text only — innerText contains no HTML tags, so < and >
-// appear as literal characters (e.g. SICI DOIs decoded from &lt; / &gt; HTML
-// entities). We allow them here so that DOIs like
+// For rendered body text only (textContent/innerText) — such text contains no
+// HTML tags, so < and > appear as literal characters (e.g. SICI DOIs decoded
+// from &lt; / &gt; HTML entities). We allow them here so that DOIs like
 // 10.1002/(SICI)...18:4<303::AID-SMJ869>3.0.CO;2-G are not truncated at '<'.
 const TEXT_SUFFIX_CHARS = `[^\\s,/\\]'"#?&\\\\]`;
 const TEXT_EXTRA_SLASH = `(?:\\/(?![a-zA-Z-]+(?:[/\\s,#?&<>{}\\[\\]]|$))${TEXT_SUFFIX_CHARS}+)*`;
@@ -369,7 +369,10 @@ export function extractDoiOccurrences(doc: Document): DoiOccurrence[] {
     // there would serialize FLoRA markup into the user's saved document.
     if (isEditableContext(link)) continue;
     const textDois = new Set<DoiString>();
-    const linkText = link.innerText || link.textContent || "";
+    // textContent (not innerText) — innerText forces a synchronous layout
+    // reflow; a link's text has no block-boundary whitespace concerns, so
+    // textContent yields the same DOI tokens without the reflow cost.
+    const linkText = link.textContent || "";
     const cleaned = decodeEncodedDois(linkText.replace(WORD_BREAK_CHARS, ""));
     for (const match of cleaned.matchAll(DOI_TEXT_REGEX)) {
       const raw = cleanDoiTrailing(match[1]);
@@ -432,7 +435,13 @@ export function extractDoiOccurrences(doc: Document): DoiOccurrence[] {
 }
 
 function extractFromVisibleText(doc: Document, found: Set<DoiString>): void {
-  const rawText = doc.body?.innerText || doc.body?.textContent || "";
+  // textContent, NOT innerText: innerText forces a full synchronous layout
+  // reflow of the whole page (the headline per-mutation cost). textContent is
+  // a superset that also includes visually-hidden text — but this set only
+  // decides which DOIs to *look up*, never where UI is placed. Badge/pill
+  // placement is gated by isVisible() at render time, so surfacing a hidden
+  // DOI here cannot make a badge appear on hidden text.
+  const rawText = doc.body?.textContent || "";
   // Strip invisible word-break characters that sites insert for overflow-wrap/break-word
   // and decode any percent-encoded DOIs
   const bodyText = decodeEncodedDois(rawText.replace(WORD_BREAK_CHARS, ""));
@@ -571,7 +580,7 @@ function extractDoiFromEntry(
   // buttons ("View", "Cite", "Add to favorites") that point at the current
   // article, not the cited/citing paper — using them first caused every
   // Wiley cited-by row to resolve to the host article's own DOI.
-  const text = entry.innerText ?? entry.textContent ?? "";
+  const text = entry.textContent ?? "";
   const cleaned = decodeEncodedDois(text.replace(WORD_BREAK_CHARS, ""));
   for (const match of cleaned.matchAll(DOI_TEXT_REGEX)) {
     const raw = cleanDoiTrailing(match[1]);
@@ -673,7 +682,7 @@ export function findReferenceEntries(doc: Document): ReferenceEntry[] {
       element,
       doi,
       doiInText: inText,
-      text: cleanReferenceText(element.innerText ?? element.textContent ?? ""),
+      text: cleanReferenceText(element.textContent ?? ""),
     };
   });
 }
@@ -686,8 +695,9 @@ function extractFromReferenceContainers(doc: Document, found: Set<DoiString>): v
       const doi = extractDoiFromHref(link.href);
       if (doi) found.add(doi);
     }
-    // Visible text inside the container
-    const text = (container as HTMLElement).innerText ?? container.textContent ?? "";
+    // Visible text inside the container (textContent, not innerText — avoids a
+    // layout reflow; placement stays visibility-gated at render time).
+    const text = container.textContent ?? "";
     const cleaned = decodeEncodedDois(text.replace(WORD_BREAK_CHARS, ""));
     for (const match of cleaned.matchAll(DOI_TEXT_REGEX)) {
       const raw = cleanDoiTrailing(match[1]);
@@ -729,7 +739,7 @@ function pageTypeFromPath(doc: Document): PageType {
  *
  * Also returns the detected page type.
  */
-export function classifyPageDois(doc: Document): ClassifiedDois {
+export function classifyPageDois(doc: Document, occurrences?: DoiOccurrence[]): ClassifiedDois {
   // Article DOIs (authoritative sources) — scanned once, reused below.
   const articleFound = new Set<DoiString>();
   extractFromUrl(doc, articleFound);
@@ -743,8 +753,19 @@ export function classifyPageDois(doc: Document): ClassifiedDois {
 
   // Remaining page-wide DOIs — seed from the article set to avoid re-scanning.
   const pageWide = new Set<DoiString>(articleFound);
-  extractFromDoiLinks(doc, pageWide);
-  extractFromVisibleText(doc, pageWide);
+  if (occurrences) {
+    // Single-scan path: reuse the position-aware occurrences already computed
+    // for this pass instead of a second a[href] sweep + a full body-text read.
+    // Occurrences capture every DOI that can be located on the page (link text,
+    // doi.org/embedded hrefs, and prose text nodes), which is exactly the set
+    // that drives lookup + placement. DOIs that occurrences deliberately skip
+    // (editable regions, or a DOI split across sibling text nodes) are ones we
+    // never render anyway, so omitting them from the lookup set is safe.
+    for (const occ of occurrences) pageWide.add(occ.doi);
+  } else {
+    extractFromDoiLinks(doc, pageWide);
+    extractFromVisibleText(doc, pageWide);
+  }
 
   // Other = everything not already classified
   const otherFound = new Set<DoiString>();

--- a/tests/unit/scan-gate.test.ts
+++ b/tests/unit/scan-gate.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from "vitest";
+import { JSDOM } from "jsdom";
+import { couldNodeIntroduceDoi, scanFingerprint, DOI_HINT_RE } from "../../src/content-general/scan-gate";
+import { extractDoiOccurrences } from "../../src/shared/doi-extractor";
+
+function docFrom(html: string): Document {
+  return new JSDOM(`<!DOCTYPE html><html><body>${html}</body></html>`).window.document;
+}
+
+// Build a detached node the way a mutation observer would hand it to us.
+function nodeFrom(html: string): ChildNode {
+  const doc = docFrom(html);
+  return doc.body.firstChild as ChildNode;
+}
+
+describe("couldNodeIntroduceDoi — the relevance pre-gate probe", () => {
+  it("is true for a text node containing a DOI", () => {
+    const t = docFrom("").createTextNode("see 10.1038/nature12373 for details");
+    expect(couldNodeIntroduceDoi(t)).toBe(true);
+  });
+
+  it("is true for an element with a DOI in visible text", () => {
+    expect(couldNodeIntroduceDoi(nodeFrom("<p>doi:10.1371/journal.pone.0012345</p>"))).toBe(true);
+  });
+
+  it("is true for an element whose DOI is only in an href (no visible DOI text)", () => {
+    // A reference link whose text is truncated but href carries the DOI — the
+    // probe must see it via outerHTML or the DOI would escape detection.
+    expect(
+      couldNodeIntroduceDoi(nodeFrom('<a href="https://doi.org/10.1002/jaba.70048">read more</a>')),
+    ).toBe(true);
+  });
+
+  it("is true for a DOI embedded in a publisher landing-page URL", () => {
+    expect(
+      couldNodeIntroduceDoi(nodeFrom('<a href="https://example.com/doi/10.1016/j.cell.2020.01.001/full">link</a>')),
+    ).toBe(true);
+  });
+
+  it("is true for a DOI split by a zero-width character in the registrant", () => {
+    // Some sites inject zero-width break chars mid-token; the probe strips them.
+    const zwsp = "\u200B";
+    expect(couldNodeIntroduceDoi(nodeFrom(`<span>10.${zwsp}1038/nature12373</span>`))).toBe(true);
+  });
+
+  it("is false for ordinary content with no DOI", () => {
+    expect(couldNodeIntroduceDoi(nodeFrom("<div><p>Inbox (42)</p><p>Meeting at 9am</p></div>"))).toBe(false);
+  });
+
+  it("is false for short decimals that are not DOI registrants ($10.50, v10.2)", () => {
+    // Requires 4+ digits after "10." — a real registrant — so prices/versions
+    // do not trigger a full scan.
+    expect(couldNodeIntroduceDoi(nodeFrom("<p>Total: $10.50 for version 10.2</p>"))).toBe(false);
+  });
+
+  it("is false for comment nodes", () => {
+    const c = docFrom("").createComment("10.1038/nature12373");
+    expect(couldNodeIntroduceDoi(c)).toBe(false);
+  });
+});
+
+describe("gate invariant — a page that becomes relevant later IS detected", () => {
+  it("flips from irrelevant to relevant when a DOI-bearing node is added", () => {
+    // Simulate the observer's per-node decision: a busy, DOI-free page, then a
+    // late mutation that injects an article reference carrying a DOI.
+    const irrelevant = nodeFrom("<div class='email'><p>Re: lunch</p><p>Sounds good!</p></div>");
+    expect(couldNodeIntroduceDoi(irrelevant)).toBe(false);
+
+    const relevantLater = nodeFrom(
+      "<li class='ref'>Smith et al. (2020). A study. <a href='https://doi.org/10.1234/abcd'>DOI</a></li>",
+    );
+    // The pre-gate would NOT bail on this mutation → the full pipeline runs and
+    // the DOI is detected. This is the "content loads late" correctness case.
+    expect(couldNodeIntroduceDoi(relevantLater)).toBe(true);
+  });
+
+  it("gate + pipeline: a DOI added by mutation passes the gate AND is extracted", () => {
+    // Full invariant, end to end at the unit level: start with an irrelevant
+    // page (fingerprint recorded, no DOIs), mutate in a DOI-bearing node, and
+    // check every layer agrees the page must now be (re)scanned and the DOI is
+    // actually found by the shared-scan pipeline.
+    const doc = docFrom("<div id='feed'><p>Just chatter, nothing scholarly.</p></div>");
+    const fpBefore = scanFingerprint(doc);
+    expect(extractDoiOccurrences(doc)).toHaveLength(0);
+
+    const added = doc.createElement("p");
+    added.innerHTML = "New citation: <a href='https://doi.org/10.1038/nature12373'>10.1038/nature12373</a>";
+    doc.getElementById("feed")!.appendChild(added);
+
+    // 1. The observer's probe flags the added node → pre-gate does NOT bail.
+    expect(couldNodeIntroduceDoi(added)).toBe(true);
+    // 2. The fingerprint changed → the memo does NOT skip the pass.
+    expect(scanFingerprint(doc)).not.toBe(fpBefore);
+    // 3. The single-scan pipeline finds the DOI on the mutated page.
+    const occs = extractDoiOccurrences(doc);
+    expect(occs.map((o) => o.doi)).toContain("10.1038/nature12373");
+  });
+
+  it("DOI_HINT_RE matches every serialised DOI form it is meant to gate on", () => {
+    for (const s of [
+      "10.1038/nature12373",
+      "https://doi.org/10.1002/jaba.70048",
+      "doi:10.1371/journal.pone.0012345",
+      "?identifierValue=10.1016/j.cell.2020.01.001",
+    ]) {
+      expect(DOI_HINT_RE.test(s)).toBe(true);
+    }
+  });
+});
+
+describe("scanFingerprint — skip-unchanged memoization", () => {
+  it("is stable when the page is unchanged", () => {
+    const doc = docFrom("<article><h1>Title</h1><p>Body with 10.1000/xyz</p></article>");
+    expect(scanFingerprint(doc)).toBe(scanFingerprint(doc));
+  });
+
+  it("changes when body text changes (same length, different chars)", () => {
+    const a = docFrom("<p>hello world AAAA</p>");
+    const b = docFrom("<p>hello world BBBB</p>");
+    expect(scanFingerprint(a)).not.toBe(scanFingerprint(b));
+  });
+
+  it("changes when text length changes", () => {
+    const a = docFrom("<p>short</p>");
+    const b = docFrom("<p>a much longer paragraph of text</p>");
+    expect(scanFingerprint(a)).not.toBe(scanFingerprint(b));
+  });
+
+  it("changes when a FLoRA badge is wiped even though light-DOM text is identical", () => {
+    // A SPA re-render can remove a placed badge (a shadow-DOM host with no
+    // light-DOM text) while leaving the article text byte-identical. Folding the
+    // placed-UI count into the fingerprint ensures such a pass is NOT skipped,
+    // so the badge gets restored.
+    const doc = docFrom("<article><p>Body with 10.1000/xyz</p></article>");
+    const before = scanFingerprint(doc);
+    const badge = doc.createElement("span");
+    badge.className = "flora-inline-badge";
+    doc.querySelector("article")!.appendChild(badge);
+    const withBadge = scanFingerprint(doc);
+    expect(withBadge).not.toBe(before);
+    // Wiping the badge (identical light-DOM text) returns to the pre-badge count,
+    // which differs from the with-badge fingerprint → the restoring pass runs.
+    badge.remove();
+    expect(scanFingerprint(doc)).toBe(before);
+    expect(scanFingerprint(doc)).not.toBe(withBadge);
+  });
+});


### PR DESCRIPTION
**Stacks on #98** (editable guard) → #97 (visual harness) — merge those first.

## Problem

The general content script runs on `<all_urls>` and re-ran its full extraction pipeline on every debounced mutation pass — roughly 3×/second, indefinitely, on busy SPAs like Gmail or Twitter. Each pass did 3–4 independent full-DOM traversals: `querySelectorAll("[class],[id]")` over the whole document, two to three `a[href]` sweeps, a TreeWalk of every text node, and — worst — a `body.innerText` read, which forces a synchronous whole-page reflow. The `hasDoiChange` gate only guarded network work, never the scans. Separately, the side-panel tab positioner's body observer had no FLoRA-owned-node filter (our own injections re-triggered its `querySelectorAll("*")` geometry sweep), the banner adjuster interleaved layout reads and writes per element, and `removeBanner` destroyed pages' original inline `top`/`padding-top` values.

## Fix

1. **Relevance pre-gate** (`scan-gate.ts`): the mutation observer probes each added external node for the DOI registrant prefix (`10.\d{4}` — a *necessary* substring of any serialised DOI, so the probe can't false-negative) and passes a hint; pages that never yielded a DOI and aren't scholarly bail before touching the DOM. Documented invariant: the initial pass is ungated, any later DOI arrives in an added subtree the probe sees, the first DOI from any source latches the gate open for the page's life, and tab re-shows/SPA navigations re-run ungated — **no DOI-bearing content can permanently escape detection**.
2. **Skip-unchanged memo**: a cheap fingerprint (`textContent` length + hash + placed-FLoRA-UI count, so a wiped badge still triggers the restoring pass) skips passes whose input didn't change.
3. **One scan per pass**: classification, badge placement, and the post-lookup "still in DOM" recheck now share a single occurrence scan; all extraction `innerText` reads became `textContent` (visibility is enforced at placement time, where it always was). Zero layout-forcing reads remain in per-mutation paths (one cold-path `innerText` *write* on a detached node survives, in the retraction modal builder).
4. **Tab positioner** ignores FLoRA-owned mutations (same filter as the main observer).
5. **Banner**: one element sweep, reads batched before writes, and `removeBanner` now *restores* each element's original inline styles instead of deleting them.

## Numbers

`npm run bench:scan-gating` (in-repo benchmark: builds the actual base branch and this branch, loads each as a real extension in Chrome for Testing, hermetic mocks, 20 synthetic mutations @ 400 ms on a 1.8 MB DOI-free "Gmail-like" page):

- **Before:** 924–1309 ms of main-thread handler time (46–65 ms/pass)
- **After:** 78 ms (3.9 ms/pass) — **~12–17× less**, every pass pre-gate-bailed
- DOI-bearing article page: still fully scans every pass (9.5 ms total/20 passes) and stays badged.

## Verification

221 unit tests green (new: probe soundness, fingerprint skip/no-skip, and a "page becomes relevant later" end-to-end gate test), `tsc` clean, and **all 11 visual fixtures pass at 0 px with zero baseline changes, run twice** — rendering is provably unchanged.

Out of scope by design: concurrency/idempotence restructuring and placement-strategy changes (follow-up PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)