### PR TITLE
Add DOI provenance

### DIFF
--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -4,7 +4,7 @@ import {RET_MAP_KEY, storageSync, type RetractionMaps} from "@shared/data-extrac
 import type {DoiString, ReplicationResult, RetractionResponse} from "@shared/types";
 import {LookupResponse, RetractionCheckResponse, SheetFetchResponse, AugmentResponse, AugmentRequest, PmcResolveResponse} from "@shared/messages";
 import {isLookupRequest, isRetractionCheckRequest, isSheetFetchRequest, isAugmentRequest, isPmcResolveRequest, isDebugEntriesRequest, isStashReportRequest, isTakeReportRequest, type TakeReportResponse} from "@shared/messages";
-import {augmentDOIs} from "@shared/doi-augment";
+import {augmentDOIsDetailed, type AugmentSource} from "@shared/doi-augment";
 import {resolvePmcIds} from "@shared/pmc-resolve";
 import {getSettings, isSetupComplete} from "@shared/settings";
 import {appendDebugEntries, installDebugLogStore} from "@shared/debug-log";
@@ -350,10 +350,14 @@ async function handleLookup(dois: DoiString[]): Promise<LookupResponse> {
 async function handleAugment(
     requests: AugmentRequest["requests"]
 ): Promise<AugmentResponse> {
-    const resultMap = await augmentDOIs(requests);
+    const resultMap = await augmentDOIsDetailed(requests);
     const results: Record<string, string | null> = {};
-    for (const [title, doi] of resultMap) results[title] = doi ?? null;
-    return { type: "FLORA_AUGMENT_RESULT", results };
+    const sources: Record<string, AugmentSource | null> = {};
+    for (const [title, outcome] of resultMap) {
+        results[title] = outcome.doi ?? null;
+        sources[title] = outcome.source;
+    }
+    return { type: "FLORA_AUGMENT_RESULT", results, sources };
 }
 
 async function handlePmcResolve(pmcids: string[]): Promise<PmcResolveResponse> {

--- a/src/shared/blob-cache.ts
+++ b/src/shared/blob-cache.ts
@@ -21,26 +21,59 @@ export interface BlobCacheOptions {
 export class BlobCache<T> {
     private mem: CacheBlob<T> | null = null;
     private loading: Promise<void> | null = null;
+    // Bumped whenever the blob changes underneath us, so a read that started
+    // before the change doesn't install what it found afterwards.
+    private generation = 0;
+    private listenerInstalled = false;
 
     constructor(private readonly opts: BlobCacheOptions) {}
 
+    /**
+     * Without this, clearing the cache does nothing while a context is alive:
+     * reads keep serving the in-memory copy, and the next write flushes it
+     * straight back into storage.
+     */
+    private installInvalidation(): void {
+        if (this.listenerInstalled) return;
+        this.listenerInstalled = true;
+        try {
+            chrome.storage.onChanged?.addListener((changes, area) => {
+                if (area !== "local" || !(this.opts.storageKey in changes)) return;
+                const next = changes[this.opts.storageKey].newValue as CacheBlob<T> | undefined;
+                this.generation++;
+                this.loading = null;
+                this.mem = next && typeof next === "object" ? next : null;
+                if (!this.mem) {
+                    debugLog(`Cache ${this.opts.storageKey}: cleared elsewhere, dropping in-memory copy`);
+                }
+            });
+        } catch {
+            // Storage change events are unavailable in tests and some contexts.
+        }
+    }
+
     private async ensureLoaded(): Promise<void> {
+        this.installInvalidation();
         if (this.mem) return;
         if (!this.loading) {
             this.loading = this.load();
         }
         await this.loading;
+        this.mem ??= {};
     }
 
     private async load(): Promise<void> {
+        const generation = this.generation;
+        let blob: CacheBlob<T> = {};
         try {
             const raw = await chrome.storage.local.get(this.opts.storageKey);
-            const blob = raw[this.opts.storageKey] as CacheBlob<T> | undefined;
-            this.mem = blob && typeof blob === "object" ? blob : {};
+            const stored = raw[this.opts.storageKey] as CacheBlob<T> | undefined;
+            blob = stored && typeof stored === "object" ? stored : {};
         } catch (err) {
             debugWarn(`Cache ${this.opts.storageKey}: load failed, starting empty —`, err);
-            this.mem = {};
         }
+        // A change landed mid-read; the listener's copy is the newer truth.
+        if (generation === this.generation) this.mem = blob;
         if (this.opts.legacyPrefixes && this.opts.legacyPrefixes.length > 0) {
             void this.sweepLegacy(this.opts.legacyPrefixes);
         }
@@ -135,8 +168,21 @@ export class BlobCache<T> {
         }
     }
 
+    /** Drop every entry, in memory and in storage. */
+    async clear(): Promise<void> {
+        this.mem = {};
+        this.generation++;
+        try {
+            await chrome.storage.local.remove(this.opts.storageKey);
+        } catch (err) {
+            debugWarn(`Cache ${this.opts.storageKey}: clear failed —`, err);
+        }
+    }
+
     resetForTesting(): void {
         this.mem = null;
         this.loading = null;
+        this.generation++;
+        this.listenerInstalled = false;
     }
 }

--- a/src/shared/doi-augment.ts
+++ b/src/shared/doi-augment.ts
@@ -2,11 +2,16 @@ import type {DoiString, DoiAugmentRequest} from "./types";
 import {normaliseDOI} from "./doi-normalise";
 import {getSettings} from "./settings";
 import {BlobCache} from "./blob-cache";
-import {debugWarn} from "./debug";
+import {debugLog, debugWarn, isDebugEnabled} from "./debug";
 
 const OPENALEX_BASE = "https://api.openalex.org/works";
 const CROSSREF_BASE = "https://api.crossref.org/works";
 const MATCH_THRESHOLD_TSR = 88; // token_set_ratio threshold (0–100)
+// token_set_ratio scores 100 whenever one title's tokens are a subset of the
+// other's, so a 3-word title matches a 7-word one perfectly. Coverage is the
+// share of the *queried* title the candidate accounts for, which that ratio
+// cannot express. Set below 100 so a candidate missing a subtitle still passes.
+const MATCH_THRESHOLD_COVERAGE = 75;
 // When page metadata (author/year) is available we accept candidates within this
 // many points of the top title score, then let the metadata break the tie.
 const METADATA_TITLE_BAND = 5;
@@ -149,7 +154,10 @@ function candidateMerit(request: DoiAugmentRequest, candidate: DoiCandidate): nu
  */
 function selectBestCandidate(request: DoiAugmentRequest, candidates: DoiCandidate[]): DoiCandidate | null {
     const eligible = candidates.filter((candidate) => candidate.score >= MATCH_THRESHOLD_TSR);
-    if (eligible.length === 0) return null;
+    if (eligible.length === 0) {
+        debugLog(`Augment: no candidate cleared ${MATCH_THRESHOLD_TSR} for "${request.title.slice(0, 80)}"`);
+        return null;
+    }
 
     const highestScore = Math.max(...eligible.map((candidate) => candidate.score));
     const titleBand = request.firstAuthor || request.year
@@ -170,9 +178,28 @@ function selectBestCandidate(request: DoiAugmentRequest, candidates: DoiCandidat
     const highestMerit = Math.max(...narrowed.map((candidate) => candidateMerit(request, candidate)));
     const best = narrowed.filter((candidate) => candidateMerit(request, candidate) === highestMerit);
     const bestDois = new Set(best.map((candidate) => candidate.doi));
-    if (bestDois.size !== 1) return null;
+    if (bestDois.size !== 1) {
+        // Ambiguity resolves to no DOI, which otherwise looks like "not found".
+        debugLog(
+            `Augment: tie between ${[...bestDois].join(", ")} at merit ${highestMerit.toFixed(1)}`
+            + ` for "${request.title.slice(0, 80)}" — resolving to no DOI`
+        );
+        return null;
+    }
 
-    return best[0];
+    const winner = best[0];
+    const reasons = [
+        candidateMatchesSourceUrl(request, winner) ? "source-url" : null,
+        yearsMatch(request.year, winner.year) ? `year=${winner.year}` : null,
+        authorsMatch(request.firstAuthor, winner.firstAuthor) ? `author=${winner.firstAuthor}` : null,
+    ].filter(Boolean);
+    debugLog(
+        `Augment: "${request.title.slice(0, 80)}" → ${winner.doi} via ${winner.source.toUpperCase()}`
+        + ` (title ${winner.score.toFixed(1)}, merit ${highestMerit.toFixed(1)}`
+        + `${reasons.length > 0 ? ", corroborated by " + reasons.join(" + ") : ", title only"})`
+        + ` from ${eligible.length} candidate(s) across ${new Set(eligible.map((c) => c.source)).size} platform(s)`
+    );
+    return winner;
 }
 
 function extractCrossrefYear(item: {
@@ -250,6 +277,43 @@ export function tokenSetRatio(s1: string, s2: string): number {
 }
 
 /**
+ * Share (0–100) of the queried title's tokens the candidate contains. Guards
+ * against a short generic title scoring 100 against a longer specific one.
+ */
+export function titleCoverage(query: string, candidate: string): number {
+    const queryTokens = new Set(normalizeTitle(query).split(/\s+/).filter(Boolean));
+    if (queryTokens.size === 0) return 0;
+    const candidateTokens = new Set(normalizeTitle(candidate).split(/\s+/).filter(Boolean));
+    let covered = 0;
+    for (const token of queryTokens) if (candidateTokens.has(token)) covered++;
+    return (covered / queryTokens.size) * 100;
+}
+
+function logQueryOutcome(
+    source: "crossref" | "openalex",
+    title: string,
+    returned: number,
+    accepted: DoiCandidate[],
+    rejected: Array<{score: number; coverage: number; title: string}>
+): void {
+    if (!isDebugEnabled()) return;
+    const head = `Augment [${source}] "${title.slice(0, 80)}": ${returned} result(s), ${accepted.length} usable`;
+    if (accepted.length > 0) {
+        const list = accepted
+            .map((c) => `${c.doi} (${c.score.toFixed(1)}) "${c.title.slice(0, 60)}"`)
+            .join("; ");
+        debugLog(`${head} — ${list}`);
+        return;
+    }
+    const best = rejected.sort((a, b) => b.score - a.score)[0];
+    debugLog(best
+        ? `${head} — best was "${best.title.slice(0, 60)}"`
+          + ` (title ${best.score.toFixed(1)}/${MATCH_THRESHOLD_TSR},`
+          + ` coverage ${best.coverage.toFixed(0)}%/${MATCH_THRESHOLD_COVERAGE}%), rejected`
+        : `${head} — nothing usable`);
+}
+
+/**
  * Query Crossref for a title, returning every candidate that clears the title
  * threshold (with author/year/URL metadata for later tie-breaking).
  */
@@ -257,8 +321,12 @@ async function queryCrossref(request: DoiAugmentRequest, email: string): Promise
     const {title} = request;
     const cleaned = cleanTitleForSearch(title);
     const url = `${CROSSREF_BASE}?query.title=${encodeURIComponent(cleaned)}&rows=5&select=DOI,title,author,issued,published-print,published-online,published,URL,link&mailto=${encodeURIComponent(email)}`;
+    debugLog(`Augment [crossref] query: "${cleaned}"`);
     const response = await fetch(url);
-    if (!response.ok) return [];
+    if (!response.ok) {
+        debugWarn(`Augment [crossref] HTTP ${response.status} for "${cleaned}" — no candidates`);
+        return [];
+    }
 
     const data = (await response.json()) as {
         message?: {
@@ -278,12 +346,17 @@ async function queryCrossref(request: DoiAugmentRequest, email: string): Promise
 
     const items = data.message?.items ?? [];
     const candidates: DoiCandidate[] = [];
+    const rejected: Array<{score: number; coverage: number; title: string}> = [];
 
     for (const item of items) {
         if (!item.DOI || !item.title?.[0]) continue;
 
         const tsr = tokenSetRatio(title, item.title[0]);
-        if (tsr >= MATCH_THRESHOLD_TSR) {
+        const coverage = titleCoverage(title, item.title[0]);
+        if (tsr < MATCH_THRESHOLD_TSR || coverage < MATCH_THRESHOLD_COVERAGE) {
+            rejected.push({score: tsr, coverage, title: item.title[0]});
+        }
+        if (tsr >= MATCH_THRESHOLD_TSR && coverage >= MATCH_THRESHOLD_COVERAGE) {
             const doi = normaliseDOI(item.DOI);
             if (doi) {
                 candidates.push({
@@ -299,6 +372,7 @@ async function queryCrossref(request: DoiAugmentRequest, email: string): Promise
         }
     }
 
+    logQueryOutcome("crossref", title, items.length, candidates, rejected);
     return candidates;
 }
 
@@ -311,13 +385,17 @@ async function queryOpenAlex(request: DoiAugmentRequest, email: string): Promise
     const cleaned = cleanTitleForSearch(title);
     const url = `${OPENALEX_BASE}?filter=title.search:${encodeURIComponent(cleaned)}&select=id,doi,title,publication_year,authorships,primary_location,locations&per_page=5&mailto=${encodeURIComponent(email)}`;
 
+    debugLog(`Augment [openalex] query: "${cleaned}"`);
     const response = await fetch(url);
     if (response.status === 429) {
         // Rate-limited — throw so Promise.allSettled marks this as rejected and
         // the caller falls back to Crossref results.
         throw new Error("OpenAlex rate limited (429)");
     }
-    if (!response.ok) return [];
+    if (!response.ok) {
+        debugWarn(`Augment [openalex] HTTP ${response.status} for "${cleaned}" — no candidates`);
+        return [];
+    }
 
     const data = (await response.json()) as {
         results?: Array<{
@@ -332,12 +410,17 @@ async function queryOpenAlex(request: DoiAugmentRequest, email: string): Promise
 
     const works = data.results ?? [];
     const candidates: DoiCandidate[] = [];
+    const rejected: Array<{score: number; coverage: number; title: string}> = [];
 
     for (const work of works) {
         if (!work.doi || !work.title) continue;
 
         const tsr = tokenSetRatio(title, work.title);
-        if (tsr >= MATCH_THRESHOLD_TSR) {
+        const coverage = titleCoverage(title, work.title);
+        if (tsr < MATCH_THRESHOLD_TSR || coverage < MATCH_THRESHOLD_COVERAGE) {
+            rejected.push({score: tsr, coverage, title: work.title});
+        }
+        if (tsr >= MATCH_THRESHOLD_TSR && coverage >= MATCH_THRESHOLD_COVERAGE) {
             const doi = normaliseDOI(work.doi);
             if (doi) {
                 candidates.push({
@@ -360,6 +443,7 @@ async function queryOpenAlex(request: DoiAugmentRequest, email: string): Promise
         }
     }
 
+    logQueryOutcome("openalex", title, works.length, candidates, rejected);
     return candidates;
 }
 
@@ -372,7 +456,23 @@ async function queryOpenAlex(request: DoiAugmentRequest, email: string): Promise
 export async function augmentDOIs(
     inputs: Array<string | DoiAugmentRequest>
 ): Promise<Map<string, DoiString | null>> {
-    const results = new Map<string, DoiString | null>();
+    const detailed = await augmentDOIsDetailed(inputs);
+    return new Map([...detailed].map(([title, r]) => [title, r.doi] as const));
+}
+
+/** Where a resolved DOI came from. "cache" means no platform was queried. */
+export type AugmentSource = "crossref" | "openalex" | "both" | "cache";
+
+export interface AugmentOutcome {
+    doi: DoiString | null;
+    source: AugmentSource | null;
+}
+
+/** As `augmentDOIs`, but reports which platform produced each DOI. */
+export async function augmentDOIsDetailed(
+    inputs: Array<string | DoiAugmentRequest>
+): Promise<Map<string, AugmentOutcome>> {
+    const results = new Map<string, AugmentOutcome>();
     if (inputs.length === 0) return results;
     const requests = inputs.map(normalizeRequest).filter((request) => request.title.trim());
     if (requests.length === 0) return results;
@@ -390,7 +490,12 @@ export async function augmentDOIs(
         const key = keyByTitle.get(request.title)!;
         const entry = cached.get(key);
         if (entry) {
-            results.set(request.title, entry.found && entry.doi ? normaliseDOI(entry.doi) : null);
+            const cachedDoi = entry.found && entry.doi ? normaliseDOI(entry.doi) : null;
+            debugLog(
+                `Augment: "${request.title.slice(0, 80)}" → ${cachedDoi ?? "no match"} from cache`
+                + " (no platform queried; clear flora_doi_blob to re-resolve)"
+            );
+            results.set(request.title, {doi: cachedDoi, source: cachedDoi ? "cache" : null});
         } else {
             const group = uncachedByKey.get(key);
             if (group) group.push(request);
@@ -406,8 +511,12 @@ export async function augmentDOIs(
     // configures their email.
     const email = await getUserEmail();
     if (!email) {
+        debugWarn(
+            `Augment: no contact email configured — skipping ${uncachedByKey.size} title(s);`
+            + " neither Crossref nor OpenAlex will be queried"
+        );
         for (const group of uncachedByKey.values()) {
-            for (const request of group) results.set(request.title, null);
+            for (const request of group) results.set(request.title, {doi: null, source: null});
         }
         return results;
     }
@@ -425,7 +534,9 @@ export async function augmentDOIs(
 
         const candidates: DoiCandidate[] = [];
         if (crossrefResult.status === "fulfilled") candidates.push(...crossrefResult.value);
+        else debugWarn(`Augment [crossref] query threw for "${request.title.slice(0, 80)}" —`, crossrefResult.reason);
         if (openalexResult.status === "fulfilled") candidates.push(...openalexResult.value);
+        else debugWarn(`Augment [openalex] query threw for "${request.title.slice(0, 80)}" —`, openalexResult.reason);
 
         // Deduplicate by DOI, merging metadata across the two sources so a
         // candidate seen by both keeps the author/year/urls either provided.
@@ -435,6 +546,10 @@ export async function augmentDOIs(
             if (!existing) {
                 byDoi.set(c.doi, c);
             } else {
+                debugLog(
+                    `Augment: ${c.doi} returned by both platforms`
+                    + ` (crossref/openalex scores ${existing.score.toFixed(1)}/${c.score.toFixed(1)})`
+                );
                 byDoi.set(c.doi, {
                     ...(c.score > existing.score ? c : existing),
                     firstAuthor: existing.firstAuthor ?? c.firstAuthor,
@@ -446,7 +561,11 @@ export async function augmentDOIs(
 
         const best = selectBestCandidate(request, [...byDoi.values()]);
         const doi = best?.doi ?? null;
-        for (const r of group) results.set(r.title, doi);
+        const seenIn = new Set(candidates.filter((c) => c.doi === doi).map((c) => c.source));
+        const source: AugmentSource | null = !best
+            ? null
+            : seenIn.size > 1 ? "both" : best.source;
+        for (const r of group) results.set(r.title, {doi, source});
         updates.push([key, {found: doi !== null, doi}]);
     });
 
@@ -456,7 +575,7 @@ export async function augmentDOIs(
 
     // Defensive: set null for any titles a rejected lookup left unresolved.
     for (const request of requests) {
-        if (!results.has(request.title)) results.set(request.title, null);
+        if (!results.has(request.title)) results.set(request.title, {doi: null, source: null});
     }
 
     return results;

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -1,4 +1,6 @@
 import type {DoiString, DoiAugmentRequest, ReplicationResult, RetractionResponse} from "./types";
+import type {AugmentSource} from "./doi-augment";
+import {debugLog} from "./debug";
 import type {DebugLogEntry} from "./debug";
 
 /** Any context → service worker: captured debug entries to persist. */
@@ -106,6 +108,8 @@ export interface AugmentRequest {
 export interface AugmentResponse {
     type: "FLORA_AUGMENT_RESULT";
     results: Record<string, string | null>;
+    /** title → which platform resolved it, so the page log can name it. */
+    sources?: Record<string, AugmentSource | null>;
 }
 
 export function isAugmentRequest(msg: unknown): msg is AugmentRequest {
@@ -171,6 +175,13 @@ export async function augmentDOIsViaWorker(
     const result = new Map<string, DoiString | null>();
     for (const [title, doi] of Object.entries(response?.results ?? {})) {
         result.set(title, doi as DoiString | null);
+        // Resolution happens in the service worker, so without this the page
+        // console never says which platform answered.
+        const source = response?.sources?.[title];
+        debugLog(
+            `Augment: "${title.slice(0, 80)}" → ${doi ?? "no match"}`
+            + (source ? ` via ${source.toUpperCase()}` : "")
+        );
     }
     return result;
 }

--- a/tests/unit/augment-coverage.test.ts
+++ b/tests/unit/augment-coverage.test.ts
@@ -1,0 +1,44 @@
+import {describe, expect, it} from "vitest";
+import {titleCoverage, tokenSetRatio} from "../../src/shared/doi-augment";
+
+const COVERAGE_THRESHOLD = 75;
+
+describe("title coverage guard", () => {
+    // research.rug.nl/en/publications/failure-to-replicate-increasing-generosity-by-eyes
+    // resolved to a 2022 New Scientist item called simply "Failure to replicate".
+    it("rejects a generic title that is a subset of the queried one", () => {
+        const query = "Failure to replicate increasing generosity by eyes";
+        const candidate = "Failure to replicate";
+
+        expect(tokenSetRatio(query, candidate)).toBe(100);
+        expect(titleCoverage(query, candidate)).toBeLessThan(COVERAGE_THRESHOLD);
+    });
+
+    it("keeps a candidate that only lacks the subtitle", () => {
+        const query = "Estimating the reproducibility of psychological science: a replication";
+        const candidate = "Estimating the reproducibility of psychological science";
+
+        expect(titleCoverage(query, candidate)).toBeGreaterThanOrEqual(COVERAGE_THRESHOLD);
+    });
+
+    it.each([
+        ["The FAIR Guiding Principles for scientific data management and stewardship",
+         "The FAIR Guiding Principles for scientific data management and stewardship"],
+        ["A manifesto for reproducible science", "A manifesto for reproducible science"],
+    ])("keeps an exact match (%s)", (query, candidate) => {
+        expect(titleCoverage(query, candidate)).toBe(100);
+    });
+
+    it("is unaffected by extra words in the candidate", () => {
+        // Supersets still cover the query fully; the tie-break handles those.
+        const query = "The FAIR Guiding Principles for scientific data management and stewardship";
+        const candidate = "Addendum: The FAIR Guiding Principles for scientific data management and stewardship";
+
+        expect(titleCoverage(query, candidate)).toBe(100);
+    });
+
+    it("scores nothing for an unrelated title", () => {
+        expect(titleCoverage("Failure to replicate increasing generosity by eyes", "Cell migration in zebrafish"))
+            .toBeLessThan(COVERAGE_THRESHOLD);
+    });
+});

--- a/tests/unit/augment-provenance.test.ts
+++ b/tests/unit/augment-provenance.test.ts
@@ -1,0 +1,55 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
+
+describe("augment provenance in the page console", () => {
+    let logSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(async () => {
+        vi.resetModules();
+        logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+        const {setDebug, _resetDebugForTesting} = await import("../../src/shared/debug");
+        _resetDebugForTesting();
+        setDebug(true);
+    });
+
+    afterEach(async () => {
+        logSpy.mockRestore();
+        const {_resetDebugForTesting} = await import("../../src/shared/debug");
+        _resetDebugForTesting();
+    });
+
+    function lines(): string {
+        return logSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+    }
+
+    it.each([
+        ["crossref", "via CROSSREF"],
+        ["openalex", "via OPENALEX"],
+        ["both", "via BOTH"],
+        ["cache", "via CACHE"],
+    ])("names %s as the resolving platform", async (source, expected) => {
+        (chrome.runtime.sendMessage as ReturnType<typeof vi.fn>).mockResolvedValue({
+            type: "FLORA_AUGMENT_RESULT",
+            results: {"A test title": "10.1234/abc"},
+            sources: {"A test title": source},
+        });
+
+        const {augmentDOIsViaWorker} = await import("../../src/shared/messages");
+        const result = await augmentDOIsViaWorker(["A test title"]);
+
+        expect(result.get("A test title")).toBe("10.1234/abc");
+        expect(lines()).toContain(`Augment: "A test title" → 10.1234/abc ${expected}`);
+    });
+
+    it("still logs when nothing resolved", async () => {
+        (chrome.runtime.sendMessage as ReturnType<typeof vi.fn>).mockResolvedValue({
+            type: "FLORA_AUGMENT_RESULT",
+            results: {"A test title": null},
+            sources: {"A test title": null},
+        });
+
+        const {augmentDOIsViaWorker} = await import("../../src/shared/messages");
+        await augmentDOIsViaWorker(["A test title"]);
+
+        expect(lines()).toContain(`Augment: "A test title" → no match`);
+    });
+});

--- a/tests/unit/blob-cache-invalidation.test.ts
+++ b/tests/unit/blob-cache-invalidation.test.ts
@@ -1,0 +1,79 @@
+import {beforeEach, describe, expect, it, vi} from "vitest";
+import {BlobCache} from "../../src/shared/blob-cache";
+
+const KEY = "flora_test_blob";
+
+type Listener = (changes: Record<string, {newValue?: unknown}>, area: string) => void;
+
+function storageListeners(): Listener[] {
+    return (chrome.storage.onChanged.addListener as ReturnType<typeof vi.fn>).mock.calls.map(
+        (call) => call[0] as Listener
+    );
+}
+
+/** Simulate a write landing in chrome.storage from anywhere. */
+function announce(newValue: unknown): void {
+    for (const listener of storageListeners()) listener({[KEY]: {newValue}}, "local");
+}
+
+describe("BlobCache invalidation", () => {
+    let store: Record<string, unknown>;
+
+    beforeEach(() => {
+        store = {};
+        (chrome.storage.local.get as ReturnType<typeof vi.fn>).mockImplementation(
+            async (k: string) => (k in store ? {[k]: store[k]} : {})
+        );
+        (chrome.storage.local.set as ReturnType<typeof vi.fn>).mockImplementation(
+            async (items: Record<string, unknown>) => Object.assign(store, items)
+        );
+        (chrome.storage.local.remove as ReturnType<typeof vi.fn>).mockImplementation(
+            async (k: string) => { delete store[k]; }
+        );
+        (chrome.storage.onChanged.addListener as ReturnType<typeof vi.fn>).mockClear();
+    });
+
+    it("stops serving entries once the blob is cleared elsewhere", async () => {
+        store[KEY] = {alpha: {v: "cached", t: Date.now()}};
+        const cache = new BlobCache<string>({storageKey: KEY, ttlMs: 60_000});
+
+        expect(await cache.get("alpha")).toBe("cached");
+
+        delete store[KEY];
+        announce(undefined);
+
+        expect(await cache.get("alpha")).toBeUndefined();
+    });
+
+    it("does not write a cleared entry back on the next save", async () => {
+        store[KEY] = {alpha: {v: "cached", t: Date.now()}};
+        const cache = new BlobCache<string>({storageKey: KEY, ttlMs: 60_000});
+        await cache.get("alpha");
+
+        delete store[KEY];
+        announce(undefined);
+        await cache.set("beta", "fresh");
+
+        expect(Object.keys(store[KEY] as object)).toEqual(["beta"]);
+    });
+
+    it("picks up a blob another context wrote", async () => {
+        const cache = new BlobCache<string>({storageKey: KEY, ttlMs: 60_000});
+        expect(await cache.get("alpha")).toBeUndefined();
+
+        announce({alpha: {v: "from another context", t: Date.now()}});
+
+        expect(await cache.get("alpha")).toBe("from another context");
+    });
+
+    it("clear() empties memory and storage together", async () => {
+        store[KEY] = {alpha: {v: "cached", t: Date.now()}};
+        const cache = new BlobCache<string>({storageKey: KEY, ttlMs: 60_000});
+        await cache.get("alpha");
+
+        await cache.clear();
+
+        expect(store[KEY]).toBeUndefined();
+        expect(await cache.get("alpha")).toBeUndefined();
+    });
+});


### PR DESCRIPTION
Record which platform produced DOI results and harden blob cache invalidation.

- Introduce augmentDOIsDetailed() and AugmentSource/AugmentOutcome so augmenters report provenance (crossref/openalex/both/cache). augmentDOIs() now delegates to the detailed variant.
- Service worker uses augmentDOIsDetailed and includes a `sources` map on FLORA_AUGMENT_RESULT so pages can log which platform resolved each title.
- Improve matching: add titleCoverage() and a coverage threshold to avoid short/generic titles matching long queries. Add richer debug logging for queries, rejections, ties, and HTTP failures; handle OpenAlex rate limits explicitly.
- BlobCache: add generation counter, storage.onChanged listener (installInvalidation) to drop in-memory blob when storage changes elsewhere, make load/generation race-safe, add clear(), and adjust resetForTesting.
- Update message handling to log provenance in the page console.
- Add unit tests: augment-coverage.test.ts, augment-provenance.test.ts, blob-cache-invalidation.test.ts to cover coverage guard, provenance logging, and cache invalidation behavior.

Notes: Existing augmentDOIs callers keep the same DOI-only return shape via the wrapper; the service worker message now optionally includes sources so pages can display provenance.