### PR TITLE
Bound the retraction-check wait, log its timing, say FLoRA in the lookup toast

### DIFF
--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -8,7 +8,7 @@ import {augmentDOIsDetailed, type AugmentSource} from "@shared/doi-augment";
 import {resolvePmcIds} from "@shared/pmc-resolve";
 import {getSettings, isSetupComplete} from "@shared/settings";
 import {appendDebugEntries, installDebugLogStore} from "@shared/debug-log";
-import {debugError, debugLog, debugWarn} from "@shared/debug";
+import {debugError, debugLog, debugWarn, isDebugEnabledAsync} from "@shared/debug";
 
 const cache = new LocalCache<ReplicationResult>("flora");
 
@@ -16,8 +16,9 @@ const cache = new LocalCache<ReplicationResult>("flora");
 // every other context ships batches here via FLORA_DEBUG_ENTRIES.
 installDebugLogStore();
 // A wake-up marker: with the log open, gaps between a page's request and this
-// line show how long Chrome took to start the worker.
-debugLog("Worker started");
+// line show how long Chrome took to start the worker. Logged once the debug
+// flag has been read — a top-level debugLog runs before that and is dropped.
+isDebugEnabledAsync().then(() => debugLog("Worker started")).catch(() => {});
 
 // Initialise cache quota from persisted settings (service worker may restart).
 getSettings().then(({ cacheQuotaMb }) => {

--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -8,13 +8,16 @@ import {augmentDOIsDetailed, type AugmentSource} from "@shared/doi-augment";
 import {resolvePmcIds} from "@shared/pmc-resolve";
 import {getSettings, isSetupComplete} from "@shared/settings";
 import {appendDebugEntries, installDebugLogStore} from "@shared/debug-log";
-import {debugError, debugWarn} from "@shared/debug";
+import {debugError, debugLog, debugWarn} from "@shared/debug";
 
 const cache = new LocalCache<ReplicationResult>("flora");
 
 // The worker owns the debug log: its own entries are stored directly, and
 // every other context ships batches here via FLORA_DEBUG_ENTRIES.
 installDebugLogStore();
+// A wake-up marker: with the log open, gaps between a page's request and this
+// line show how long Chrome took to start the worker.
+debugLog("Worker started");
 
 // Initialise cache quota from persisted settings (service worker may restart).
 getSettings().then(({ cacheQuotaMb }) => {
@@ -498,6 +501,7 @@ function getRetractionSource(): Promise<RetractionMaps> {
 
 async function loadRetractionSource(): Promise<RetractionMaps> {
     const generation = retractionGeneration;
+    const started = performance.now();
     const storageResult = await chrome.storage.local.get([RET_MAP_KEY]);
     const stored = storageResult[RET_MAP_KEY] as RetractionMaps | undefined;
     const hasStoredData = !!stored && (
@@ -508,17 +512,20 @@ async function loadRetractionSource(): Promise<RetractionMaps> {
     if (hasStoredData) {
         const source = normaliseRetractionMaps(stored!);
         if (generation === retractionGeneration) cachedRetractionSource = source;
+        debugLog(`Retractions: source loaded from storage in ${Math.round(performance.now() - started)} ms`);
         return source;
     }
 
     // Nothing synced yet: kick off a sync for next time and answer from the
     // bundled JSON now. Don't cache the fallback — onChanged will pick up the
     // synced map, but until then we re-read so an in-flight sync is noticed.
+    debugLog("Retractions: nothing synced yet — answering from the bundled map and starting a sync");
     syncRetractionsInfo().catch((err) => debugError("Retractions: sync failed —", err));
     return loadBundledRetractionMap();
 }
 
 async function handleRetractionCheck(dois: DoiString[]): Promise<RetractionCheckResponse> {
+    const started = performance.now();
     let source: RetractionMaps;
     try {
         source = await getRetractionSource();
@@ -526,6 +533,7 @@ async function handleRetractionCheck(dois: DoiString[]): Promise<RetractionCheck
         debugError(`Retractions: no source available, ${dois.length} DOI(s) unchecked —`, err);
         return {type: "FLORA_RET_CHECK_RESULT", results: [], error: "Retraction data unavailable"};
     }
+    debugLog(`Retractions: checking ${dois.length} DOI(s), source ready after ${Math.round(performance.now() - started)} ms`);
 
     const results: RetractionResponse[] = [];
     for (const doi of dois) {

--- a/src/content-general/index.ts
+++ b/src/content-general/index.ts
@@ -346,7 +346,7 @@ async function runScanPass(): Promise<void> {
         // that isn't happening.
         let response: LookupResponse | undefined;
         try {
-            reportWorkStage("lookup", `Looking up ${count(newDois.length, "DOI")} in FORRT…`);
+            reportWorkStage("lookup", `Looking up ${count(newDois.length, "DOI")} in FLoRA…`);
             response = await safeSendMessage<LookupResponse>(request);
         } catch (err) {
             debugError("Replication lookup failed:", err);

--- a/src/shared/doi-retraction.ts
+++ b/src/shared/doi-retraction.ts
@@ -2,7 +2,7 @@ import {extractDoiFromHref} from "@shared/doi-extractor";
 import {FLORA_NOTICE_PILL_CLASS} from "@shared/doi-label";
 import type {DoiString, NoticeKind, RetractionResponse} from "@shared/types";
 import {safeSendMessage, type RetractionCheckResponse} from "@shared/messages";
-import {debugError} from "@shared/debug";
+import {debugError, debugLog, debugWarn} from "@shared/debug";
 
 export const FLORA_RET_CHECK_KEY = "flora-ret-checked";
 
@@ -106,18 +106,41 @@ export function noticePresentation(kind: NoticeKind): NoticePresentation {
 const pendingDois = new Set<DoiString>();
 let pendingBatch: Promise<Map<DoiString, RetractionResponse>> | null = null;
 
+// The check is a lookup table read in the worker, so a slow answer means the
+// worker is wedged or slow to wake — not that the data is slow. Give up on
+// this pass after this long so the page's own lookup and report still run.
+export const RETRACTION_CHECK_TIMEOUT_MS = 15_000;
+
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T | "timeout"> {
+    return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => resolve("timeout"), ms);
+        promise.then(
+            (v) => { clearTimeout(timer); resolve(v); },
+            (e) => { clearTimeout(timer); reject(e); },
+        );
+    });
+}
+
 function flushRetractionQueue(): Promise<Map<DoiString, RetractionResponse>> {
     return new Promise((resolve) => {
         setTimeout(async () => {
             const dois = [...pendingDois];
             pendingDois.clear();
             pendingBatch = null;
+            const started = performance.now();
             try {
-                const response = await safeSendMessage<RetractionCheckResponse>({
-                    type: "FLORA_RET_CHECK",
-                    dois,
-                });
+                const response = await withTimeout(
+                    safeSendMessage<RetractionCheckResponse>({type: "FLORA_RET_CHECK", dois}),
+                    RETRACTION_CHECK_TIMEOUT_MS,
+                );
+                const elapsed = Math.round(performance.now() - started);
+                if (response === "timeout") {
+                    debugWarn(`Retraction check: no answer from the worker after ${elapsed} ms for ${dois.length} DOI(s) — continuing without notices`);
+                    resolve(new Map());
+                    return;
+                }
                 const results = response?.type === "FLORA_RET_CHECK_RESULT" ? response.results : [];
+                debugLog(`Retraction check: ${dois.length} DOI(s) → ${results.length} notice(s) in ${elapsed} ms`);
                 resolve(new Map(results.map((r) => [r.originDoi, r] as const)));
             } catch (err) {
                 // One failed batch must not reject every caller sharing it.

--- a/tests/unit/doi-retraction.test.ts
+++ b/tests/unit/doi-retraction.test.ts
@@ -77,4 +77,17 @@ describe("doi retraction content helper", () => {
         const {retractionCheck} = await import("../../src/shared/doi-retraction");
         await expect(retractionCheck([doi("10.1038/nature12373")])).resolves.toEqual([]);
     });
+
+    it("gives up on a worker that never answers so the pass can continue", async () => {
+        vi.useFakeTimers();
+        try {
+            (chrome.runtime.sendMessage as ReturnType<typeof vi.fn>).mockReturnValue(new Promise(() => {}));
+            const {retractionCheck, RETRACTION_CHECK_TIMEOUT_MS} = await import("../../src/shared/doi-retraction");
+            const pending = retractionCheck([doi("10.1038/nature12373")]);
+            await vi.advanceTimersByTimeAsync(RETRACTION_CHECK_TIMEOUT_MS + 1);
+            await expect(pending).resolves.toEqual([]);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
 });

--- a/tests/unit/progress-toast.test.ts
+++ b/tests/unit/progress-toast.test.ts
@@ -60,15 +60,15 @@ describe("progress toast", () => {
 
     it("reports the running stage and fills the bar", () => {
         beginWorkIndicator();
-        reportWorkStage("lookup", "Looking up 10 DOIs in FORRT…");
+        reportWorkStage("lookup", "Looking up 10 DOIs in FLoRA…");
         settle();
-        expect(label()).toBe("Looking up 10 DOIs in FORRT…");
+        expect(label()).toBe("Looking up 10 DOIs in FLoRA…");
         expect(Number(percent())).toBeGreaterThan(0);
     });
 
     it("never rewinds the bar when a parallel stage reports late", () => {
         beginWorkIndicator();
-        reportWorkStage("lookup", "Looking up 10 DOIs in FORRT…");
+        reportWorkStage("lookup", "Looking up 10 DOIs in FLoRA…");
         settle();
         const atLookup = Number(percent());
         // References resolve alongside validation — stages report out of order.
@@ -78,7 +78,7 @@ describe("progress toast", () => {
     });
 
     it("ignores a stage reported with no pass in flight", () => {
-        reportWorkStage("lookup", "Looking up 10 DOIs in FORRT…");
+        reportWorkStage("lookup", "Looking up 10 DOIs in FLoRA…");
         settle();
         expect(toast()).toBeNull();
     });
@@ -118,14 +118,14 @@ describe("progress toast", () => {
 
         hideWorkIndicator();
         expect(toast()).toBeNull();
-        reportWorkStage("lookup", "Looking up 10 DOIs in FORRT…");
+        reportWorkStage("lookup", "Looking up 10 DOIs in FLoRA…");
         settle();
         expect(toast()).toBeNull();
 
         showWorkIndicator();
         // The pass kept running while hidden — the bar resumes where it got to.
         expect(toast()).not.toBeNull();
-        expect(label()).toBe("Looking up 10 DOIs in FORRT…");
+        expect(label()).toBe("Looking up 10 DOIs in FLoRA…");
         expect(Number(percent())).toBeGreaterThan(0);
     });
 


### PR DESCRIPTION
## What

- **Retraction check can no longer hang a page pass.** `retractionCheck` (content side) gives up after 15 s if the service worker never answers, logs a warning, and lets the FLoRA lookup and report run without notices for that pass.
- **Timing in the debug log**, both sides: content logs `Retraction check: N DOI(s) → M notice(s) in X ms`; the worker logs `Worker started` on every wake, `Retractions: source loaded from storage in X ms`, and `Retractions: checking N DOI(s), source ready after X ms`. A debug report will now show whether time goes to the worker wake, the storage read, or the message itself.
- **Toast wording**: "Looking up N DOIs in FORRT…" → "…in FLoRA…".

## Why

The check itself is a lookup-table read: measured in Chrome for Testing it takes <1 ms with a warm worker and ~50–200 ms after a cold worker start (storage read of the 3.3 MB map). Reported stalls on "Checking N DOIs for retractions…" therefore mean the message to the worker is not being answered promptly — most likely a slow or wedged worker wake, since this is normally the first message a page sends. That could not be reproduced locally, so this PR bounds the damage and adds the instrumentation needed to pin it down from a debug report.

## Tests

- `npm test`: 640 passing (new test: timeout resolves to no notices).
- `npm run typecheck` clean.
- End-to-end in Chrome for Testing on the Wikipedia "Replication crisis" page (179 DOIs): new log lines appear, label reads "in FLoRA".

🤖 Generated with [Claude Code](https://claude.com/claude-code)