### PR TITLE
Schedule daily retraction sync via alarms

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,8 @@
   "permissions": [
     "storage",
     "unlimitedStorage",
-    "activeTab"
+    "activeTab",
+    "alarms"
   ],
   "action": {
     "default_popup": "dist/popup.html"

--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -94,6 +94,22 @@ chrome.runtime.onStartup.addListener(() => {
     syncRetractionsInfo().then().catch();
 });
 
+const RETRACTION_SYNC_ALARM = "flora-retraction-sync";
+
+async function ensureRetractionSyncAlarm(): Promise<void> {
+    // Re-creating an alarm restarts its countdown, and this runs on every worker wake.
+    const existing = await chrome.alarms.get(RETRACTION_SYNC_ALARM);
+    if (!existing) chrome.alarms.create(RETRACTION_SYNC_ALARM, {periodInMinutes: 60 * 24});
+}
+
+chrome.alarms.onAlarm.addListener((alarm) => {
+    if (alarm.name === RETRACTION_SYNC_ALARM) syncRetractionsInfo().then().catch();
+});
+
+ensureRetractionSyncAlarm().catch((err) => {
+    debugWarn("Retractions: could not schedule the daily refresh alarm —", err);
+});
+
 
 /** In-flight dedup: prevents duplicate API calls for the same DOI */
 const inflight = new Map<DoiString, Promise<ReplicationResult | null>>();

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -47,6 +47,14 @@ Object.defineProperty(globalThis, "chrome", {
       },
       openOptionsPage: vi.fn(),
     },
+    alarms: {
+      get: vi.fn().mockResolvedValue(undefined),
+      create: vi.fn(),
+      clear: vi.fn().mockResolvedValue(true),
+      onAlarm: {
+        addListener: vi.fn(),
+      },
+    },
     tabs: {
       create: vi.fn(),
       onUpdated: {

--- a/tests/unit/service-worker.test.ts
+++ b/tests/unit/service-worker.test.ts
@@ -28,6 +28,13 @@ vi.mock("../../src/shared/settings", () => ({
     getSettings: vi.fn().mockResolvedValue({email: "test@example.com", cacheQuotaMb: 500}),
 }));
 
+// Mock the retraction download so no test reaches the network
+const mockStorageSync = vi.fn().mockResolvedValue(true);
+vi.mock("../../src/shared/data-extract", async (importOriginal) => ({
+    ...(await importOriginal<typeof import("../../src/shared/data-extract")>()),
+    storageSync: () => mockStorageSync(),
+}));
+
 // Mock cache
 const cacheStore = new Map<string, unknown>();
 // Records every cache.set(key, data, ttlMs) so tests can assert TTL is applied.
@@ -65,6 +72,7 @@ describe("service-worker", () => {
         sender: unknown,
         sendResponse: (response: unknown) => void
     ) => boolean | undefined;
+    let alarmHandler: (alarm: {name: string}) => void;
 
     beforeEach(async () => {
         cacheStore.clear();
@@ -72,17 +80,24 @@ describe("service-worker", () => {
         cacheSetError = null;
         mockLookupDOIs.mockReset();
         mockResolvePmcIds.mockReset();
+        mockStorageSync.mockClear();
         (chrome.storage.local.get as ReturnType<typeof vi.fn>).mockResolvedValue({});
+        (chrome.alarms.get as ReturnType<typeof vi.fn>).mockReset().mockResolvedValue(undefined);
+        (chrome.alarms.create as ReturnType<typeof vi.fn>).mockReset();
 
 
         const addListenerMock = vi.fn();
         (chrome.runtime.onMessage.addListener as ReturnType<typeof vi.fn>) =
             addListenerMock;
+        const alarmListenerMock = vi.fn();
+        (chrome.alarms.onAlarm.addListener as ReturnType<typeof vi.fn>) =
+            alarmListenerMock;
 
         vi.resetModules();
         await import("../../src/background/service-worker");
 
         messageHandler = addListenerMock.mock.calls[0][0];
+        alarmHandler = alarmListenerMock.mock.calls[0][0];
     });
 
     function sendMessage(request: LookupRequest): Promise<LookupResponse> {
@@ -344,6 +359,46 @@ describe("service-worker", () => {
             expect(response.results).toEqual([]);
             expect(response.error).toBeTruthy();
             vi.unstubAllGlobals();
+        });
+    });
+
+    describe("scheduled retraction refresh", () => {
+        it("creates a daily alarm when none exists", async () => {
+            await vi.waitFor(() =>
+                expect(chrome.alarms.create).toHaveBeenCalledWith(
+                    "flora-retraction-sync",
+                    {periodInMinutes: 60 * 24}
+                )
+            );
+        });
+
+        it("does not recreate an existing alarm", async () => {
+            (chrome.alarms.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+                name: "flora-retraction-sync",
+            });
+            (chrome.alarms.create as ReturnType<typeof vi.fn>).mockClear();
+
+            vi.resetModules();
+            await import("../../src/background/service-worker");
+
+            await vi.waitFor(() => expect(chrome.alarms.get).toHaveBeenCalled());
+            expect(chrome.alarms.create).not.toHaveBeenCalled();
+        });
+
+        it("syncs retraction data when the alarm fires", async () => {
+            alarmHandler({name: "flora-retraction-sync"});
+
+            await vi.waitFor(() => expect(mockStorageSync).toHaveBeenCalled());
+            expect(chrome.storage.local.set).toHaveBeenCalledWith(
+                expect.objectContaining({synctime: expect.any(Number)})
+            );
+        });
+
+        it("ignores alarms belonging to other features", async () => {
+            alarmHandler({name: "some-other-alarm"});
+
+            await Promise.resolve();
+            expect(mockStorageSync).not.toHaveBeenCalled();
         });
     });
 


### PR DESCRIPTION
Add alarm-based scheduling for daily retraction refresh: grant the alarms permission in manifest.json, create/ensure a daily alarm in the service worker, and listen for chrome.alarms to trigger syncRetractionsInfo. Update tests and test setup to mock chrome.alarms and the retraction download; add unit tests covering alarm creation, non-recreation when already present, alarm-triggered sync, and ignoring unrelated alarms.