### PR TITLE
Add expiry trimming and max entries to BlobCache

### DIFF
--- a/src/shared/blob-cache.ts
+++ b/src/shared/blob-cache.ts
@@ -11,9 +11,12 @@ interface CacheEntry<T> {
 
 type CacheBlob<T> = Record<string, CacheEntry<T>>;
 
+const DEFAULT_MAX_ENTRIES = 5000;
+
 export interface BlobCacheOptions {
     storageKey: string;
     ttlMs: number;
+    maxEntries?: number;
     /** One-shot cleanup of legacy per-row keys from the pre-blob cache shape. */
     legacyPrefixes?: string[];
 }
@@ -72,8 +75,15 @@ export class BlobCache<T> {
         } catch (err) {
             debugWarn(`Cache ${this.opts.storageKey}: load failed, starting empty —`, err);
         }
+        const dropped = this.sweepExpired(blob);
         // A change landed mid-read; the listener's copy is the newer truth.
-        if (generation === this.generation) this.mem = blob;
+        if (generation === this.generation) {
+            this.mem = blob;
+            if (dropped > 0) {
+                debugLog(`Cache ${this.opts.storageKey}: dropped ${dropped} expired entr(ies) on load`);
+                void this.flush();
+            }
+        }
         if (this.opts.legacyPrefixes && this.opts.legacyPrefixes.length > 0) {
             void this.sweepLegacy(this.opts.legacyPrefixes);
         }
@@ -139,8 +149,35 @@ export class BlobCache<T> {
         await this.flush();
     }
 
+    private sweepExpired(blob: CacheBlob<T>): number {
+        const now = Date.now();
+        let dropped = 0;
+        for (const key of Object.keys(blob)) {
+            if (now - blob[key].t > this.opts.ttlMs) {
+                delete blob[key];
+                dropped++;
+            }
+        }
+        return dropped;
+    }
+
+    private trimToMaxEntries(blob: CacheBlob<T>): number {
+        const max = this.opts.maxEntries ?? DEFAULT_MAX_ENTRIES;
+        const keys = Object.keys(blob);
+        if (keys.length <= max) return 0;
+        keys.sort((a, b) => blob[a].t - blob[b].t);
+        const dropCount = keys.length - max;
+        for (let i = 0; i < dropCount; i++) delete blob[keys[i]];
+        return dropCount;
+    }
+
     private async flush(): Promise<void> {
         if (!this.mem) return;
+        this.sweepExpired(this.mem);
+        const trimmed = this.trimToMaxEntries(this.mem);
+        if (trimmed > 0) {
+            debugLog(`Cache ${this.opts.storageKey}: trimmed ${trimmed} oldest entr(ies) over the cap`);
+        }
         try {
             await chrome.storage.local.set({[this.opts.storageKey]: this.mem});
         } catch {

--- a/src/shared/citation.ts
+++ b/src/shared/citation.ts
@@ -61,6 +61,7 @@ export interface Citation {
 const CITATION_CACHE = new BlobCache<{text: string; html?: string | null}>({
     storageKey: "flora_citation_blob",
     ttlMs: 90 * 24 * 60 * 60 * 1000, // 90 days — a published record's citation is stable
+    maxEntries: 1500,
 });
 
 const inflight = new Map<string, Promise<Citation | null>>();

--- a/tests/unit/blob-cache-expiry.test.ts
+++ b/tests/unit/blob-cache-expiry.test.ts
@@ -1,0 +1,87 @@
+import {beforeEach, describe, expect, it, vi} from "vitest";
+import {BlobCache} from "../../src/shared/blob-cache";
+
+const KEY = "flora_test_blob";
+const TTL = 60_000;
+
+describe("BlobCache expiry sweeping", () => {
+    let store: Record<string, any>;
+
+    beforeEach(() => {
+        store = {};
+        (chrome.storage.local.get as ReturnType<typeof vi.fn>).mockImplementation(
+            async (k: string) => (k in store ? {[k]: store[k]} : {})
+        );
+        (chrome.storage.local.set as ReturnType<typeof vi.fn>).mockImplementation(
+            async (items: Record<string, unknown>) => Object.assign(store, items)
+        );
+        (chrome.storage.local.remove as ReturnType<typeof vi.fn>).mockImplementation(
+            async (k: string) => { delete store[k]; }
+        );
+    });
+
+    function storedKeys(): string[] {
+        return Object.keys((store[KEY] ?? {}) as object);
+    }
+
+    it("drops expired entries on load even though nobody queries them", async () => {
+        const now = Date.now();
+        store[KEY] = {
+            stale: {v: "old", t: now - TTL - 1},
+            fresh: {v: "new", t: now},
+        };
+        const cache = new BlobCache<string>({storageKey: KEY, ttlMs: TTL});
+
+        expect(await cache.get("fresh")).toBe("new");
+        await vi.waitFor(() => expect(storedKeys()).toEqual(["fresh"]));
+    });
+
+    it("writes the pruned blob back when only reads happen", async () => {
+        const now = Date.now();
+        store[KEY] = {stale: {v: "old", t: now - TTL - 1}};
+        const cache = new BlobCache<string>({storageKey: KEY, ttlMs: TTL});
+
+        expect(await cache.get("missing")).toBeUndefined();
+        await vi.waitFor(() => expect(storedKeys()).toEqual([]));
+    });
+
+    it("prunes expired entries of other keys on write", async () => {
+        const now = Date.now();
+        store[KEY] = {stale: {v: "old", t: now - TTL - 1}};
+        const cache = new BlobCache<string>({storageKey: KEY, ttlMs: TTL});
+        await cache.set("beta", "fresh");
+
+        expect(storedKeys()).toEqual(["beta"]);
+    });
+
+    it("keeps unexpired entries", async () => {
+        const now = Date.now();
+        store[KEY] = {alpha: {v: "still good", t: now - TTL + 5_000}};
+        const cache = new BlobCache<string>({storageKey: KEY, ttlMs: TTL});
+        await cache.set("beta", "fresh");
+
+        expect(storedKeys().sort()).toEqual(["alpha", "beta"]);
+        expect(await cache.get("alpha")).toBe("still good");
+    });
+
+    it("trims the oldest entries once the cap is exceeded", async () => {
+        const now = Date.now();
+        store[KEY] = {
+            oldest: {v: "1", t: now - 3_000},
+            middle: {v: "2", t: now - 2_000},
+            newest: {v: "3", t: now - 1_000},
+        };
+        const cache = new BlobCache<string>({storageKey: KEY, ttlMs: TTL, maxEntries: 3});
+        await cache.set("added", "4");
+
+        expect(storedKeys().sort()).toEqual(["added", "middle", "newest"]);
+        expect(await cache.get("oldest")).toBeUndefined();
+    });
+
+    it("does not trim while under the cap", async () => {
+        const cache = new BlobCache<string>({storageKey: KEY, ttlMs: TTL, maxEntries: 3});
+        await cache.setMany([["a", "1"], ["b", "2"]]);
+
+        expect(storedKeys().sort()).toEqual(["a", "b"]);
+    });
+});


### PR DESCRIPTION
Introduce DEFAULT_MAX_ENTRIES and a maxEntries option to BlobCache. Add sweepExpired (used on load and before flush) to drop stale entries and trimToMaxEntries to evict oldest entries when the cap is exceeded; flush now applies both and logs drop/trim events. Set citation cache maxEntries to 1500. Add unit tests (tests/unit/blob-cache-expiry.test.ts) covering expiry sweeping, write-back on read-only loads, pruning on write, and trimming behavior.