### PR TITLE
Strip query/fragment from DOI normalization

### DIFF
--- a/retractions-updater.ts
+++ b/retractions-updater.ts
@@ -65,6 +65,10 @@ function clean(s: string | undefined): string {
     return (s ?? '').replace(/^"|"$/g, '').trim();
 }
 
+function cleanDoi(s: string | undefined): string {
+    return clean(s).replace(/\?.*$|#.+$/s, "");
+}
+
 function isRealDoi(doi: string): boolean {
     return doi !== '' && doi.toLowerCase() !== 'unavailable';
 }
@@ -97,12 +101,12 @@ export async function getRetractionMap(): Promise<RetractionMaps | undefined> {
         const cols = rows[i];
         const nature = clean(cols[natureIdx]);
         if (!STATUS_NATURES.has(nature)) continue;
-        const originalDOI = clean(cols[originalIdx]);
+        const originalDOI = cleanDoi(cols[originalIdx]);
         if (!isRealDoi(originalDOI)) continue;
         const event: StatusEvent = {
             nature,
             time: parseDate(cols[dateIdx]),
-            notice: clean(cols[noticeIdx]),
+            notice: cleanDoi(cols[noticeIdx]),
         };
         const list = byDoi.get(originalDOI);
         if (list) list.push(event);

--- a/src/shared/doi-normalise.ts
+++ b/src/shared/doi-normalise.ts
@@ -1,5 +1,7 @@
 import type { DoiString } from "./types";
 
+const URL_QUERY_OR_FRAGMENT = /\?.*$|#.+$/s;
+
 const DOI_PREFIXES = [
   "https://doi.org/",
   "http://doi.org/",
@@ -35,6 +37,8 @@ export function normaliseDOI(raw: unknown): DoiString | null {
       break;
     }
   }
+
+  doi = doi.replace(URL_QUERY_OR_FRAGMENT, "");
 
   // A valid DOI starts with "10." followed by a registrant code
   if (!/^10\.\d{4,}/.test(doi)) {

--- a/tests/unit/doi-extractor.test.ts
+++ b/tests/unit/doi-extractor.test.ts
@@ -4,6 +4,7 @@ import { join } from "path";
 import { JSDOM } from "jsdom";
 import {
   extractDOIs,
+  extractDoiFromHref,
   extractDOIsFromText,
   findReferenceContainers,
   findReferenceEntries,
@@ -993,5 +994,31 @@ describe("containsDoiCandidate", () => {
 
   it("is false for a bare year or version number that is not a DOI prefix", () => {
     expect(containsDoiCandidate(el(`<div><span>Published 2019, v10.2 of the toolkit</span></div>`))).toBe(false);
+  });
+});
+
+describe("extractDoiFromHref", () => {
+  it("drops a tracking query string on a doi.org link", () => {
+    expect(extractDoiFromHref("https://doi.org/10.1002/job.2278?af=R")).toBe(
+      "10.1002/job.2278"
+    );
+  });
+
+  it("drops a fragment anchor on a doi.org link", () => {
+    expect(extractDoiFromHref("https://doi.org/10.1002/job.2278#abstract")).toBe(
+      "10.1002/job.2278"
+    );
+  });
+
+  it("drops a tracking query string on a publisher landing page", () => {
+    expect(
+      extractDoiFromHref("https://onlinelibrary.wiley.com/doi/full/10.1002/job.2278?af=R")
+    ).toBe("10.1002/job.2278");
+  });
+
+  it("still reads a DOI out of a doi query param", () => {
+    expect(
+      extractDoiFromHref("https://example.com/article?doi=10.1002/job.2278&src=feed")
+    ).toBe("10.1002/job.2278");
   });
 });

--- a/tests/unit/doi-normalise.test.ts
+++ b/tests/unit/doi-normalise.test.ts
@@ -69,4 +69,44 @@ describe("normaliseDOI", () => {
   it("returns null for just a URL prefix with no DOI", () => {
     expect(normaliseDOI("https://doi.org/")).toBeNull();
   });
+
+  it("strips a publisher tracking query string", () => {
+    expect(normaliseDOI("https://doi.org/10.1002/job.2278?af=R")).toBe(
+      "10.1002/job.2278"
+    );
+  });
+
+  it("strips a fragment anchor", () => {
+    expect(normaliseDOI("https://doi.org/10.1002/job.2278#abstract")).toBe(
+      "10.1002/job.2278"
+    );
+  });
+
+  it("strips a share fragment appended after the DOI", () => {
+    expect(
+      normaliseDOI("https://doi.org/10.1080/09645292.2010.545518#.Us5z4LSsxK0")
+    ).toBe("10.1080/09645292.2010.545518");
+  });
+
+  it("strips a query string that arrived percent-encoded", () => {
+    expect(normaliseDOI("https://doi.org/10.1002%2Fjob.2278%3Faf%3DR")).toBe(
+      "10.1002/job.2278"
+    );
+  });
+
+  it("strips a query string ahead of a fragment", () => {
+    expect(normaliseDOI("https://doi.org/10.1002/job.2278?af=R#abstract")).toBe(
+      "10.1002/job.2278"
+    );
+  });
+
+  it("keeps a trailing '#' — a SICI check character, not a fragment", () => {
+    expect(
+      normaliseDOI("10.1002/(SICI)1097-0142(19960101)77:1<1::AID-CNCR1>3.0.CO;2-#")
+    ).toBe("10.1002/(sici)1097-0142(19960101)77:1<1::aid-cncr1>3.0.co;2-#");
+  });
+
+  it("returns null when the DOI is only a query string", () => {
+    expect(normaliseDOI("https://doi.org/?af=R")).toBeNull();
+  });
 });


### PR DESCRIPTION
Remove URL query strings and fragment anchors when normalising DOIs. Added a URL_QUERY_OR_FRAGMENT regex to src/shared/doi-normalise.ts and apply it before DOI validation. Introduced cleanDoi in retractions-updater.ts and used it for original DOI and notice fields to avoid retaining tracking params. Added unit tests: extractDoiFromHref tests in doi-extractor.test.ts and multiple normaliseDOI cases in doi-normalise.test.ts (including percent-encoded queries and SICI '#' edge-case).