### PR TITLE
Normalize PubPeer DOI casing for cache/requests

### DIFF
--- a/src/shared/pubpeer-api.ts
+++ b/src/shared/pubpeer-api.ts
@@ -47,6 +47,8 @@ export async function lookupPubPeer(
 
 const CACHE_TTL = 24 * 60 * 60 * 1000; // 24h
 
+const cacheKey = (doi: string): string => doi.toLowerCase();
+
 const PUBPEER_CACHE = new BlobCache<{ feedback: PubPeerFeedback | null }>({
   storageKey: "flora_pubpeer_blob",
   ttlMs: CACHE_TTL,
@@ -78,9 +80,9 @@ export async function lookupPubPeerForDois<T extends string>(
   // 1. Serve from cache; collect DOIs that need a network call.
   const uncached: T[] = [];
   const now = Date.now();
-  const cached = await PUBPEER_CACHE.getMany(dois);
+  const cached = await PUBPEER_CACHE.getMany(dois.map(cacheKey));
   for (const doi of dois) {
-    const entry = cached.get(doi);
+    const entry = cached.get(cacheKey(doi));
     if (entry) {
       if (entry.feedback) result.set(doi, entry.feedback);
     } else {
@@ -101,7 +103,7 @@ export async function lookupPubPeerForDois<T extends string>(
   // 2. One batch call for all uncached DOIs.
   let feedbacks: PubPeerFeedback[] = [];
   try {
-    feedbacks = await lookupPubPeer(uncached, []);
+    feedbacks = await lookupPubPeer(uncached.map(cacheKey), []);
   } catch (err) {
     if (err instanceof PubPeerRateLimitError) {
       rateLimitedUntil = now + err.retryAfterMs;
@@ -113,14 +115,14 @@ export async function lookupPubPeerForDois<T extends string>(
   // feedback.id is the DOI — build a lookup map from the response.
   const hitByDoi = new Map<string, PubPeerFeedback>();
   for (const fb of feedbacks) {
-    if (fb.id) hitByDoi.set(fb.id, fb);
+    if (fb.id) hitByDoi.set(cacheKey(fb.id), fb);
   }
 
   // 3. Cache every uncached DOI (hit → feedback, miss → null) and populate result.
   const writes: Array<[string, { feedback: PubPeerFeedback | null }]> = [];
   for (const doi of uncached) {
-    const feedback = hitByDoi.get(doi) ?? null;
-    writes.push([doi, { feedback }]);
+    const feedback = hitByDoi.get(cacheKey(doi)) ?? null;
+    writes.push([cacheKey(doi), { feedback }]);
     if (feedback) result.set(doi, feedback);
   }
   void PUBPEER_CACHE.setMany(writes);

--- a/src/walkthrough/demos.ts
+++ b/src/walkthrough/demos.ts
@@ -54,7 +54,7 @@ function pubpeerFeedback(doi: string): PubPeerFeedback | null {
     const fixture = PUBPEER_FIXTURES[doi];
     if (!fixture) return null;
     return {
-        id: doi,
+        id: doi.toLowerCase(),
         title: fixture.title,
         total_comments: fixture.comments,
         total_peeriodical_comments: 0,

--- a/tests/unit/pubpeer-casing.test.ts
+++ b/tests/unit/pubpeer-casing.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  lookupPubPeerForDois,
+  _resetPubPeerCacheForTesting,
+} from "../../src/shared/pubpeer-api";
+
+const MIXED = "10.3233/JIFS-219197";
+const LOWER = "10.3233/jifs-219197";
+
+function feedback(id: string) {
+  return {
+    id,
+    title: "A paper",
+    total_comments: 7,
+    total_peeriodical_comments: 0,
+    last_commented_at: "",
+    users: "",
+    url: `https://pubpeer.com/publications/${id}`,
+  };
+}
+
+describe("PubPeer DOI casing", () => {
+  let store: Record<string, unknown>;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    store = {};
+    chrome.storage.local.get = vi.fn(async (key: string | string[] | null) => {
+      if (key === null) return { ...store };
+      const k = Array.isArray(key) ? key[0] : key;
+      return k in store ? { [k]: store[k] } : {};
+    });
+    chrome.storage.local.set = vi.fn(async (items: Record<string, unknown>) => {
+      Object.assign(store, items);
+    });
+    chrome.storage.local.remove = vi.fn(async (key: string | string[]) => {
+      const keys = Array.isArray(key) ? key : [key];
+      for (const k of keys) delete store[k];
+    });
+
+    _resetPubPeerCacheForTesting();
+
+    fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      headers: { get: () => null },
+      json: async () => ({ status: "good", feedbacks: [feedback(LOWER)] }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    _resetPubPeerCacheForTesting();
+  });
+
+  it("matches a lowercase response id against a mixed-case query DOI", async () => {
+    const result = await lookupPubPeerForDois([MIXED]);
+
+    expect(result.get(MIXED)?.total_comments).toBe(7);
+  });
+
+  it("queries PubPeer with the lowercased DOI", async () => {
+    await lookupPubPeerForDois([MIXED]);
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+    expect(body.dois).toEqual([LOWER]);
+  });
+
+  it("serves a differently-cased DOI from the same cache entry", async () => {
+    await lookupPubPeerForDois([MIXED]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const result = await lookupPubPeerForDois([LOWER]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(result.get(LOWER)?.total_comments).toBe(7);
+  });
+
+  it("still caches a genuine miss", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: { get: () => null },
+      json: async () => ({ status: "good", feedbacks: [] }),
+    });
+
+    expect((await lookupPubPeerForDois([MIXED])).size).toBe(0);
+    expect((await lookupPubPeerForDois([MIXED])).size).toBe(0);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Ensure PubPeer DOIs are handled case-insensitively by lowercasing before cache lookups, writes and network requests. Added cacheKey(doi) helper and wired it through lookupPubPeerForDois; adjusted demo fixtures to emit lowercase feedback IDs. Added unit tests (tests/unit/pubpeer-casing.test.ts) covering querying with mixed-case DOIs, request payload lowercasing, shared cache entries across casings, and caching of misses.