### PR TITLE
Add copyable citation row & settings

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -17,6 +17,8 @@
     "https://api.openalex.org/*",
     "https://api.crossref.org/*",
     "https://api.unpaywall.org/*",
+    "https://doi.org/*",
+    "https://data.crosscite.org/*",
     "https://pmc.ncbi.nlm.nih.gov/*",
     "https://docs.google.com/*",
     "https://pubpeer.com/*",

--- a/src/options/index.html
+++ b/src/options/index.html
@@ -168,6 +168,33 @@
             </label>
           </div>
 
+          <!-- ═══ CITATION STYLE ═══ -->
+          <div class="detail-card" style="margin-top: 1.25rem">
+            <div class="dh">
+              <div class="dh-label">Copy Citation</div>
+              <h2 class="dh-title">Citation Style</h2>
+              <div class="dh-authors">
+                Every DOI pill has a <strong>Citation</strong> row that copies
+                the reference in one click. Pick the style it uses here &mdash;
+                that style, and only that style, is what the pill copies.
+                Citations are rendered by
+                <a href="https://api.crossref.org" target="_blank" rel="noopener"
+                  >Crossref</a
+                >
+                and fetched only when you ask for one.
+              </div>
+            </div>
+
+            <div class="action-bar" style="align-items: flex-end;">
+              <div class="ab-group">
+                <label class="ab-label" for="citation-style-select">Style</label>
+                <select id="citation-style-select" class="ab-input" style="width: 220px;"></select>
+              </div>
+            </div>
+
+            <p id="citation-style-preview" class="citation-sample" hidden></p>
+          </div>
+
           <!-- ═══ CACHE STORAGE ═══ -->
           <div class="detail-card" style="margin-top: 1.25rem">
             <div class="dh">

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -1,5 +1,6 @@
 import { getSettings, saveSettings } from "../shared/settings";
 import { getBlockedDomains, saveBlockedDomains } from "../shared/domains";
+import { CITATION_FORMATS, citationFormat, fetchCitation } from "../shared/citation";
 import {
   getHiddenCommenters,
   isHiddenCommenter,
@@ -50,6 +51,45 @@ getSettings().then(({ showDoiPillsOnAllReferences }) => {
 
 allRefsToggle.addEventListener("change", () => {
   void saveSettings({ showDoiPillsOnAllReferences: allRefsToggle.checked });
+});
+
+// ── Citation style ──────────────────────────────────────────────────
+
+const citationStyleSelect = document.getElementById("citation-style-select") as HTMLSelectElement;
+const citationPreview = document.getElementById("citation-style-preview") as HTMLParagraphElement;
+
+// Ioannidis (2005) — a stable, widely-known record to render the sample from.
+const SAMPLE_DOI = "10.1371/journal.pmed.0020124";
+
+for (const format of CITATION_FORMATS) {
+  const option = document.createElement("option");
+  option.value = format.id;
+  option.textContent = format.label;
+  citationStyleSelect.appendChild(option);
+}
+
+let sampleToken = 0;
+
+async function showCitationSample(formatId: string): Promise<void> {
+  const token = ++sampleToken;
+  citationPreview.className = "citation-sample";
+  citationPreview.textContent = "Rendering a sample…";
+  citationPreview.hidden = false;
+  const sample = await fetchCitation(SAMPLE_DOI, formatId);
+  if (token !== sampleToken) return;
+  citationPreview.textContent = sample ?? "Sample unavailable — Crossref could not be reached.";
+  if (!sample) citationPreview.className = "citation-sample error";
+}
+
+getSettings().then(({ citationStyle }) => {
+  citationStyleSelect.value = citationFormat(citationStyle).id;
+  void showCitationSample(citationStyleSelect.value);
+});
+
+citationStyleSelect.addEventListener("change", async () => {
+  const citationStyle = citationFormat(citationStyleSelect.value).id;
+  await saveSettings({ citationStyle });
+  void showCitationSample(citationStyle);
 });
 
 // ── Cache storage quota ─────────────────────────────────────────────

--- a/src/options/styles.css
+++ b/src/options/styles.css
@@ -569,6 +569,26 @@ label {
   margin: 0.65rem 1.75rem 0.85rem;
 }
 
+/* ─── Citation sample ─── */
+.citation-sample {
+  margin: 0.65rem 1.75rem 0.9rem;
+  padding: 0.65rem 0.8rem;
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius);
+  background: var(--surface);
+  color: var(--text-secondary);
+  font-size: 12.5px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.citation-sample.error {
+  color: var(--error);
+  background: var(--error-bg);
+  border-color: rgba(180, 35, 24, 0.15);
+}
+
 /* ─── Toggle row (settings switch) ─── */
 .toggle-row {
   display: flex;

--- a/src/shared/citation.ts
+++ b/src/shared/citation.ts
@@ -1,0 +1,158 @@
+// Formatted citations for a DOI via content negotiation. Crossref's transform
+// endpoint renders the CSL styles; doi.org's negotiation service is the fallback
+// for DOIs Crossref doesn't own (DataCite: datasets, Zenodo, figshare).
+//
+// Nothing is fetched until a reader asks for a citation — one lookup per DOI per
+// format, then cached — so a page full of references costs no extra requests.
+
+import {getSettings} from "./settings";
+import {BlobCache} from "./blob-cache";
+
+export interface CitationFormat {
+    id: string;
+    label: string;
+    /** Content-negotiation Accept header. */
+    accept: string;
+    /** Reference-manager exports keep their own line breaks and field order. */
+    verbatim?: boolean;
+}
+
+const csl = (style: string): string => `text/x-bibliography; style=${style}; locale=en-US`;
+
+export const CITATION_FORMATS: readonly CitationFormat[] = [
+    {id: "apa", label: "APA", accept: csl("apa")},
+    {id: "modern-language-association", label: "MLA", accept: csl("modern-language-association")},
+    {id: "chicago-author-date", label: "Chicago", accept: csl("chicago-author-date")},
+    {id: "harvard-cite-them-right", label: "Harvard", accept: csl("harvard-cite-them-right")},
+    {id: "elsevier-vancouver", label: "Vancouver", accept: csl("elsevier-vancouver")},
+    {id: "ieee", label: "IEEE", accept: csl("ieee")},
+    {id: "american-medical-association", label: "AMA", accept: csl("american-medical-association")},
+    {id: "american-sociological-association", label: "ASA", accept: csl("american-sociological-association")},
+    {id: "nature", label: "Nature", accept: csl("nature")},
+    {id: "bibtex", label: "BibTeX", accept: "application/x-bibtex", verbatim: true},
+    {id: "ris", label: "RIS (EndNote, Zotero)", accept: "application/x-research-info-systems", verbatim: true},
+];
+
+export const DEFAULT_CITATION_FORMAT_ID = CITATION_FORMATS[0].id;
+
+/** Resolve a stored format id, falling back to the default for unknown ids. */
+export function citationFormat(id: string | null | undefined): CitationFormat {
+    return CITATION_FORMATS.find((format) => format.id === id) ?? CITATION_FORMATS[0];
+}
+
+/** The reader's preferred format from settings. */
+export async function preferredCitationFormat(): Promise<CitationFormat> {
+    try {
+        const {citationStyle} = await getSettings();
+        return citationFormat(citationStyle);
+    } catch {
+        return CITATION_FORMATS[0];
+    }
+}
+
+const CITATION_CACHE = new BlobCache<{text: string}>({
+    storageKey: "flora_citation_blob",
+    ttlMs: 90 * 24 * 60 * 60 * 1000, // 90 days — a published record's citation is stable
+});
+
+const inflight = new Map<string, Promise<string | null>>();
+
+const ENTITIES: Record<string, string> = {
+    amp: "&",
+    lt: "<",
+    gt: ">",
+    quot: '"',
+    apos: "'",
+    "#39": "'",
+    nbsp: " ",
+};
+
+/** CSL output carries markup (`<i>`, `&amp;`); the clipboard wants plain text. */
+function stripMarkup(raw: string): string {
+    return raw
+        .replace(/<[^>]*>/g, "")
+        .replace(/&(#?[a-z0-9]+);/gi, (match, entity: string) => ENTITIES[entity.toLowerCase()] ?? match);
+}
+
+/**
+ * Crossref stores an empty editor list on many journal articles, which citeproc
+ * renders as a dangling "edited by ," / ", ed." in the styles that name editors.
+ */
+function dropEmptyEditor(text: string): string {
+    return text
+        .replace(/\.\s*edited by\s*,\s*/gi, ". ")
+        .replace(/,?\s*edited by\s*,\s*/gi, ", ")
+        .replace(/\s*edited by\s*\.\s*/gi, " ")
+        .replace(/\.\s*,\s*ed\.\s+/gi, ". ");
+}
+
+export function tidyCitation(raw: string, format: CitationFormat): string {
+    const text = stripMarkup(raw).trim();
+    if (format.verbatim) return text;
+    return dropEmptyEditor(text)
+        // Numeric styles prefix the entry with its bibliography position.
+        .replace(/^(?:\[\d+\]|\d+\.)\s*/, "")
+        .replace(/\s+/g, " ")
+        .trim();
+}
+
+function crossrefUrl(doi: string, email: string): string {
+    const mailto = email ? `?mailto=${encodeURIComponent(email)}` : "";
+    return `https://api.crossref.org/works/${encodeURIComponent(doi)}/transform${mailto}`;
+}
+
+function doiOrgUrl(doi: string): string {
+    return `https://doi.org/${doi.split("/").map(encodeURIComponent).join("/")}`;
+}
+
+async function requestCitation(doi: string, format: CitationFormat): Promise<string | null> {
+    let email = "";
+    try {
+        email = (await getSettings()).email;
+    } catch {
+        // Polite-pool contact is optional for content negotiation.
+    }
+
+    for (const url of [crossrefUrl(doi, email), doiOrgUrl(doi)]) {
+        try {
+            const response = await fetch(url, {headers: {Accept: format.accept}});
+            if (!response.ok) continue;
+            const text = tidyCitation(await response.text(), format);
+            if (text) return text;
+        } catch {
+            // Try the next service.
+        }
+    }
+    return null;
+}
+
+/**
+ * Render `doi` in the given format, cached in chrome.storage.local. Returns null
+ * when neither Crossref nor doi.org can render the DOI — failures are not cached
+ * so a transient outage doesn't suppress the citation for the cache TTL.
+ */
+export async function fetchCitation(doi: string, formatId: string): Promise<string | null> {
+    const format = citationFormat(formatId);
+    const key = `${doi}|${format.id}`;
+
+    const cached = await CITATION_CACHE.get(key);
+    if (cached) return cached.text;
+
+    const existing = inflight.get(key);
+    if (existing) return existing;
+
+    const pending = requestCitation(doi, format)
+        .then(async (text) => {
+            if (text) await CITATION_CACHE.set(key, {text});
+            return text;
+        })
+        .finally(() => inflight.delete(key));
+    inflight.set(key, pending);
+    return pending;
+}
+
+/** Test-only: drop in-memory cache state so each case starts fresh. */
+export function _resetCitationCacheForTesting(): void {
+    CITATION_CACHE.resetForTesting();
+    inflight.clear();
+}

--- a/src/shared/indicator-pill.ts
+++ b/src/shared/indicator-pill.ts
@@ -16,6 +16,7 @@ import type {PubPeerFeedback} from "@shared/pubpeer-api";
 import {lookupPubPeerForDoi} from "@shared/pubpeer-api";
 import {noticePresentation} from "@shared/doi-retraction";
 import {OA_UNLOCK_SVG} from "@shared/doi-label";
+import {fetchCitation, preferredCitationFormat, type CitationFormat} from "@shared/citation";
 
 export const INDICATOR_PILL_CLASS = "flora-indicator-pill";
 
@@ -42,6 +43,60 @@ const DOI_LINK_SVG =
     `.75.75 0 0 0-1.06 1.06 3.5 3.5 0 0 0 4.95 0l2.5-2.5a3.5 3.5 0 0 0-4.95-4.95l-1.25 1.25Zm-4.69 9.64a2 2 0 0 1 0-2.83l2.5-2.5a2 2 0 0 1 2.83 0 ` +
     `.75.75 0 0 0 1.06-1.06 3.5 3.5 0 0 0-4.95 0l-2.5 2.5a3.5 3.5 0 0 0 4.95 4.95l1.25-1.25a.75.75 0 0 0-1.06-1.06l-1.25 1.25a2 2 0 0 1-2.83 0Z">` +
     `</path></svg>`;
+
+// Reference-block glyph for the popover's citation row.
+const CITATION_SVG =
+    `<svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" style="display:block;">` +
+    `<rect x="2" y="2.25" width="8" height="1.5" rx="0.75"/>` +
+    `<rect x="2" y="5.75" width="12" height="1.5" rx="0.75"/>` +
+    `<rect x="2" y="9.25" width="12" height="1.5" rx="0.75"/>` +
+    `<rect x="2" y="12.75" width="6" height="1.5" rx="0.75"/></svg>`;
+
+const CLIPBOARD_SVG = `<svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" style="display:block;"><path d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 0 1 0 1.5h-1.5a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-1.5a.75.75 0 0 1 1.5 0v1.5A1.75 1.75 0 0 1 9.25 16h-7.5A1.75 1.75 0 0 1 0 14.25Z"></path><path d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0 1 14.25 11h-7.5A1.75 1.75 0 0 1 5 9.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z"></path></svg>`;
+const CHECK_SVG = `<svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" style="display:block;"><path d="M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.75.75 0 0 1 1.06-1.06L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0Z"></path></svg>`;
+
+const ICON_BTN_STYLE = `
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    box-sizing: content-box;
+    width: 14px !important;
+    height: 14px !important;
+    min-width: 0 !important;
+    max-width: 14px !important;
+    padding: 0 !important;
+    margin: 0;
+    border: none !important;
+    background: transparent !important;
+    cursor: pointer;
+    color: #656d76;
+    transition: color 0.15s ease;
+    line-height: 0;
+    font-size: 0;
+    text-decoration: none;
+    flex: 0 0 auto;
+  `;
+
+function writeClipboard(value: string): void {
+    const writePromise = navigator.clipboard?.writeText
+        ? navigator.clipboard.writeText(value)
+        : Promise.reject();
+    writePromise.catch(() => {
+        // Fallback for contexts where the async clipboard API is blocked
+        const ta = document.createElement("textarea");
+        ta.value = value;
+        ta.setAttribute("data-flora-ui", "");
+        ta.style.cssText = "position:fixed;left:-9999px;top:-9999px;";
+        document.body.appendChild(ta);
+        ta.select();
+        try {
+            document.execCommand("copy");
+        } catch {
+            /* nothing more we can do */
+        }
+        ta.remove();
+    });
+}
 
 function makeDivider(): HTMLElement {
     const d = document.createElement("span");
@@ -429,35 +484,10 @@ function buildDoiRow(
     labelWrap.appendChild(doiText);
     labelWrap.appendChild(provenance);
 
-    const clipboardSvg = `<svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" style="display:block;"><path d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 0 1 0 1.5h-1.5a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-1.5a.75.75 0 0 1 1.5 0v1.5A1.75 1.75 0 0 1 9.25 16h-7.5A1.75 1.75 0 0 1 0 14.25Z"></path><path d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0 1 14.25 11h-7.5A1.75 1.75 0 0 1 5 9.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z"></path></svg>`;
-    const checkSvg = `<svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" style="display:block;"><path d="M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.75.75 0 0 1 1.06-1.06L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0Z"></path></svg>`;
-
-    const iconBtnStyle = `
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    box-sizing: content-box;
-    width: 14px !important;
-    height: 14px !important;
-    min-width: 0 !important;
-    max-width: 14px !important;
-    padding: 0 !important;
-    margin: 0;
-    border: none !important;
-    background: transparent !important;
-    cursor: pointer;
-    color: #656d76;
-    transition: color 0.15s ease;
-    line-height: 0;
-    font-size: 0;
-    text-decoration: none;
-    flex: 0 0 auto;
-  `;
-
     const copyBtn = document.createElement("button");
-    copyBtn.innerHTML = clipboardSvg;
+    copyBtn.innerHTML = CLIPBOARD_SVG;
     copyBtn.title = "Copy DOI";
-    copyBtn.style.cssText = iconBtnStyle;
+    copyBtn.style.cssText = ICON_BTN_STYLE;
     let copySuccess = false;
     copyBtn.addEventListener("mouseenter", () => {
         if (!copySuccess) copyBtn.style.color = color;
@@ -468,30 +498,13 @@ function buildDoiRow(
     copyBtn.addEventListener("click", (e) => {
         e.stopPropagation();
         copySuccess = true;
-        copyBtn.innerHTML = checkSvg;
+        copyBtn.innerHTML = CHECK_SVG;
         copyBtn.style.color = color;
         copyBtn.title = "Copied";
-        const writePromise = navigator.clipboard?.writeText
-            ? navigator.clipboard.writeText(doi)
-            : Promise.reject();
-        writePromise.catch(() => {
-            // Fallback for contexts where the async clipboard API is blocked
-            const ta = document.createElement("textarea");
-            ta.value = doi;
-            ta.setAttribute("data-flora-ui", "");
-            ta.style.cssText = "position:fixed;left:-9999px;top:-9999px;";
-            document.body.appendChild(ta);
-            ta.select();
-            try {
-                document.execCommand("copy");
-            } catch {
-                /* nothing more we can do */
-            }
-            ta.remove();
-        });
+        writeClipboard(doi);
         setTimeout(() => {
             copySuccess = false;
-            copyBtn.innerHTML = clipboardSvg;
+            copyBtn.innerHTML = CLIPBOARD_SVG;
             copyBtn.style.color = copyBtn.matches(":hover") ? color : "#656d76";
             copyBtn.title = "Copy DOI";
         }, 1500);
@@ -505,7 +518,7 @@ function buildDoiRow(
     openLink.target = "_blank";
     openLink.rel = "noopener noreferrer";
     openLink.title = "Open on doi.org";
-    openLink.style.cssText = iconBtnStyle;
+    openLink.style.cssText = ICON_BTN_STYLE;
     openLink.addEventListener("mouseenter", () => {
         openLink.style.color = color;
     });
@@ -527,6 +540,98 @@ function buildDoiRow(
     return contentRow;
 }
 
+/**
+ * The citation row: copies this reference in the style chosen in settings.
+ * Nothing is fetched until the row is clicked, so a page of references adds no
+ * requests unless a reader asks for one.
+ */
+function buildCitationRow(doi: string, color: string, compact = false): HTMLElement {
+    const row = document.createElement("div");
+    row.setAttribute("data-flora-citation-row", "");
+    row.style.cssText = `display:flex;align-items:center;gap:${compact ? "5px" : "8px"};padding:${compact ? "1px 3px" : "5px 4px"};border-radius:6px;cursor:pointer;`;
+    row.addEventListener("mouseenter", () => { row.style.background = "#f6f8fa"; });
+    row.addEventListener("mouseleave", () => { row.style.background = "transparent"; });
+
+    const icon = document.createElement("span");
+    icon.style.cssText = rowIconWrapStyle(color, true, compact);
+    icon.innerHTML = CITATION_SVG;
+
+    const labelWrap = document.createElement("span");
+    labelWrap.style.cssText = compact ? ROW_LABEL_WRAP_COMPACT : ROW_LABEL_WRAP;
+
+    const title = document.createElement("span");
+    title.style.cssText = compact ? ROW_TITLE_STYLE_COMPACT : ROW_TITLE_STYLE;
+    title.textContent = "Citation";
+
+    const status = document.createElement("span");
+    status.setAttribute("data-flora-row-sub", "");
+    status.style.cssText = rowSubStyle(true, compact);
+
+    labelWrap.appendChild(title);
+    labelWrap.appendChild(status);
+
+    const copyAction = document.createElement("span");
+    copyAction.setAttribute("data-flora-citation-copy", "");
+    copyAction.style.cssText = rowActionStyle(color, compact);
+    copyAction.textContent = "Copy";
+
+    row.appendChild(icon);
+    row.appendChild(labelWrap);
+    row.appendChild(copyAction);
+
+    let label = "";
+    let loadToken = 0;
+    let statusTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const setStatus = (text: string): void => {
+        if (statusTimer) {
+            clearTimeout(statusTimer);
+            statusTimer = null;
+        }
+        status.textContent = text;
+    };
+
+    const flashStatus = (text: string): void => {
+        setStatus(text);
+        statusTimer = setTimeout(() => {
+            status.textContent = label;
+        }, 1500);
+    };
+
+    const showStyle = (format: CitationFormat): void => {
+        label = format.label;
+        row.title = `Copy this reference in ${format.label} — change the style in FLoRA's settings`;
+        setStatus(format.label);
+    };
+
+    void preferredCitationFormat().then(showStyle);
+
+    // Re-read the preference on every copy: the reader may have changed it in
+    // settings while this page stayed open.
+    const copyCitation = async (): Promise<void> => {
+        const token = ++loadToken;
+        const format = await preferredCitationFormat();
+        if (token !== loadToken) return;
+        showStyle(format);
+        setStatus("Fetching…");
+        const citation = await fetchCitation(doi, format.id);
+        if (token !== loadToken) return;
+        if (!citation) {
+            setStatus("Citation unavailable");
+            return;
+        }
+        writeClipboard(citation);
+        flashStatus("Copied");
+    };
+
+    row.addEventListener("click", (e) => {
+        e.stopPropagation();
+        void copyCitation();
+    });
+
+    return row;
+}
+
 interface IndicatorRowsOptions {
     doi: DoiString;
     color: string;
@@ -545,8 +650,9 @@ interface IndicatorRowsOptions {
 
 /**
  * The row stack shared by the pill's popover and the standalone panel: DOI,
- * Open Access, PubPeer, replication/retraction. The OA and PubPeer rows start
- * unresolved and swap themselves in when their lookups land.
+ * citation, Open Access, PubPeer, replication/retraction. The OA and PubPeer
+ * rows start unresolved and swap themselves in when their lookups land; the
+ * citation row fetches nothing until a reader clicks it.
  */
 function buildIndicatorRows(opts: IndicatorRowsOptions): HTMLElement {
     const compact = opts.compact ?? false;
@@ -554,6 +660,7 @@ function buildIndicatorRows(opts: IndicatorRowsOptions): HTMLElement {
     rows.style.cssText = `display:flex;flex-direction:column;gap:${compact ? "0" : "2px"};`;
 
     rows.appendChild(buildDoiRow(opts.doi, opts.color, opts.isAugmented, compact, opts.provenanceLabel));
+    rows.appendChild(buildCitationRow(opts.doi, opts.color, compact));
 
     const sectionDivider = document.createElement("div");
     sectionDivider.style.cssText = `height:1px;background:#eaeef2;margin:${compact ? "2px 0" : "0 0 2px"};`;

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -9,6 +9,8 @@ export interface FloraSettings {
    * visible DOI of their own get a pill.
    */
   showDoiPillsOnAllReferences: boolean;
+  /** Citation format id used by the pill's Copy citation row (see citation.ts). */
+  citationStyle: string;
   /**
    * Soft cap on chrome.storage.local usage in MB. 0 = unlimited. With the
    * "unlimitedStorage" permission the browser lifts the ~10 MB hard cap, so
@@ -23,6 +25,7 @@ const STORAGE_KEY = "flora_settings";
 const DEFAULTS: FloraSettings = {
   email: "",
   showDoiPillsOnAllReferences: false,
+  citationStyle: "apa",
   cacheQuotaMb: 50,
 };
 
@@ -66,6 +69,11 @@ export async function saveSettings(
   const current = await getSettings();
   cachedSettings = { ...current, ...partial };
   await chrome.storage.sync.set({ [STORAGE_KEY]: cachedSettings });
+}
+
+/** Test-only: drop the cached settings so the next read hits storage again. */
+export function _resetSettingsCacheForTesting(): void {
+  cachedSettings = null;
 }
 
 /** Returns true if the user has completed initial setup (email provided). */

--- a/src/walkthrough/index.html
+++ b/src/walkthrough/index.html
@@ -107,7 +107,8 @@
                         Open Access, PubPeer discussion and replication counts
                         each get their own row, listed outright rather than
                         hidden behind a hover. The replication row links to the
-                        FORRT Replication Atlas.
+                        FORRT Replication Atlas, and the citation row copies a
+                        formatted reference in the style you picked in Settings.
                       </div>
                     </div>
                   </div>
@@ -176,6 +177,14 @@
                               >
                             </span>
                             <span class="mock-panel-actions">&#8599; &#10697;</span>
+                          </div>
+                          <div class="mock-panel-row">
+                            <span class="mock-panel-icon">&#9776;</span>
+                            <span class="mock-panel-label">
+                              <span class="mock-panel-title">Citation</span>
+                              <span class="mock-panel-sub">APA</span>
+                            </span>
+                            <span class="mock-panel-action">Copy</span>
                           </div>
                           <div class="mock-panel-divider"></div>
                           <div class="mock-panel-row">
@@ -354,6 +363,14 @@
                               >
                             </span>
                             <span class="mock-panel-actions">&#8599; &#10697;</span>
+                          </div>
+                          <div class="mock-panel-row">
+                            <span class="mock-panel-icon">&#9776;</span>
+                            <span class="mock-panel-label">
+                              <span class="mock-panel-title">Citation</span>
+                              <span class="mock-panel-sub">APA</span>
+                            </span>
+                            <span class="mock-panel-action">Copy</span>
                           </div>
                           <div class="mock-panel-divider"></div>
                           <div class="mock-panel-row">
@@ -775,7 +792,8 @@
                       <div class="wt-callout-text">
                         One pill per DOI carries every signal at once — DOI,
                         Open Access, PubPeer, replications. Hover it for the
-                        detail, click to pin it open.
+                        detail, click to pin it open, and copy a formatted
+                        citation from the row under the DOI.
                       </div>
                     </div>
                   </div>

--- a/tests/unit/citation-row.test.ts
+++ b/tests/unit/citation-row.test.ts
@@ -1,0 +1,131 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
+import {createIndicatorPill, createIndicatorPanel} from "../../src/shared/indicator-pill";
+import {_resetCitationCacheForTesting} from "../../src/shared/citation";
+import type {DoiString} from "../../src/shared/types";
+
+const DOI = "10.1234/x" as DoiString;
+const CITATION = "Ray, O. (2004). How the Mind Hurts and Heals the Body. American Psychologist.";
+
+let fetchMock: ReturnType<typeof vi.fn>;
+let writeText: ReturnType<typeof vi.fn>;
+
+/** Citations resolve; the pill's own PubPeer lookup is left hanging. */
+function stubFetch(): void {
+  fetchMock = vi.fn((url: string) =>
+    /crossref|doi\.org/.test(url)
+      ? Promise.resolve({ok: true, status: 200, text: () => Promise.resolve(CITATION)} as unknown as Response)
+      : new Promise<Response>(() => {})
+  );
+  vi.stubGlobal("fetch", fetchMock);
+}
+
+function citationCalls(): unknown[][] {
+  return fetchMock.mock.calls.filter(([url]) => /crossref|doi\.org/.test(String(url)));
+}
+
+function acceptHeader(call: unknown[]): string {
+  return ((call[1] as RequestInit).headers as Record<string, string>).Accept;
+}
+
+function row(host: HTMLElement): HTMLElement {
+  return host.querySelector<HTMLElement>("[data-flora-citation-row]")!;
+}
+
+function storedSettings(stored: Record<string, unknown>): void {
+  (chrome.storage.sync.get as ReturnType<typeof vi.fn>).mockResolvedValue({flora_settings: stored});
+}
+
+describe("citation row", () => {
+  beforeEach(() => {
+    _resetCitationCacheForTesting();
+    stubFetch();
+    writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {value: {writeText}, configurable: true});
+  });
+
+  afterEach(async () => {
+    vi.unstubAllGlobals();
+    (chrome.storage.sync.get as ReturnType<typeof vi.fn>).mockResolvedValue({});
+    (await import("../../src/shared/settings"))._resetSettingsCacheForTesting();
+    document.body.innerHTML = "";
+  });
+
+  it("is offered on both the pill's popover and the Scholar panel", () => {
+    expect(row(createIndicatorPill({doi: DOI}))).not.toBeNull();
+    expect(row(createIndicatorPanel({doi: DOI}))).not.toBeNull();
+  });
+
+  it("fetches nothing until the reader asks", async () => {
+    // A references list injects one of these per entry; a citation lookup per
+    // reference on page load would be dozens of requests nobody asked for.
+    const pill = createIndicatorPill({doi: DOI});
+    document.body.appendChild(pill);
+    await vi.waitFor(() => expect(row(pill).textContent).toContain("APA"));
+    expect(citationCalls()).toHaveLength(0);
+  });
+
+  it("copies the citation on a click, and says so", async () => {
+    const pill = createIndicatorPill({doi: DOI});
+    document.body.appendChild(pill);
+
+    row(pill).click();
+
+    await vi.waitFor(() => expect(writeText).toHaveBeenCalledWith(CITATION));
+    expect(citationCalls()).toHaveLength(1);
+    expect(row(pill).querySelector("[data-flora-row-sub]")!.textContent).toBe("Copied");
+  });
+
+  it("offers copying and nothing else — the style is a settings decision", () => {
+    const pill = createIndicatorPill({doi: DOI});
+    expect(row(pill).querySelector("select")).toBeNull();
+    expect(row(pill).querySelector("[data-flora-citation-text]")).toBeNull();
+    expect(row(pill).querySelector("[data-flora-citation-copy]")!.textContent).toBe("Copy");
+  });
+
+  it("copies in the style the reader chose in settings", async () => {
+    storedSettings({email: "a@b.co", citationStyle: "ieee"});
+    const pill = createIndicatorPill({doi: DOI});
+    document.body.appendChild(pill);
+    await vi.waitFor(() => expect(row(pill).textContent).toContain("IEEE"));
+
+    row(pill).click();
+
+    await vi.waitFor(() => expect(citationCalls()).toHaveLength(1));
+    expect(acceptHeader(citationCalls()[0])).toContain("style=ieee");
+  });
+
+  it("picks up a style changed in settings while the page stayed open", async () => {
+    const pill = createIndicatorPill({doi: DOI});
+    document.body.appendChild(pill);
+    await vi.waitFor(() => expect(row(pill).textContent).toContain("APA"));
+
+    // saveSettings from the options page invalidates the cached settings via the
+    // storage.onChanged listener; the row must re-read rather than reuse APA.
+    storedSettings({email: "a@b.co", citationStyle: "nature"});
+    (await import("../../src/shared/settings"))._resetSettingsCacheForTesting();
+
+    row(pill).click();
+
+    await vi.waitFor(() => expect(citationCalls()).toHaveLength(1));
+    expect(acceptHeader(citationCalls()[0])).toContain("style=nature");
+    expect(row(pill).title).toContain("Nature");
+  });
+
+  it("says so when the citation can't be rendered", async () => {
+    fetchMock.mockImplementation((url: string) =>
+      /crossref|doi\.org/.test(url)
+        ? Promise.reject(new Error("offline"))
+        : new Promise<Response>(() => {})
+    );
+    const pill = createIndicatorPill({doi: DOI});
+    document.body.appendChild(pill);
+
+    row(pill).click();
+
+    await vi.waitFor(() =>
+      expect(row(pill).querySelector("[data-flora-row-sub]")!.textContent)
+        .toBe("Citation unavailable")
+    );
+    expect(writeText).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/citation.test.ts
+++ b/tests/unit/citation.test.ts
@@ -1,0 +1,135 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
+import {
+  CITATION_FORMATS,
+  citationFormat,
+  fetchCitation,
+  tidyCitation,
+  _resetCitationCacheForTesting,
+} from "../../src/shared/citation";
+
+const DOI = "10.1037/0003-066X.59.1.29";
+
+function okText(body: string): Response {
+  return {ok: true, status: 200, text: () => Promise.resolve(body)} as unknown as Response;
+}
+
+function notFound(): Response {
+  return {ok: false, status: 404, text: () => Promise.resolve("")} as unknown as Response;
+}
+
+describe("citation formats", () => {
+  it("falls back to APA for an unknown or missing style id", () => {
+    expect(citationFormat("apa").id).toBe("apa");
+    expect(citationFormat("no-such-style").id).toBe("apa");
+    expect(citationFormat(undefined).id).toBe("apa");
+  });
+
+  it("asks for each CSL style by name, and exports by content type", () => {
+    expect(citationFormat("ieee").accept).toContain("style=ieee");
+    expect(citationFormat("bibtex").accept).toBe("application/x-bibtex");
+    expect(citationFormat("ris").accept).toBe("application/x-research-info-systems");
+  });
+});
+
+describe("tidyCitation", () => {
+  const apa = citationFormat("apa");
+
+  it("reduces CSL markup to the plain text that goes on the clipboard", () => {
+    expect(tidyCitation("Pelletier, A. (2023). <i>pathseq</i> &amp; friends.", apa))
+      .toBe("Pelletier, A. (2023). pathseq & friends.");
+  });
+
+  it("drops the bibliography number numeric styles prefix the entry with", () => {
+    expect(tidyCitation("[1]O. Ray, “Title,” Journal, 2004.", citationFormat("ieee")))
+      .toBe("O. Ray, “Title,” Journal, 2004.");
+    expect(tidyCitation("1.Ray O. Title. Journal. 2004.", citationFormat("american-medical-association")))
+      .toBe("Ray O. Title. Journal. 2004.");
+  });
+
+  it("removes the dangling editor phrase left by records with an empty editor list", () => {
+    expect(tidyCitation("Ray, O. “Title.” American Psychologist, edited by , vol. 59, 2004.", apa))
+      .toBe("Ray, O. “Title.” American Psychologist, vol. 59, 2004.");
+    expect(tidyCitation("Ray, O. (2004) “Title,” American Psychologist. Edited by , 59(1).", apa))
+      .toBe("Ray, O. (2004) “Title,” American Psychologist. 59(1).");
+    expect(tidyCitation("Ray, O. 2004. “Title.” edited by . American Psychologist 59(1).", apa))
+      .toBe("Ray, O. 2004. “Title.” American Psychologist 59(1).");
+    expect(tidyCitation("Ray O. Title. , ed. American Psychologist. 2004.", apa))
+      .toBe("Ray O. Title. American Psychologist. 2004.");
+  });
+
+  it("keeps reference-manager exports byte-for-byte apart from markup", () => {
+    const ris = "TY  - JOUR\nTI  - Title\nAU  - Ray, Oakley\nER  - ";
+    expect(tidyCitation(ris, citationFormat("ris"))).toBe(ris.trim());
+  });
+});
+
+describe("fetchCitation", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    _resetCitationCacheForTesting();
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("renders via Crossref's transform endpoint, asking for the chosen style", async () => {
+    fetchMock.mockResolvedValue(okText("Ray, O. (2004). Title. American Psychologist."));
+
+    await expect(fetchCitation(DOI, "chicago-author-date"))
+      .resolves.toBe("Ray, O. (2004). Title. American Psychologist.");
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toContain("api.crossref.org/works/");
+    expect(url).toContain("/transform");
+    expect(init.headers.Accept).toContain("style=chicago-author-date");
+  });
+
+  it("caches a rendered citation per DOI and format", async () => {
+    fetchMock.mockResolvedValue(okText("Ray, O. (2004). Title."));
+
+    await fetchCitation(DOI, "apa");
+    await fetchCitation(DOI, "apa");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await fetchCitation(DOI, "ieee");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("coalesces concurrent requests for the same citation", async () => {
+    fetchMock.mockResolvedValue(okText("Ray, O. (2004). Title."));
+
+    await Promise.all([fetchCitation(DOI, "apa"), fetchCitation(DOI, "apa")]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to doi.org for DOIs Crossref does not own", async () => {
+    // DataCite DOIs (Zenodo, figshare, datasets) 404 at Crossref.
+    fetchMock
+      .mockResolvedValueOnce(notFound())
+      .mockResolvedValueOnce(okText("Pelletier, A. (2023). pathseq. Zenodo."));
+
+    await expect(fetchCitation("10.5281/zenodo.7942546", "apa"))
+      .resolves.toBe("Pelletier, A. (2023). pathseq. Zenodo.");
+    expect(fetchMock.mock.calls[1][0]).toBe("https://doi.org/10.5281/zenodo.7942546");
+  });
+
+  it("does not cache a failure, so an outage doesn't suppress the citation", async () => {
+    fetchMock.mockRejectedValue(new Error("offline"));
+    await expect(fetchCitation(DOI, "apa")).resolves.toBeNull();
+
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue(okText("Ray, O. (2004). Title."));
+    await expect(fetchCitation(DOI, "apa")).resolves.toBe("Ray, O. (2004). Title.");
+  });
+
+  it("offers the styles Google Scholar does, plus BibTeX and RIS", () => {
+    const labels = CITATION_FORMATS.map((format) => format.label);
+    for (const expected of ["APA", "MLA", "Chicago", "Harvard", "Vancouver", "BibTeX"]) {
+      expect(labels).toContain(expected);
+    }
+  });
+});

--- a/tests/unit/settings-domains-cache.test.ts
+++ b/tests/unit/settings-domains-cache.test.ts
@@ -6,6 +6,7 @@ import {afterEach, describe, expect, it, vi} from "vitest";
 const FULL_SETTINGS = {
   email: "test@example.com",
   showDoiPillsOnAllReferences: false,
+  citationStyle: "apa",
   cacheQuotaMb: 50,
 };
 


### PR DESCRIPTION
Introduce a copyable citation feature: new src/shared/citation.ts provides citation formats, content-negotiation fetching (Crossref → doi.org fallback), tidy/strip logic, per-DOI+format caching (BlobCache) and inflight coalescing. Wire UI: options page gets a Citation Style selector + preview; indicator pill/panel shows a lazy-loading Citation row that copies the chosen style to the clipboard with a fallback. Add styles, icons and clipboard helper. Update manifest host permissions for doi.org and data.crosscite.org. Persist citationStyle in settings (default APA) and add test coverage for citation behavior and the citation row.