### PR TITLE
Add OSF.io adapter, tighten focus styles and tests

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "FORRT ORE — Open Research Extension",
   "short_name": "FORRT ORE",
-  "version": "0.1.0.4",
+  "version": "0.1.0.5",
   "description": "Shows replication evidence, retractions, PubPeer comments and open-access copies for the papers on any page you read.",
   "minimum_chrome_version": "116",
   "permissions": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flora-extension",
-  "version": "0.1.0.4",
+  "version": "0.1.0.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/shared/flora-ui.ts
+++ b/src/shared/flora-ui.ts
@@ -6,7 +6,9 @@
 
 export const FLORA_UI_SELECTOR = "[data-flora-ui]";
 
-const FLORA_OWNED_SELECTOR = `${FLORA_UI_SELECTOR}, [id^="flora-"]`;
+const FLORA_OWNED_PARTS = [FLORA_UI_SELECTOR, '[id^="flora-"]'];
+
+const FLORA_OWNED_SELECTOR = FLORA_OWNED_PARTS.join(", ");
 
 const FOCUS_STYLE_ID = "flora-focus-style";
 
@@ -14,9 +16,12 @@ export function ensureFocusStyle(): void {
     if (document.getElementById(FOCUS_STYLE_ID)) return;
     const style = document.createElement("style");
     style.id = FOCUS_STYLE_ID;
+    const focused = FLORA_OWNED_PARTS.flatMap((part) => [
+        `${part}:focus-visible`,
+        `${part} :focus-visible`,
+    ]);
     style.textContent =
-        `${FLORA_OWNED_SELECTOR} :focus-visible, ${FLORA_OWNED_SELECTOR}:focus-visible {` +
-        ` outline: 2px solid #853953; outline-offset: 2px; }`;
+        `${focused.join(", ")} { outline: 2px solid #853953; outline-offset: 2px; }`;
     (document.head ?? document.documentElement).appendChild(style);
 }
 

--- a/src/shared/site-adapters.ts
+++ b/src/shared/site-adapters.ts
@@ -438,6 +438,24 @@ const PMC_NCBI: SiteAdapter = {
     referencePillStyle: { top: "0px" },
 };
 
+const OSF_IO: SiteAdapter = {
+    id: "osf-io",
+    hostnames: ["osf.io"],
+    titlePill: [
+        {
+            selector: "a.flex.flex-column.gap-3.custom-light-hover.dark-blue-link.md\\:flex-row",
+            position: "after",
+        },
+        { selector: ".title", position: "after" },
+    ],
+    referencePill: [
+        { selector: ":self", position: "after" },
+    ],
+    referenceScope: ".references",
+    titlePillStyle: { top: "0px" },
+    referencePillStyle: { top: "0px" },
+};
+
 export const SITE_ADAPTERS: SiteAdapter[] = [
     SCIENCE_ORG,
     SAGEPUB,
@@ -465,7 +483,8 @@ export const SITE_ADAPTERS: SiteAdapter[] = [
     PEERCOMMUNITYIN,
     METAROR,
     F1000RESEARCH,
-    PMC_NCBI
+    PMC_NCBI,
+    OSF_IO,
 ];
 
 function normaliseHost(hostname: string): string {

--- a/tests/unit/a11y-contrast-focus.test.ts
+++ b/tests/unit/a11y-contrast-focus.test.ts
@@ -58,6 +58,36 @@ describe("keyboard focus visibility", () => {
         expect(style?.textContent).toContain("[data-flora-ui]");
     });
 
+    it("gates every selector on :focus-visible so pills are not outlined at rest", () => {
+        ensureFocusStyle();
+
+        const rule = document.getElementById("flora-focus-style")!.textContent!;
+        const selectors = rule.slice(0, rule.indexOf("{")).split(",").map((s) => s.trim());
+
+        expect(selectors.length).toBeGreaterThan(0);
+        for (const selector of selectors) {
+            expect(selector).toContain(":focus-visible");
+        }
+    });
+
+    it("does not match a pill that has never been focused", () => {
+        vi.stubGlobal("fetch", vi.fn(() => new Promise(() => {})));
+        ensureFocusStyle();
+        const pill = createIndicatorPill({
+            doi: "10.1000/x" as DoiString,
+            oaStatus: null,
+            retraction: null,
+        });
+        document.body.appendChild(pill);
+
+        const rule = document.getElementById("flora-focus-style")!.textContent!;
+        const selectors = rule.slice(0, rule.indexOf("{")).split(",").map((s) => s.trim());
+        const unfocused = selectors.filter((s) => !s.includes(":focus-visible"));
+
+        expect(unfocused.some((s) => pill.matches(s))).toBe(false);
+        vi.unstubAllGlobals();
+    });
+
     it("injects the rule only once", () => {
         ensureFocusStyle();
         ensureFocusStyle();

--- a/tests/unit/site-adapters.test.ts
+++ b/tests/unit/site-adapters.test.ts
@@ -366,3 +366,49 @@ describe("registry hygiene", () => {
     expect(science.referencePill).not.toBe(sage.referencePill);
   });
 });
+
+describe("osf.io title placement", () => {
+  const adapter = () => resolveSiteAdapter("osf.io") as SiteAdapter;
+
+  function osfDoc(): Document {
+    return new JSDOM(`<!doctype html><html><body>
+      <div id="root">
+        <a href="/abc12" class="flex flex-column gap-3 custom-light-hover dark-blue-link md:flex-row">
+          <h2 class="title">A registered report</h2>
+        </a>
+      </div>
+    </body></html>`).window.document;
+  }
+
+  it("resolves osf.io to its own adapter", () => {
+    expect(adapter().id).toBe("osf-io");
+  });
+
+  it("places the title pill directly after the title link", () => {
+    const doc = osfDoc();
+    const p = doc.createElement("span");
+
+    expect(applyPlacement(adapter().titlePill, doc.documentElement, p)).toBe(true);
+
+    const link = doc.querySelector("a.custom-light-hover")!;
+    expect(link.nextElementSibling).toBe(p);
+    expect(link.contains(p)).toBe(false);
+  });
+
+  it("escapes the responsive class so the selector parses", () => {
+    const doc = osfDoc();
+    const selector = adapter().titlePill![0].selector;
+
+    expect(selector).toContain("md\\:flex-row");
+    expect(doc.querySelector(selector)).toBe(doc.querySelector("a.custom-light-hover"));
+  });
+
+  it("falls back to .title when the link's utility classes change", () => {
+    const doc = osfDoc();
+    doc.querySelector("a")!.className = "flex flex-column gap-3";
+    const p = doc.createElement("span");
+
+    expect(applyPlacement(adapter().titlePill, doc.documentElement, p)).toBe(true);
+    expect(doc.querySelector(".title")!.nextElementSibling).toBe(p);
+  });
+});


### PR DESCRIPTION
Add a site adapter for osf.io (title and reference pill placements) and register it in SITE_ADAPTERS. Refactor flora UI focus CSS to build selectors from owned parts and gate with :focus-visible so pills aren't outlined at rest. Add unit tests verifying focus-style selectors and osf.io placement/selector escaping/fallback. Bump extension version in manifest.json and package.json to 0.1.0.5. Files changed: manifest.json, package.json, src/shared/flora-ui.ts, src/shared/site-adapters.ts, tests/unit/a11y-contrast-focus.test.ts, tests/unit/site-adapters.test.ts.