### PR TITLE
Add configurable PubPeer commenter muting & panel stability

### DIFF
--- a/src/content-general/dom-listener.ts
+++ b/src/content-general/dom-listener.ts
@@ -2,8 +2,6 @@ import {containsDoiCandidate} from "@shared/doi-extractor";
 import {isExternalMutation, isFloraOwnedNode} from "@shared/flora-ui";
 import {debugLog} from "@shared/debug";
 
-// Above this many added subtrees in one debounce window, probing each one costs
-// more than the scan it is trying to avoid.
 const MAX_INCREMENTAL_NODES = 50;
 
 const DEBOUNCE_MS = 300;
@@ -18,18 +16,10 @@ export function scanAddedNodes(nodes: Element[]): boolean {
 }
 
 export interface DomListenerOptions {
-    /** Full-page rescan. Run for the initial load, SPA navigation, structural
-     *  changes, and any mutation that brings DOI-like content onto the page. */
     scanWholePage: () => void;
     /** Current URL as of the last full scan — a change means SPA navigation. */
     getLastUrl: () => string;
 }
-
-/**
- * Watch the page for changes worth rescanning. Mutations that carry no DOI-like
- * content — ads, cookie banners, chat widgets, SPA chrome — are dropped after a
- * cheap per-node probe instead of triggering a full document extraction.
- */
 export function startDomListener({scanWholePage, getLastUrl}: DomListenerOptions): MutationObserver {
     let debounceTimer: ReturnType<typeof setTimeout>;
     let pendingNodes: Element[] = [];
@@ -40,7 +30,6 @@ export function startDomListener({scanWholePage, getLastUrl}: DomListenerOptions
         const full = pendingFullScan;
         pendingNodes = [];
         pendingFullScan = false;
-        // SPA navigation resets all page state, so it always needs a full pass.
         if (full || location.href !== getLastUrl() || scanAddedNodes(nodes)) {
             scanWholePage();
         } else {
@@ -55,7 +44,6 @@ export function startDomListener({scanWholePage, getLastUrl}: DomListenerOptions
         for (const m of mutations) {
             if (!isExternalMutation(m)) continue;
             hasExternalChange = true;
-            // A re-render of the page shell can't be reasoned about node by node.
             if (m.target === document.body || m.target === document.documentElement) {
                 pendingFullScan = true;
             }

--- a/src/content-general/index.ts
+++ b/src/content-general/index.ts
@@ -125,7 +125,6 @@ async function primaryDoiFastPath(): Promise<void> {
         const request: LookupRequest = {type: "FLORA_LOOKUP", dois: [primary]};
         const response = await safeSendMessage<LookupResponse>(request);
         if (!response) {
-            // Extension context invalidated (reload/update) — stale script.
             rollback();
             return;
         }
@@ -755,7 +754,6 @@ async function fetchSheetDois(): Promise<void> {
             // Start the article's own lookup off URL/meta/JSON-LD, then let the
             // full scan wait for idle rather than competing with page render.
             void primaryDoiFastPath();
-            // Static pages may never trigger the MutationObserver.
             whenIdle(() => void scanWholePage());
             // Defer the observer until full load so load-time mutations don't spam it.
             if (document.readyState === "complete") {

--- a/src/content-general/injector.ts
+++ b/src/content-general/injector.ts
@@ -377,8 +377,6 @@ export function renderInlineBadges(
 
         const badgeHost = document.createElement("span");
         badgeHost.className = BADGE_CLASS;
-        // Keyed on the occurrence DOI (the pageState key), not the result's
-        // echoed DOI, so anchorAlreadyBadged matches what it is asked about.
         badgeHost.setAttribute("data-flora-doi", occ.doi);
         const shadow = badgeHost.attachShadow({mode: "open"});
 
@@ -912,6 +910,34 @@ function setupTabPositioning(tab: HTMLElement): void {
   window.addEventListener("resize", reposition, { passive: true });
 }
 
+/** Stable string describing everything the side panel renders. */
+function panelSignature(
+  primary: PubPeerFeedback | null,
+  references: { doi: DoiString; title: string }[],
+  articleDois: DoiString[],
+  pageState: Map<DoiString, LookupState>,
+  refFeedbackByDoi: Map<DoiString, PubPeerFeedback>,
+  retractionByDoi: Map<DoiString, RetractionResponse>
+): string {
+  const statsOf = (doi: DoiString): string => {
+    const s = pageState.get(doi);
+    if (s?.status !== "matched") return s?.status ?? "none";
+    const {n_replications_total, n_reproductions_total, n_originals_total} = s.result.record.stats;
+    return `${n_replications_total}/${n_reproductions_total}/${n_originals_total}`;
+  };
+  const noticeOf = (doi: DoiString): string => retractionByDoi.get(doi)?.kind ?? "";
+
+  const parts = [
+    `primary:${primary ? `${primary.url}#${primary.total_comments}` : "none"}`,
+    `article:${articleDois.map((d) => `${d}=${statsOf(d)}:${noticeOf(d)}`).sort().join(",")}`,
+    `refs:${references
+      .map((r) => `${r.doi}|${r.title}|${statsOf(r.doi)}|${noticeOf(r.doi)}|${refFeedbackByDoi.get(r.doi)?.total_comments ?? 0}`)
+      .sort()
+      .join(",")}`,
+  ];
+  return parts.join(";;");
+}
+
 export function renderSidePanel(
   articleFeedbacks: PubPeerFeedback[],
   references: { doi: DoiString; title: string }[],
@@ -926,8 +952,6 @@ export function renderSidePanel(
   // (e.g. `translateX(0)` → `translateX(0px)`). The marker is set in
   // openPanel/closePanel below so reading it here is always reliable.
   const wasOpen = existingHost?.dataset.floraPanelOpen === "1";
-  cleanupTabPositioning();
-  existingHost?.remove();
 
   const withComments = articleFeedbacks.filter((f) => f.total_comments > 0);
 
@@ -989,8 +1013,21 @@ export function renderSidePanel(
 
   if (primary && !isSafePubPeerUrl(primary.url)) return;
 
+  // Rebuilding recreates the <iframe>, reloading the embedded PubPeer thread.
+  const signature = panelSignature(
+    primary, references, articleDois, pageState, refFeedbackByDoi, retractionByDoi
+  );
+  if (existingHost && existingHost.dataset.floraPanelSig === signature) {
+    debugLog("renderSidePanel: unchanged — kept existing panel");
+    return;
+  }
+
+  cleanupTabPositioning();
+  existingHost?.remove();
+
   const host = document.createElement("div");
   host.id = PUBPEER_PANEL_ID;
+  host.dataset.floraPanelSig = signature;
 
   const hostStyle = document.createElement("style");
   hostStyle.textContent = `

--- a/src/content-pubpeer/index.ts
+++ b/src/content-pubpeer/index.ts
@@ -1,19 +1,13 @@
-// PubPeer iframe script.
-//
-// FLoRA embeds pubpeer.com in an iframe inside its side panel. This script runs
-// only in that embedded frame: it strips PubPeer's own chrome, hides comments
-// from bot/org accounts, and reports the content height back to the panel so it
-// can size the iframe.
-//
-// It is deliberately separate from content-general so the (much larger) general
-// script no longer has to be injected into every frame of every page — see
-// issue #84.
+// Runs in the pubpeer.com iframe embedded in FLoRA's side panel. Separate from
+// content-general so that script needn't be injected into every frame.
 
-// PubPeer commenter IDs whose comments are hidden in the embedded iframe.
-// Add any bot/org account ID here to suppress its annotations from the panel.
-const HIDDEN_PUBPEER_COMMENTER_IDS = new Set([
-    "FORRT",
-]);
+import {
+    applyCommenterFilter,
+    getHiddenCommenters,
+    onHiddenCommentersChanged
+} from "@shared/pubpeer-filter";
+
+let hiddenCommenters: string[] = [];
 
 const PANEL_CSS = "body.top-navigation{overflow:hidden!important;} nav, .breadcrumb, ol.breadcrumb, div.forum-sub-title, div.sticky.affix, div.sticky.affix-top, div.extension-installer.container, div.footer.fixed, div.page-component-up, a.forum-item-title { display: none !important; } div.vertical-timeline-block {margin:0 15px 0px 10px;} div.selected div {background-color: transparent!important;} div.wrapper {width: 500px!important;} ul.nav.nav-tabs>li>a{color:#fff!important;} ul.nav.nav-tabs>li:nth-child(2).active>a{color:#853953!important;} ul.nav.nav-tabs>li:nth-child(1).active>a{color:#853953!important;} .ibox-title div, .ibox-title strong, .ibox-title span, .ibox-title em, .ibox-content a{color:#853953!important;}  .all-user-footer div:nth-child(1){visibility:hidden;} .el-button{background-color:#853953!important; border-color:#853953!important;} .ibox-bordered:before{background-color:#853953!important;} .btn-link.manual-file-chooser-text{color:#853953!important;}  .el-button.el-button--text{background:transparent!important;border-color:transparent!important;color:#853953!important;}}";
 
@@ -36,29 +30,19 @@ if (window !== window.top) {
         }
     };
 
-    const hideTaggedComments = (root: Node = document.body): void => {
-        if (!root) return;
-        const el = root instanceof Element ? root : root.parentElement;
-        if (!el) return;
-        for (const strong of el.querySelectorAll<HTMLElement>("strong.inner-id[id]")) {
-            if (!HIDDEN_PUBPEER_COMMENTER_IDS.has(strong.id)) continue;
-            // .vertical-timeline-content is the full comment block (header + body + footer).
-            const commentBlock = strong.closest(".vertical-timeline-content");
-            if (commentBlock) (commentBlock as HTMLElement).style.display = "none";
-        }
-    };
+    const filterAll = (): void => applyCommenterFilter(document.body, hiddenCommenters);
 
     const observer = new MutationObserver((mutations) => {
         for (const m of mutations) {
             for (const n of m.addedNodes) {
                 stripCommentAccepted(n);
-                hideTaggedComments(n);
+                applyCommenterFilter(n, hiddenCommenters);
             }
         }
     });
     const startStripping = (): void => {
         stripCommentAccepted();
-        hideTaggedComments();
+        filterAll();
         observer.observe(document.body, {childList: true, subtree: true});
     };
     if (document.readyState === "loading") {
@@ -66,6 +50,15 @@ if (window !== window.top) {
     } else {
         startStripping();
     }
+
+    void getHiddenCommenters().then((ids) => {
+        hiddenCommenters = ids;
+        filterAll();
+    });
+    onHiddenCommentersChanged((ids) => {
+        hiddenCommenters = ids;
+        filterAll();
+    });
 
     const sendHeight = (): void => {
         const h = Math.max(document.body?.scrollHeight ?? 0, document.documentElement.scrollHeight);

--- a/src/options/index.html
+++ b/src/options/index.html
@@ -254,6 +254,58 @@
 
             <p id="domain-status-msg" class="status domain-status" hidden></p>
           </div>
+
+          <!-- ═══ PUBPEER COMMENTERS ═══ -->
+          <div class="detail-card" style="margin-top: 1.25rem">
+            <div class="dh">
+              <div class="dh-label">PubPeer Comments</div>
+              <h2 class="dh-title">Muted Commenters</h2>
+              <div class="dh-authors">
+                FLoRA shows PubPeer threads in its side panel. Add a commenter's
+                display name — the name shown on their comment, such as
+                <em>Statcheck</em> or a pseudonym like <em>Anolis Jacare</em> —
+                to hide their comments from that panel. FORRT is muted by
+                default because the panel already shows its data; remove it
+                below if you'd rather see those comments too.
+              </div>
+            </div>
+
+            <!-- Add muted commenter -->
+            <div class="action-bar domain-add-bar">
+              <div class="ab-group">
+                <label class="ab-label" for="commenter-input">Commenter</label>
+                <input
+                  id="commenter-input"
+                  type="text"
+                  class="ab-input"
+                  placeholder="Statcheck"
+                  autocomplete="off"
+                  spellcheck="false"
+                />
+              </div>
+              <div class="ab-sep"></div>
+              <div class="ab-group">
+                <button type="button" id="add-commenter-btn" class="ab-btn accent">
+                  <svg
+                    width="12"
+                    height="12"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                  >
+                    <path d="M12 5v14M5 12h14" />
+                  </svg>
+                  Mute
+                </button>
+              </div>
+            </div>
+
+            <!-- Muted commenter list -->
+            <div id="commenter-list" class="domain-list"></div>
+
+            <p id="commenter-status-msg" class="status domain-status" hidden></p>
+          </div>
         </div>
       </div>
     </div>

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -1,5 +1,10 @@
 import { getSettings, saveSettings } from "../shared/settings";
 import { getBlockedDomains, saveBlockedDomains } from "../shared/domains";
+import {
+  getHiddenCommenters,
+  isHiddenCommenter,
+  saveHiddenCommenters,
+} from "../shared/pubpeer-filter";
 
 // ── Email form ──────────────────────────────────────────────────────
 
@@ -178,4 +183,92 @@ domainInput.addEventListener("keydown", (e) => {
 getBlockedDomains().then((b) => {
   blocked = b;
   renderBlockedList();
+});
+
+// ── Muted PubPeer commenters ────────────────────────────────────────
+
+const commenterInput = document.getElementById("commenter-input") as HTMLInputElement;
+const addCommenterBtn = document.getElementById("add-commenter-btn") as HTMLButtonElement;
+const commenterList = document.getElementById("commenter-list") as HTMLDivElement;
+const commenterStatusMsg = document.getElementById("commenter-status-msg") as HTMLParagraphElement;
+
+let mutedCommenters: string[] = [];
+
+function renderCommenterList(): void {
+  commenterList.innerHTML = "";
+
+  if (mutedCommenters.length === 0) {
+    const empty = document.createElement("div");
+    empty.className = "domain-empty";
+    empty.textContent = "No commenters muted — all PubPeer comments are shown.";
+    commenterList.appendChild(empty);
+    return;
+  }
+
+  const sorted = [...mutedCommenters].sort((a, b) => a.localeCompare(b));
+
+  for (const id of sorted) {
+    const row = document.createElement("div");
+    row.className = "domain-row";
+
+    const label = document.createElement("span");
+    label.className = "domain-name";
+    label.textContent = id;
+
+    const removeBtn = document.createElement("button");
+    removeBtn.type = "button";
+    removeBtn.className = "domain-remove";
+    removeBtn.setAttribute("aria-label", `Unmute ${id}`);
+    removeBtn.innerHTML = "&times;";
+    removeBtn.addEventListener("click", () => unmuteCommenter(id));
+
+    row.appendChild(label);
+    row.appendChild(removeBtn);
+    commenterList.appendChild(row);
+  }
+}
+
+async function unmuteCommenter(id: string): Promise<void> {
+  mutedCommenters = mutedCommenters.filter((c) => c !== id);
+  await saveHiddenCommenters(mutedCommenters);
+  renderCommenterList();
+  showCommenterStatus(`Unmuted ${id}`, "success");
+}
+
+async function muteCommenter(): Promise<void> {
+  const id = commenterInput.value.trim();
+  if (!id) return;
+
+  if (isHiddenCommenter(id, mutedCommenters)) {
+    showCommenterStatus(`${id} is already muted.`, "error");
+    return;
+  }
+
+  mutedCommenters.push(id);
+  await saveHiddenCommenters(mutedCommenters);
+  commenterInput.value = "";
+  renderCommenterList();
+  showCommenterStatus(`Muted ${id}`, "success");
+}
+
+function showCommenterStatus(msg: string, type: "success" | "error"): void {
+  commenterStatusMsg.textContent = msg;
+  commenterStatusMsg.className = `status domain-status ${type}`;
+  commenterStatusMsg.hidden = false;
+  setTimeout(() => {
+    commenterStatusMsg.hidden = true;
+  }, 3000);
+}
+
+addCommenterBtn.addEventListener("click", muteCommenter);
+commenterInput.addEventListener("keydown", (e) => {
+  if (e.key === "Enter") {
+    e.preventDefault();
+    muteCommenter();
+  }
+});
+
+getHiddenCommenters().then((ids) => {
+  mutedCommenters = ids;
+  renderCommenterList();
 });

--- a/src/shared/doi-extractor.ts
+++ b/src/shared/doi-extractor.ts
@@ -381,19 +381,12 @@ export function extractDoiOccurrences(doc: Document): DoiOccurrence[] {
   return occurrences;
 }
 
-// Non-global so it carries no lastIndex state between calls.
 const DOI_PROBE_REGEX = /10\.\d{4,}/;
 
-/**
- * Cheap "could this subtree contain a DOI?" test, used to decide whether a DOM
- * mutation is worth a full-page scan. Over-inclusive on purpose: a false
- * positive costs a scan that would have happened anyway, a false negative
- * silently loses a DOI.
- */
+/** Cheap, over-inclusive test for whether a subtree could contain a DOI. */
 export function containsDoiCandidate(el: Element): boolean {
   const text = el.textContent ?? "";
   if (text.length >= 12 && DOI_PROBE_REGEX.test(text)) return true;
-  // A DOI can hide entirely in an href; every such URL contains "10.".
   if (el.matches?.('a[href*="10."]')) return true;
   return el.querySelector?.('a[href*="10."]') !== null;
 }

--- a/src/shared/pubpeer-filter.ts
+++ b/src/shared/pubpeer-filter.ts
@@ -1,0 +1,120 @@
+// Commenters muted in the embedded PubPeer panel, matched case-insensitively
+// on their PubPeer display name.
+
+const HIDDEN_COMMENTERS_KEY = "flora_hidden_pubpeer_commenters";
+
+export const DEFAULT_HIDDEN_COMMENTERS = ["FORRT"];
+
+let cachedHiddenCommenters: string[] | null = null;
+let listenerInstalled = false;
+
+function installInvalidation(): void {
+  if (listenerInstalled) return;
+  listenerInstalled = true;
+  try {
+    chrome.storage.onChanged?.addListener((changes, area) => {
+      if (area === "sync" && changes[HIDDEN_COMMENTERS_KEY]) {
+        cachedHiddenCommenters =
+          (changes[HIDDEN_COMMENTERS_KEY].newValue as string[] | undefined) ??
+          [...DEFAULT_HIDDEN_COMMENTERS];
+      }
+    });
+  } catch {
+    // Storage change events are unavailable in tests and some non-extension contexts.
+  }
+}
+
+/** Read the hidden-commenter list from chrome.storage.sync. */
+export async function getHiddenCommenters(): Promise<string[]> {
+  installInvalidation();
+  if (cachedHiddenCommenters) return cachedHiddenCommenters;
+  try {
+    const raw = await chrome.storage.sync.get(HIDDEN_COMMENTERS_KEY);
+    const stored = raw[HIDDEN_COMMENTERS_KEY] as string[] | undefined;
+    cachedHiddenCommenters = stored ?? [...DEFAULT_HIDDEN_COMMENTERS];
+    return cachedHiddenCommenters;
+  } catch {
+    cachedHiddenCommenters = [...DEFAULT_HIDDEN_COMMENTERS];
+    return cachedHiddenCommenters;
+  }
+}
+
+/** Persist the hidden-commenter list. */
+export async function saveHiddenCommenters(ids: string[]): Promise<void> {
+  cachedHiddenCommenters = ids;
+  await chrome.storage.sync.set({ [HIDDEN_COMMENTERS_KEY]: ids });
+}
+
+/** Subscribe to list changes. Returns an unsubscribe function. */
+export function onHiddenCommentersChanged(fn: (ids: string[]) => void): () => void {
+  const listener = (
+    changes: Record<string, chrome.storage.StorageChange>,
+    area: string
+  ): void => {
+    if (area !== "sync" || !changes[HIDDEN_COMMENTERS_KEY]) return;
+    fn(
+      (changes[HIDDEN_COMMENTERS_KEY].newValue as string[] | undefined) ??
+        [...DEFAULT_HIDDEN_COMMENTERS]
+    );
+  };
+  try {
+    chrome.storage.onChanged?.addListener(listener);
+  } catch {
+    return () => {};
+  }
+  return () => {
+    try {
+      chrome.storage.onChanged?.removeListener(listener);
+    } catch {
+      // Nothing to detach.
+    }
+  };
+}
+
+/** Case-insensitive membership test against a hidden-commenter list. */
+export function isHiddenCommenter(id: string, hidden: readonly string[]): boolean {
+  const needle = id.trim().toLowerCase();
+  if (!needle) return false;
+  return hidden.some((h) => h.trim().toLowerCase() === needle);
+}
+
+/** Marks a comment block hidden by FLoRA, so unmuting can restore it. */
+export const HIDDEN_COMMENTER_ATTR = "data-flora-hidden-commenter";
+
+const COMMENT_BLOCK_SELECTOR = ".vertical-timeline-content";
+
+/**
+ * The commenter's display name: the first `strong` that is not `.inner-id`
+ * (which holds the comment number). Pseudonyms are wrapped in `<em>`.
+ */
+export function commenterNameOf(block: Element): string | null {
+  const left = block.querySelector(".ibox-title .left");
+  const nameEl = left?.querySelector("strong:not(.inner-id)");
+  const name = nameEl?.textContent?.trim();
+  return name ? name : null;
+}
+
+/** Hide, and re-show on unmute, PubPeer comment blocks under `root`. */
+export function applyCommenterFilter(root: Node | null, hidden: readonly string[]): void {
+  if (!root) return;
+  const el = root instanceof Element ? root : root.parentElement;
+  if (!el) return;
+
+  const blocks: Element[] = el.matches?.(COMMENT_BLOCK_SELECTOR) ? [el] : [];
+  blocks.push(...el.querySelectorAll(COMMENT_BLOCK_SELECTOR));
+
+  for (const block of blocks) {
+    const name = commenterNameOf(block);
+    // No name means this isn't a real comment (e.g. the reply editor shares the
+    // block class) — leave it alone.
+    if (!name) continue;
+    const el = block as HTMLElement;
+    if (isHiddenCommenter(name, hidden)) {
+      el.style.display = "none";
+      el.setAttribute(HIDDEN_COMMENTER_ATTR, name);
+    } else if (el.hasAttribute(HIDDEN_COMMENTER_ATTR)) {
+      el.style.removeProperty("display");
+      el.removeAttribute(HIDDEN_COMMENTER_ATTR);
+    }
+  }
+}

--- a/tests/unit/pubpeer-filter.test.ts
+++ b/tests/unit/pubpeer-filter.test.ts
@@ -1,0 +1,194 @@
+import {afterEach, describe, expect, it, vi} from "vitest";
+
+const KEY = "flora_hidden_pubpeer_commenters";
+
+describe("pubpeer commenter filter", () => {
+  afterEach(() => {
+    vi.resetModules();
+    (chrome.storage.sync.get as ReturnType<typeof vi.fn>).mockReset();
+    (chrome.storage.sync.set as ReturnType<typeof vi.fn>).mockReset();
+  });
+
+  it("defaults to muting FORRT when nothing is stored", async () => {
+    (chrome.storage.sync.get as ReturnType<typeof vi.fn>).mockResolvedValue({});
+
+    const {getHiddenCommenters} = await import("../../src/shared/pubpeer-filter");
+
+    await expect(getHiddenCommenters()).resolves.toEqual(["FORRT"]);
+  });
+
+  it("returns the stored list when the user has customised it", async () => {
+    (chrome.storage.sync.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+      [KEY]: ["FORRT", "Noisy Reviewer"],
+    });
+
+    const {getHiddenCommenters} = await import("../../src/shared/pubpeer-filter");
+
+    await expect(getHiddenCommenters()).resolves.toEqual(["FORRT", "Noisy Reviewer"]);
+  });
+
+  it("honours an explicitly empty list instead of re-applying the default", async () => {
+    (chrome.storage.sync.get as ReturnType<typeof vi.fn>).mockResolvedValue({[KEY]: []});
+
+    const {getHiddenCommenters} = await import("../../src/shared/pubpeer-filter");
+
+    await expect(getHiddenCommenters()).resolves.toEqual([]);
+  });
+
+  it("caches reads within a module lifecycle", async () => {
+    (chrome.storage.sync.get as ReturnType<typeof vi.fn>).mockResolvedValue({[KEY]: ["FORRT"]});
+
+    const {getHiddenCommenters} = await import("../../src/shared/pubpeer-filter");
+
+    await getHiddenCommenters();
+    await getHiddenCommenters();
+    expect(chrome.storage.sync.get).toHaveBeenCalledTimes(1);
+  });
+
+  it("updates the cache when the list is saved", async () => {
+    (chrome.storage.sync.get as ReturnType<typeof vi.fn>).mockResolvedValue({[KEY]: ["FORRT"]});
+    (chrome.storage.sync.set as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+
+    const {getHiddenCommenters, saveHiddenCommenters} = await import(
+      "../../src/shared/pubpeer-filter"
+    );
+
+    await saveHiddenCommenters(["Someone Else"]);
+    await expect(getHiddenCommenters()).resolves.toEqual(["Someone Else"]);
+    expect(chrome.storage.sync.set).toHaveBeenCalledWith({[KEY]: ["Someone Else"]});
+  });
+
+  describe("isHiddenCommenter", () => {
+    it("matches regardless of case or surrounding whitespace", async () => {
+      const {isHiddenCommenter} = await import("../../src/shared/pubpeer-filter");
+
+      expect(isHiddenCommenter("forrt", ["FORRT"])).toBe(true);
+      expect(isHiddenCommenter("  FORRT  ", ["forrt"])).toBe(true);
+    });
+
+    it("does not match unrelated commenters", async () => {
+      const {isHiddenCommenter} = await import("../../src/shared/pubpeer-filter");
+
+      expect(isHiddenCommenter("Anolis Jacare", ["FORRT"])).toBe(false);
+    });
+
+    it("is false for a blank id and for an empty list", async () => {
+      const {isHiddenCommenter} = await import("../../src/shared/pubpeer-filter");
+
+      expect(isHiddenCommenter("   ", ["FORRT"])).toBe(false);
+      expect(isHiddenCommenter("FORRT", [])).toBe(false);
+    });
+  });
+
+  describe("applyCommenterFilter", () => {
+    // Mirrors real PubPeer markup: `.inner-id` is the comment NUMBER, and the
+    // commenter is the following bare <strong> (wrapped in <em> when
+    // pseudonymous). Captured from a live thread.
+    function comment(id: string, num: string, name: string, pseudonymous = false): string {
+      const inner = pseudonymous ? `<em>${name}</em>` : `${name} `;
+      return `
+        <div id="${id}" class="vertical-timeline-content ibox float-e-margins">
+          <div>
+            <div class="ibox-title">
+              <div class="left">
+                <strong id="${num}" class="inner-id">#${num}</strong>
+                <strong>${inner}</strong>
+                <div><span>comment accepted July 2026</span></div>
+              </div>
+            </div>
+          </div>
+          <div class="ibox-content markdown-body"><p>Comment body.</p></div>
+        </div>`;
+    }
+
+    function thread(): void {
+      document.body.innerHTML =
+        comment("c1", "1", "FORRT") +
+        comment("c2", "2", "Anolis Jacare", true);
+    }
+
+    const displayOf = (id: string): string =>
+      (document.getElementById(id) as HTMLElement).style.display;
+
+    it("hides only the muted commenter's comment block", async () => {
+      const {applyCommenterFilter} = await import("../../src/shared/pubpeer-filter");
+      thread();
+
+      applyCommenterFilter(document.body, ["FORRT"]);
+
+      expect(displayOf("c1")).toBe("none");
+      expect(displayOf("c2")).toBe("");
+    });
+
+    it("restores a comment when its commenter is unmuted", async () => {
+      const {applyCommenterFilter} = await import("../../src/shared/pubpeer-filter");
+      thread();
+
+      applyCommenterFilter(document.body, ["FORRT"]);
+      applyCommenterFilter(document.body, []);
+
+      expect(displayOf("c1")).toBe("");
+      expect(document.getElementById("c1")!.hasAttribute("data-flora-hidden-commenter")).toBe(false);
+    });
+
+    it("hides a newly muted commenter without touching the rest", async () => {
+      const {applyCommenterFilter} = await import("../../src/shared/pubpeer-filter");
+      thread();
+
+      applyCommenterFilter(document.body, ["FORRT"]);
+      applyCommenterFilter(document.body, ["FORRT", "Anolis Jacare"]);
+
+      expect(displayOf("c1")).toBe("none");
+      expect(displayOf("c2")).toBe("none");
+    });
+
+    it("leaves comments hidden by the page itself alone when unmuting", async () => {
+      const {applyCommenterFilter} = await import("../../src/shared/pubpeer-filter");
+      thread();
+      // Not hidden by FLoRA — no marker attribute, so it must not be revealed.
+      (document.getElementById("c2") as HTMLElement).style.display = "none";
+
+      applyCommenterFilter(document.body, []);
+
+      expect(displayOf("c2")).toBe("none");
+    });
+
+    it("does not mute on the comment number", async () => {
+      const {applyCommenterFilter} = await import("../../src/shared/pubpeer-filter");
+      thread();
+
+      // "1" is the .inner-id of comment c1 — muting it must hide nothing.
+      applyCommenterFilter(document.body, ["1"]);
+
+      expect(displayOf("c1")).toBe("");
+      expect(displayOf("c2")).toBe("");
+    });
+
+    it("ignores the reply editor, which shares the comment block class", async () => {
+      const {applyCommenterFilter} = await import("../../src/shared/pubpeer-filter");
+      document.body.innerHTML = `
+        <div id="editor" class="vertical-timeline-content">
+          <div class="ibox-content ibox-bordered"><div id="comment-editor"></div></div>
+        </div>`;
+
+      applyCommenterFilter(document.body, ["FORRT"]);
+
+      expect(displayOf("editor")).toBe("");
+    });
+
+    it("filters a comment block passed directly as the root", async () => {
+      const {applyCommenterFilter} = await import("../../src/shared/pubpeer-filter");
+      thread();
+
+      applyCommenterFilter(document.getElementById("c1"), ["FORRT"]);
+
+      expect(displayOf("c1")).toBe("none");
+    });
+
+    it("is a no-op for a null root", async () => {
+      const {applyCommenterFilter} = await import("../../src/shared/pubpeer-filter");
+
+      expect(() => applyCommenterFilter(null, ["FORRT"])).not.toThrow();
+    });
+  });
+});

--- a/tests/unit/side-panel-stability.test.ts
+++ b/tests/unit/side-panel-stability.test.ts
@@ -1,0 +1,88 @@
+import {describe, it, expect, beforeEach} from "vitest";
+import {renderSidePanel} from "../../src/content-general/injector";
+import type {DoiContext, DoiString, LookupState} from "../../src/shared/types";
+import type {PubPeerFeedback} from "../../src/shared/pubpeer-api";
+import {doi, mockResult} from "../helpers";
+
+const ARTICLE = doi("10.1038/nature12373");
+
+function feedback(overrides: Partial<PubPeerFeedback> = {}): PubPeerFeedback {
+    return {
+        id: ARTICLE,
+        title: "Test Article",
+        total_comments: 3,
+        total_peeriodical_comments: 0,
+        last_commented_at: "2024-01-01",
+        users: "Statcheck",
+        url: "https://pubpeer.com/publications/ABC123",
+        ...overrides,
+    };
+}
+
+function render(feedbacks: PubPeerFeedback[], refs: {doi: DoiString; title: string}[] = []): void {
+    const pageState = new Map<DoiString, LookupState>([
+        [ARTICLE, {status: "matched", result: mockResult(), source: "extracted"}],
+    ]);
+    const doiContext = new Map<DoiString, DoiContext>([[ARTICLE, "article"]]);
+    renderSidePanel(feedbacks, refs, pageState, doiContext, new Map(), []);
+}
+
+const panel = (): HTMLElement | null => document.getElementById("flora-pubpeer-panel");
+const iframe = (): HTMLIFrameElement | null =>
+    document.querySelector<HTMLIFrameElement>("#flora-pubpeer-panel iframe");
+
+describe("side panel stability", () => {
+    beforeEach(() => {
+        document.body.innerHTML = "";
+    });
+
+    it("keeps the same iframe element when re-rendered with identical data", () => {
+        render([feedback()]);
+        const first = iframe();
+        expect(first).not.toBeNull();
+        // Marks the live node — a rebuilt iframe would not carry this.
+        (first as unknown as {floraMark?: number}).floraMark = 42;
+
+        render([feedback()]);
+
+        expect(iframe()).toBe(first);
+        expect((iframe() as unknown as {floraMark?: number}).floraMark).toBe(42);
+    });
+
+    it("preserves the panel host across a no-op re-render", () => {
+        render([feedback()]);
+        const host = panel();
+
+        render([feedback()]);
+
+        expect(panel()).toBe(host);
+    });
+
+    it("rebuilds when the PubPeer thread changes", () => {
+        render([feedback()]);
+        const first = iframe();
+
+        render([feedback({url: "https://pubpeer.com/publications/DIFFERENT", total_comments: 9})]);
+
+        expect(iframe()).not.toBe(first);
+        expect(iframe()?.src).toContain("DIFFERENT");
+    });
+
+    it("rebuilds when the comment count changes on the same thread", () => {
+        render([feedback({total_comments: 3})]);
+        const first = iframe();
+
+        render([feedback({total_comments: 4})]);
+
+        expect(iframe()).not.toBe(first);
+    });
+
+    it("rebuilds when a flagged reference is added", () => {
+        render([feedback()]);
+        const first = iframe();
+
+        render([feedback()], [{doi: doi("10.1371/journal.pone.0012345"), title: "A cited paper"}]);
+
+        expect(iframe()).not.toBe(first);
+    });
+});


### PR DESCRIPTION
Extract PubPeer commenter filtering into a shared, configurable module with chrome.storage sync. Users can now mute commenters via the options page.

Add panel signature-based stability check to prevent unnecessary side panel iframe reloads when content hasn't changed. Removes redundant comments throughout the codebase and adds comprehensive tests for the new filtering logic and panel stability.