### PR TITLE
Don't cache no-match on provider outages

### DIFF
--- a/src/shared/doi-augment.ts
+++ b/src/shared/doi-augment.ts
@@ -323,10 +323,7 @@ async function queryCrossref(request: DoiAugmentRequest, email: string): Promise
     const url = `${CROSSREF_BASE}?query.title=${encodeURIComponent(cleaned)}&rows=5&select=DOI,title,author,issued,published-print,published-online,published,URL,link&mailto=${encodeURIComponent(email)}`;
     debugLog(`Augment [crossref] query: "${cleaned}"`);
     const response = await fetch(url);
-    if (!response.ok) {
-        debugWarn(`Augment [crossref] HTTP ${response.status} for "${cleaned}" — no candidates`);
-        return [];
-    }
+    if (!response.ok) throw new Error(`Crossref HTTP ${response.status}`);
 
     const data = (await response.json()) as {
         message?: {
@@ -387,15 +384,7 @@ async function queryOpenAlex(request: DoiAugmentRequest, email: string): Promise
 
     debugLog(`Augment [openalex] query: "${cleaned}"`);
     const response = await fetch(url);
-    if (response.status === 429) {
-        // Rate-limited — throw so Promise.allSettled marks this as rejected and
-        // the caller falls back to Crossref results.
-        throw new Error("OpenAlex rate limited (429)");
-    }
-    if (!response.ok) {
-        debugWarn(`Augment [openalex] HTTP ${response.status} for "${cleaned}" — no candidates`);
-        return [];
-    }
+    if (!response.ok) throw new Error(`OpenAlex HTTP ${response.status}`);
 
     const data = (await response.json()) as {
         results?: Array<{
@@ -566,7 +555,17 @@ export async function augmentDOIsDetailed(
             ? null
             : seenIn.size > 1 ? "both" : best.source;
         for (const r of group) results.set(r.title, {doi, source});
-        updates.push([key, {found: doi !== null, doi}]);
+
+        const answered =
+            crossrefResult.status === "fulfilled" || openalexResult.status === "fulfilled";
+        if (answered) {
+            updates.push([key, {found: doi !== null, doi}]);
+        } else {
+            debugWarn(
+                `Augment: neither platform answered for "${request.title.slice(0, 80)}"`
+                + " — not caching the no-match so it retries next time"
+            );
+        }
     });
 
     await Promise.allSettled(lookupPromises);
@@ -598,11 +597,14 @@ export async function fetchTitleByDoi(doi: string): Promise<string | null> {
     if (cached) return cached.title;
 
     let title: string | null = null;
+    let crossrefAnswered = false;
+    let openalexAnswered = false;
 
     try {
         const email = await getUserEmail();
         const mailto = email ? `?mailto=${encodeURIComponent(email)}` : "";
         const response = await fetch(`${CROSSREF_BASE}/${doi}${mailto}`);
+        crossrefAnswered = response.ok || response.status === 404;
         if (response.ok) {
             const data = (await response.json()) as { message?: { title?: string[] } };
             title = data.message?.title?.[0] ?? null;
@@ -614,6 +616,7 @@ export async function fetchTitleByDoi(doi: string): Promise<string | null> {
     if (!title) {
         try {
             const response = await fetch(`${OPENALEX_BASE}/doi:${doi}?select=title`);
+            openalexAnswered = response.ok || response.status === 404;
             if (response.ok) {
                 const data = (await response.json()) as { title?: string };
                 title = data.title ?? null;
@@ -623,7 +626,9 @@ export async function fetchTitleByDoi(doi: string): Promise<string | null> {
         }
     }
 
-    void TITLE_CACHE.set(doi, {title});
+    if (title !== null || (crossrefAnswered && openalexAnswered)) {
+        void TITLE_CACHE.set(doi, {title});
+    }
     return title;
 }
 

--- a/tests/unit/doi-augment.test.ts
+++ b/tests/unit/doi-augment.test.ts
@@ -8,7 +8,7 @@ vi.mock("../../src/shared/settings", () => ({
   isSetupComplete: vi.fn().mockResolvedValue(true),
 }));
 
-import { normalizeTitle, similarity, tokenSetRatio, augmentDOIs, _resetAugmentCachesForTesting } from "../../src/shared/doi-augment";
+import { normalizeTitle, similarity, tokenSetRatio, augmentDOIs, fetchTitleByDoi, _resetAugmentCachesForTesting } from "../../src/shared/doi-augment";
 import { getSettings } from "../../src/shared/settings";
 
 const OPENALEX_URL = "https://api.openalex.org/works";
@@ -387,6 +387,70 @@ describe("augmentDOIs", () => {
     expect(setSpy).not.toHaveBeenCalled(); // and crucially never poisoned the cache
   });
 
+  it("does not cache a no-match when neither platform answered", async () => {
+    server.use(
+      http.get(CROSSREF_URL, () => HttpResponse.error()),
+      http.get(OPENALEX_URL, () => HttpResponse.error())
+    );
+    const setSpy = chrome.storage.local.set as ReturnType<typeof vi.fn>;
+    setSpy.mockClear();
+
+    const results = await augmentDOIs(["An Offline Paper"]);
+
+    expect(results.get("An Offline Paper")).toBeNull();
+    expect(setSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not cache a no-match when both platforms are down", async () => {
+    server.use(
+      http.get(CROSSREF_URL, () => new HttpResponse(null, { status: 503 })),
+      http.get(OPENALEX_URL, () => new HttpResponse(null, { status: 503 }))
+    );
+    const setSpy = chrome.storage.local.set as ReturnType<typeof vi.fn>;
+    setSpy.mockClear();
+
+    const results = await augmentDOIs(["A Paper During An Outage"]);
+
+    expect(results.get("A Paper During An Outage")).toBeNull();
+    expect(setSpy).not.toHaveBeenCalled();
+  });
+
+  it("caches a no-match when one platform answered", async () => {
+    server.use(
+      http.get(CROSSREF_URL, () => HttpResponse.json({ message: { items: [] } })),
+      http.get(OPENALEX_URL, () => new HttpResponse(null, { status: 503 }))
+    );
+    const setSpy = chrome.storage.local.set as ReturnType<typeof vi.fn>;
+    setSpy.mockClear();
+
+    const results = await augmentDOIs(["A Genuinely Unknown Paper"]);
+
+    expect(results.get("A Genuinely Unknown Paper")).toBeNull();
+    expect(setSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-queries a title after a failed lookup instead of serving a cached miss", async () => {
+    server.use(
+      http.get(CROSSREF_URL, () => HttpResponse.error()),
+      http.get(OPENALEX_URL, () => HttpResponse.error())
+    );
+
+    expect((await augmentDOIs(["A Retried Paper"])).get("A Retried Paper")).toBeNull();
+
+    server.use(
+      http.get(CROSSREF_URL, () =>
+        HttpResponse.json({
+          message: { items: [{ DOI: "10.1038/retried", title: ["A Retried Paper"] }] },
+        })
+      ),
+      http.get(OPENALEX_URL, () => HttpResponse.json({ results: [] }))
+    );
+
+    expect((await augmentDOIs(["A Retried Paper"])).get("A Retried Paper")).toBe(
+      "10.1038/retried"
+    );
+  });
+
   it("deduplicates titles that share a normalized key", async () => {
     let crossrefHits = 0;
     server.use(
@@ -600,5 +664,57 @@ describe("augmentDOIs", () => {
     const results = await augmentDOIs([{ title, firstAuthor: "Vaswani", year: 2017 }]);
 
     expect(results.get(title)).toBeNull();
+  });
+});
+
+describe("fetchTitleByDoi", () => {
+  const DOI = "10.1038/nature12373";
+  const CROSSREF_WORK = `${CROSSREF_URL}/*`;
+  const OPENALEX_WORK = "https://api.openalex.org/works/*";
+
+  beforeEach(() => {
+    (chrome.storage.local.get as ReturnType<typeof vi.fn>).mockResolvedValue({});
+    (chrome.storage.local.set as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+    _resetAugmentCachesForTesting();
+  });
+
+  it("does not cache a null title when a platform never answered", async () => {
+    server.use(
+      http.get(CROSSREF_WORK, () => new HttpResponse(null, { status: 404 })),
+      http.get(OPENALEX_WORK, () => HttpResponse.error())
+    );
+    const setSpy = chrome.storage.local.set as ReturnType<typeof vi.fn>;
+    setSpy.mockClear();
+
+    expect(await fetchTitleByDoi(DOI)).toBeNull();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(setSpy).not.toHaveBeenCalled();
+  });
+
+  it("caches a null title when both platforms answered", async () => {
+    server.use(
+      http.get(CROSSREF_WORK, () => new HttpResponse(null, { status: 404 })),
+      http.get(OPENALEX_WORK, () => new HttpResponse(null, { status: 404 }))
+    );
+    const setSpy = chrome.storage.local.set as ReturnType<typeof vi.fn>;
+    setSpy.mockClear();
+
+    expect(await fetchTitleByDoi(DOI)).toBeNull();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(setSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("caches a title resolved by Crossref", async () => {
+    server.use(
+      http.get(CROSSREF_WORK, () =>
+        HttpResponse.json({ message: { title: ["The Effect of Sleep on Memory Consolidation"] } })
+      )
+    );
+    const setSpy = chrome.storage.local.set as ReturnType<typeof vi.fn>;
+    setSpy.mockClear();
+
+    expect(await fetchTitleByDoi(DOI)).toBe("The Effect of Sleep on Memory Consolidation");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(setSpy).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
Treat non-OK Crossref/OpenAlex responses as errors so failing providers cause rejections instead of empty results. Only write a "no-match" to cache when at least one platform actually answered; similarly track Crossref/OpenAlex answers in fetchTitleByDoi and cache a null title only when both services responded (ok or 404). Adds unit tests covering outage scenarios and caching behavior.