### PR TITLE
Clarify error messages: report a failed lookup as a failed lookup

### DIFF
--- a/src/content-general/index.ts
+++ b/src/content-general/index.ts
@@ -31,7 +31,7 @@ import {
     showAllFloraUI
 } from "./injector";
 import {lookupPubPeer, lookupPubPeerForDois, type PubPeerFeedback} from "@shared/pubpeer-api";
-import {debugLog} from "@shared/debug";
+import {debugError, debugLog} from "@shared/debug";
 import {isSetupComplete} from "@shared/settings";
 import {isDomainBlocked} from "@shared/domains";
 import {isBotCheckPage} from "@shared/bot-check";
@@ -308,7 +308,18 @@ async function scanWholePage(): Promise<void> {
 
     beginWorkIndicator();
     try {
-        const response = await safeSendMessage<LookupResponse>(request);
+        // Only the lookup itself gets the error banner. Everything after it is
+        // our own rendering, and a throw there is a bug on this page's markup —
+        // reporting that as a failed lookup sends the reader chasing an outage
+        // that isn't happening.
+        let response: LookupResponse | undefined;
+        try {
+            response = await safeSendMessage<LookupResponse>(request);
+        } catch (err) {
+            debugError("Replication lookup failed:", err);
+            renderErrorBanner("Couldn't load replication data for this page");
+            return;
+        }
         if (!response) {
             // Extension context invalidated (reload/update) — stale script, stop quietly.
             return;
@@ -333,50 +344,54 @@ async function scanWholePage(): Promise<void> {
         }
         pageStateVersion++; // signal that replication data is now available
 
-        // Collect matched DOIs for display
-        // On Sheets, skip the "still in DOM" re-check — the canvas DOM is unreliable
-        const currentDois = isSheets ? null : new Set(extractDOIs(document));
-        const matched = [...pageState.entries()]
-            .filter(([doi, s]) => {
-                if (s.status !== "matched") return false;
-                if (!isSheets && !currentDois!.has(doi)) return false;
-                // Only include DOIs that actually have replication or reproduction data
-                const stats = s.result.record.stats;
-                return stats.n_replications_total > 0 || stats.n_reproductions_total > 0;
-            })
-            .map(([doi, s]) => ({
-                doi,
-                result: (s as {
-                    status: "matched";
-                    result: import("../shared/types").ReplicationResult;
-                    source: "extracted"
-                }).result,
-            }));
+        try {
+            // Collect matched DOIs for display
+            // On Sheets, skip the "still in DOM" re-check — the canvas DOM is unreliable
+            const currentDois = isSheets ? null : new Set(extractDOIs(document));
+            const matched = [...pageState.entries()]
+                .filter(([doi, s]) => {
+                    if (s.status !== "matched") return false;
+                    if (!isSheets && !currentDois!.has(doi)) return false;
+                    // Only include DOIs that actually have replication or reproduction data
+                    const stats = s.result.record.stats;
+                    return stats.n_replications_total > 0 || stats.n_reproductions_total > 0;
+                })
+                .map(([doi, s]) => ({
+                    doi,
+                    result: (s as {
+                        status: "matched";
+                        result: import("../shared/types").ReplicationResult;
+                        source: "extracted"
+                    }).result,
+                }));
 
-        debugLog("Matched DOIs with replication data:", matched.length, matched.map(m => m.doi));
-        if (matched.length > 0) {
-            if (isSheets) {
-                if (!isSheetsModalSuppressed()) {
-                    renderSheetsModal(matched, sheetsModalCallbacks);
+            debugLog("Matched DOIs with replication data:", matched.length, matched.map(m => m.doi));
+            if (matched.length > 0) {
+                if (isSheets) {
+                    if (!isSheetsModalSuppressed()) {
+                        renderSheetsModal(matched, sheetsModalCallbacks);
+                    }
+                } else {
+                    void checkPubPeer();
                 }
             } else {
-                void checkPubPeer();
+                if (isSheets) {
+                    removeSheetsModal();
+                } else {
+                    void checkPubPeer();
+                }
             }
-        } else {
-            if (isSheets) {
-                removeSheetsModal();
-            } else {
-                void checkPubPeer();
-            }
-        }
 
-        // Merged indicator pills (skip on Google Sheets — modal only).
-        if (!isSheets) {
-            placeTitleIndicatorPill();
-            updateIndicatorPillBadges(document, pageState, redacts);
+            // Merged indicator pills (skip on Google Sheets — modal only).
+            if (!isSheets) {
+                placeTitleIndicatorPill();
+                updateIndicatorPillBadges(document, pageState, redacts);
+            }
+        } catch (err) {
+            // Rendering failed after a successful lookup: log it for a bug
+            // report rather than blaming the service the reader can't fix.
+            debugError("Rendering replication results failed:", err);
         }
-    } catch {
-        renderErrorBanner("Failed to contact the FORRT service");
     } finally {
         endWorkIndicator();
     }


### PR DESCRIPTION
Stacked on #128 — it edits a string that PR introduces, so **merge #128 first**; the base will retarget to `main` automatically.

## The problem

`renderErrorBanner("Failed to contact the FORRT service")` sat in a catch wrapping ~70 lines of `content-general/index.ts`: the `FLORA_LOOKUP` round trip, but also `extractDOIs`, `placeTitleIndicatorPill`, `updateIndicatorPillBadges`, the Sheets modal and the PubPeer kick-off. A throw anywhere in that rendering work — no network involved — reported the API as unreachable. A pill-placement bug on some publisher's markup would have been reported to you as an outage.

It was wrong in the other direction too: `flora-api.ts` catches per 50-DOI batch and the worker returns per-DOI entries in `response.errors`, so a genuine API failure sets `status: "error"` on each DOI without throwing, and never reaches this banner at all.

## The change

- The lookup gets its own `try`. A transport failure renders **"Couldn't load replication data for this page"** — true whichever layer failed, and it doesn't name a service the reader has no way to check.
- The rendering that follows gets a separate catch that `debugError`s. A failure there is a bug in our own DOM handling and should arrive as a bug report, not an outage report.
- `safeSendMessage` returns `undefined` only for an invalidated extension context (already handled by returning quietly) and rethrows everything else, so the new catch is the real transport-failure path.

No behaviour change on the happy path; `primaryDoiFastPath` keeps its existing silent rollback, which is right for a speculative pre-fetch.

## Not addressed

Every other service still fails silently, and its failure is indistinguishable from a genuine negative: a dimmed padlock means either "no free copy exists" or "Unpaywall didn't answer", and a dimmed PubPeer segment means either "no comments" or "rate-limited". Telling those apart needs a third visual state per segment — a design change rather than a bug fix, so it belongs in its own PR. Citations are the exception and already report per-action ("Citation unavailable" plus a toast), because they are user-initiated.

## Testing

`npm test` (358 tests) and `npm run typecheck` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)