### PR TITLE
Reference augmentation: don't block the page on it, pace the APIs, split the load

### DIFF
--- a/src/content-general/index.ts
+++ b/src/content-general/index.ts
@@ -49,7 +49,20 @@ import {serializeWithRerun} from "./serial-scan";
 import {startDomListener} from "./dom-listener";
 
 const pageState = new Map<DoiString, LookupState>();
+// Retraction notices for the page: `pageNotices` is replaced by each check of
+// the page's own DOIs, `refNotices` accumulates those of resolved references
+// (whose DOIs are not on the page), and `redacts` is the union everyone reads.
 let redacts: RetractionResponse[] = [];
+let pageNotices: RetractionResponse[] = [];
+const refNotices = new Map<DoiString, RetractionResponse>();
+function refreshRedacts(): void {
+    const onPage = new Set(pageNotices.map((n) => n.originDoi));
+    redacts = [...pageNotices, ...[...refNotices.values()].filter((n) => !onPage.has(n.originDoi))];
+}
+// Reference resolution still running after the pass that started it, and the
+// "nothing to flag" verdict it must complete before that toast is shown.
+let refsPending = 0;
+let pendingNothingToFlag: {examined: number; flagged: boolean} | null = null;
 // Keep memory of detected DOIs to track dynamic page changes
 const processedDois = new Set<DoiString>();
 const seenDois = new SeenDois();
@@ -201,6 +214,9 @@ async function runScanPass(): Promise<void> {
         lastRenderedPageStateVersion = -1;
         pageState.clear();
         redacts = [];
+        pageNotices = [];
+        refNotices.clear();
+        pendingNothingToFlag = null;
         augmentAttempted = false;
         resetRetractionPills();
         removeIndicatorPills();
@@ -273,34 +289,22 @@ async function runScanPass(): Promise<void> {
         (occ) => !FLORA_UI_IDS.some((id) => occ.anchor.closest(`#${id}`) !== null)
     );
 
-    // One retraction check for occurrences + resolved refs; held in `redacts`.
-    const resolvedRefs = await refsPromise;
-    if ((hasDoiChange && dois.length > 0) || resolvedRefs.length > 0) {
-        try {
-            const allNoticeDois = Array.from(new Set([
-                ...dois,
-                ...resolvedRefs.map((r) => r.doi),
-            ]));
-            reportWorkStage("notices", `Checking ${count(allNoticeDois.length, "DOI")} for retractions…`);
-            redacts = await retractionCheck(allNoticeDois);
-            reportWorkStage("notices", `Marking up ${count(resolvedRefs.length, "reference")}…`);
-
-            const retractionByDoi = new Map(redacts.map((r) => [r.originDoi, r] as const));
-            const titleEl = document.querySelector<HTMLHeadingElement>("h1");
-
-            injectInlineRetractionPills(
-                pageOccurrences,
-                retractionByDoi,
-                titleEl ? extractPrimaryDOI(document) : null,
-            );
-
-            // Pills for augmented refs with no on-page anchor (idempotent).
-            renderResolvedReferences(resolvedRefs, retractionByDoi, pageState);
-        } catch (err) {
-            releaseReferenceEntries(resolvedRefs);
-            throw err;
-        }
+    // Retraction check for the page's own DOIs. Reference resolution (title
+    // augmentation, PMC ids) can take many seconds against rate-limited APIs,
+    // so the pass does not wait for it: finishReferences() pills those
+    // references when their DOIs arrive.
+    if (hasDoiChange && dois.length > 0) {
+        reportWorkStage("notices", `Checking ${count(dois.length, "DOI")} for retractions…`);
+        pageNotices = await retractionCheck(dois);
+        refreshRedacts();
+        const titleEl = document.querySelector<HTMLHeadingElement>("h1");
+        injectInlineRetractionPills(
+            pageOccurrences,
+            new Map(redacts.map((r) => [r.originDoi, r] as const)),
+            titleEl ? extractPrimaryDOI(document) : null,
+        );
     }
+    const refsDone = finishReferences(refsPromise);
 
     // Filter out already-processed DOIs
     const newDois = dois.filter((doi) => !processedDois.has(doi));
@@ -311,7 +315,7 @@ async function runScanPass(): Promise<void> {
         if (!isSheets) placeTitleIndicatorPill();
         if (!isSheets) updateIndicatorPillBadges(document, pageState, redacts);
         if (!isSheets) augmentFromTitle().catch((err) => debugError("Title augmentation failed —", err));
-        if (!isSheets) void checkPubPeer(refsPromise);
+        if (!isSheets) void checkPubPeer(refsDone);
         return;
     }
 
@@ -322,7 +326,7 @@ async function runScanPass(): Promise<void> {
         // (triggered by that mutation) would otherwise return without restoring it.
         if (!isSheets) placeTitleIndicatorPill();
         if (!isSheets) updateIndicatorPillBadges(document, pageState, redacts);
-        if (!isSheets) void checkPubPeer(refsPromise);
+        if (!isSheets) void checkPubPeer(refsDone);
         return;
     }
     debugLog(isSheets ? "Sheets:" : "General:", "New DOIs to look up:", newDois.length, newDois);
@@ -406,14 +410,21 @@ async function runScanPass(): Promise<void> {
                 if (isSheetsModalSuppressed()) removeSheetsModal();
                 else renderSheetsModal(matched, redacts, sheetsModalCallbacks);
             } else {
-                void checkPubPeer(refsPromise);
+                void checkPubPeer(refsDone);
             }
 
             // Merged indicator pills (skip on Google Sheets — modal only).
             if (!isSheets) {
                 placeTitleIndicatorPill();
                 updateIndicatorPillBadges(document, pageState, redacts);
-                reportNothingToFlag(dois.length, matched.length > 0 || redacts.length > 0);
+                const flagged = matched.length > 0 || redacts.length > 0;
+                if (refsPending > 0) {
+                    // Verdict waits for the references still being resolved.
+                    pendingNothingToFlag = {examined: dois.length, flagged};
+                    reportWorkStage("report", "Resolving references without a DOI…");
+                } else {
+                    reportNothingToFlag(dois.length, flagged);
+                }
             }
         } catch (err) {
             // Rendering failed after a successful lookup: log it for a bug
@@ -423,6 +434,57 @@ async function runScanPass(): Promise<void> {
     } finally {
         endWorkIndicator();
     }
+}
+
+/**
+ * Second half of a scan pass, off the pass's own timeline: once the DOI-less
+ * references are resolved, check them for retractions, pill them, refresh the
+ * badges, and settle the "nothing to flag" verdict the pass left open. Keeps
+ * the work toast up while it runs. Never rejects — a failure releases the
+ * reference entries so a later pass can retry them.
+ */
+function finishReferences(refsPromise: Promise<ResolvedReference[]>): Promise<ResolvedReference[]> {
+    const passUrl = lastUrl;
+    refsPending++;
+    beginWorkIndicator();
+    return refsPromise
+        .then(async (resolvedRefs) => {
+            if (location.href !== passUrl) {
+                // Navigated away while resolving — these entries belong to the old page.
+                releaseReferenceEntries(resolvedRefs);
+                return [];
+            }
+            let notices: RetractionResponse[] = [];
+            if (resolvedRefs.length > 0) {
+                try {
+                    reportWorkStage("notices", `Checking ${count(resolvedRefs.length, "reference")} for retractions…`);
+                    notices = await retractionCheck([...new Set(resolvedRefs.map((r) => r.doi))]);
+                    for (const n of notices) refNotices.set(n.originDoi, n);
+                    refreshRedacts();
+                    reportWorkStage("notices", `Marking up ${count(resolvedRefs.length, "reference")}…`);
+                    renderResolvedReferences(resolvedRefs, new Map(redacts.map((r) => [r.originDoi, r] as const)), pageState);
+                    if (!isSheets) updateIndicatorPillBadges(document, pageState, redacts);
+                } catch (err) {
+                    releaseReferenceEntries(resolvedRefs);
+                    debugError(`References: marking up ${resolvedRefs.length} resolved reference(s) failed —`, err);
+                    return [];
+                }
+            }
+            if (pendingNothingToFlag && refsPending === 1) {
+                const {examined, flagged} = pendingNothingToFlag;
+                pendingNothingToFlag = null;
+                reportNothingToFlag(examined + resolvedRefs.length, flagged || notices.length > 0);
+            }
+            return resolvedRefs;
+        })
+        .catch((err) => {
+            debugError("References: resolution failed —", err);
+            return [];
+        })
+        .finally(() => {
+            refsPending--;
+            endWorkIndicator();
+        });
 }
 
 /**

--- a/src/shared/doi-augment.ts
+++ b/src/shared/doi-augment.ts
@@ -455,6 +455,7 @@ export async function augmentDOIs(
 
 /** Where a resolved DOI came from. "cache" means no platform was queried. */
 export type AugmentSource = "crossref" | "openalex" | "both" | "cache";
+type AugmentPlatform = "crossref" | "openalex";
 
 export interface AugmentOutcome {
     doi: DoiString | null;
@@ -515,22 +516,33 @@ export async function augmentDOIsDetailed(
         return results;
     }
 
-    // Query each distinct title once (Crossref + OpenAlex in parallel), then use
-    // the page metadata to pick the single best candidate. Cache writes are
+    // Query each distinct title on one platform first — titles alternate
+    // between Crossref and OpenAlex so the load (and OpenAlex's daily credit
+    // budget) is split — and ask the other only when the first fails, finds
+    // nothing, or returns several DOIs (a preprint/journal pair, say) whose
+    // tie the second platform's metadata may break. Then use the page
+    // metadata to pick the single best candidate. Cache writes are
     // accumulated and flushed once at the end.
     const updates: Array<[string, CachedDoiResult]> = [];
-    const lookupPromises = [...uncachedByKey.entries()].map(async ([key, group]) => {
+    const lookupPromises = [...uncachedByKey.entries()].map(async ([key, group], index) => {
         const request = group[0];
-        const [crossrefResult, openalexResult] = await Promise.allSettled([
-            queryCrossref(request, email),
-            queryOpenAlex(request, email),
-        ]);
+        const order: AugmentPlatform[] = index % 2 === 0 ? ["crossref", "openalex"] : ["openalex", "crossref"];
+        const outcomes: Partial<Record<AugmentPlatform, PromiseSettledResult<DoiCandidate[]>>> = {};
+        for (const platform of order) {
+            const [outcome] = await Promise.allSettled([
+                platform === "crossref" ? queryCrossref(request, email) : queryOpenAlex(request, email),
+            ]);
+            outcomes[platform] = outcome;
+            if (outcome.status === "fulfilled" && new Set(outcome.value.map((c) => c.doi)).size === 1) break;
+        }
+        const crossrefResult = outcomes.crossref ?? {status: "skipped"} as const;
+        const openalexResult = outcomes.openalex ?? {status: "skipped"} as const;
 
         const candidates: DoiCandidate[] = [];
         if (crossrefResult.status === "fulfilled") candidates.push(...crossrefResult.value);
-        else debugWarn(`Augment [crossref] query threw for "${request.title.slice(0, 80)}" —`, crossrefResult.reason);
+        else if (crossrefResult.status === "rejected") debugWarn(`Augment [crossref] query threw for "${request.title.slice(0, 80)}" —`, crossrefResult.reason);
         if (openalexResult.status === "fulfilled") candidates.push(...openalexResult.value);
-        else debugWarn(`Augment [openalex] query threw for "${request.title.slice(0, 80)}" —`, openalexResult.reason);
+        else if (openalexResult.status === "rejected") debugWarn(`Augment [openalex] query threw for "${request.title.slice(0, 80)}" —`, openalexResult.reason);
 
         // Deduplicate by DOI, merging metadata across the two sources so a
         // candidate seen by both keeps the author/year/urls either provided.

--- a/src/shared/doi-augment.ts
+++ b/src/shared/doi-augment.ts
@@ -3,9 +3,18 @@ import {normaliseDOI} from "./doi-normalise";
 import {getSettings} from "./settings";
 import {BlobCache} from "./blob-cache";
 import {debugLog, debugWarn, isDebugEnabled} from "./debug";
+import {RequestGate} from "./request-gate";
 
 const OPENALEX_BASE = "https://api.openalex.org/works";
 const CROSSREF_BASE = "https://api.crossref.org/works";
+
+// A reference list can hold dozens of titles without a DOI; fired all at once,
+// both platforms answer 429 within the second. Crossref's polite pool allows
+// 3 concurrent requests at 3/s; OpenAlex allows 10/s but charges a title
+// search 10 credits against a free budget of 1000/day per client, and answers
+// 429 with a Retry-After of "midnight UTC" once that is spent.
+const crossrefGate = new RequestGate("Crossref", 3, 400);
+const openalexGate = new RequestGate("OpenAlex", 3, 100);
 const MATCH_THRESHOLD_TSR = 88; // token_set_ratio threshold (0–100)
 // token_set_ratio scores 100 whenever one title's tokens are a subset of the
 // other's, so a 3-word title matches a 7-word one perfectly. Coverage is the
@@ -317,7 +326,7 @@ async function queryCrossref(request: DoiAugmentRequest, email: string): Promise
     const cleaned = cleanTitleForSearch(title);
     const url = `${CROSSREF_BASE}?query.title=${encodeURIComponent(cleaned)}&rows=5&select=DOI,title,author,issued,published-print,published-online,published,URL,link&mailto=${encodeURIComponent(email)}`;
     debugLog(`Augment [crossref] query: "${cleaned}"`);
-    const response = await fetch(url);
+    const response = await crossrefGate.fetch(url);
     if (!response.ok) throw new Error(`Crossref HTTP ${response.status}`);
 
     const data = (await response.json()) as {
@@ -378,7 +387,7 @@ async function queryOpenAlex(request: DoiAugmentRequest, email: string): Promise
     const url = `${OPENALEX_BASE}?filter=title.search:${encodeURIComponent(cleaned)}&select=id,doi,title,publication_year,authorships,primary_location,locations&per_page=5&mailto=${encodeURIComponent(email)}`;
 
     debugLog(`Augment [openalex] query: "${cleaned}"`);
-    const response = await fetch(url);
+    const response = await openalexGate.fetch(url);
     if (!response.ok) throw new Error(`OpenAlex HTTP ${response.status}`);
 
     const data = (await response.json()) as {
@@ -601,7 +610,7 @@ export async function fetchTitleByDoi(doi: string): Promise<string | null> {
     try {
         const email = await getUserEmail();
         const mailto = email ? `?mailto=${encodeURIComponent(email)}` : "";
-        const response = await fetch(`${CROSSREF_BASE}/${encodedDoi}${mailto}`);
+        const response = await crossrefGate.fetch(`${CROSSREF_BASE}/${encodedDoi}${mailto}`);
         crossrefAnswered = response.ok || response.status === 404;
         if (response.ok) {
             const data = (await response.json()) as { message?: { title?: string[] } };
@@ -613,7 +622,7 @@ export async function fetchTitleByDoi(doi: string): Promise<string | null> {
 
     if (!title) {
         try {
-            const response = await fetch(`${OPENALEX_BASE}/doi:${encodedDoi}?select=title`);
+            const response = await openalexGate.fetch(`${OPENALEX_BASE}/doi:${encodedDoi}?select=title`);
             openalexAnswered = response.ok || response.status === 404;
             if (response.ok) {
                 const data = (await response.json()) as { title?: string };

--- a/src/shared/doi-validate.ts
+++ b/src/shared/doi-validate.ts
@@ -1,6 +1,7 @@
 import type { DoiString } from "./types";
 import { debugLog, debugWarn } from "./debug";
 import { BlobCache } from "./blob-cache";
+import { mapWithLimit } from "./request-gate";
 
 /**
  * Validate DOIs by checking the doi.org Handle System API.
@@ -10,20 +11,6 @@ import { BlobCache } from "./blob-cache";
 
 const HANDLE_API = "https://doi.org/api/handles/";
 const MAX_CONCURRENT_CHECKS = 6;
-
-async function mapWithLimit<T>(
-  items: T[],
-  limit: number,
-  worker: (item: T) => Promise<void>
-): Promise<void> {
-  let next = 0;
-  const runners = Array.from({ length: Math.min(limit, items.length) }, async () => {
-    while (next < items.length) {
-      await worker(items[next++]);
-    }
-  });
-  await Promise.all(runners);
-}
 const CACHE_TTL = 7 * 24 * 60 * 60 * 1000; // 7 days
 
 const VALIDATION_CACHE = new BlobCache<{ valid: boolean }>({

--- a/src/shared/request-gate.ts
+++ b/src/shared/request-gate.ts
@@ -1,0 +1,91 @@
+import {debugWarn} from "./debug";
+
+/** Run `worker` over `items` with at most `limit` in flight. */
+export async function mapWithLimit<T>(
+    items: T[],
+    limit: number,
+    worker: (item: T) => Promise<void>,
+): Promise<void> {
+    let next = 0;
+    const runners = Array.from({length: Math.min(limit, items.length)}, async () => {
+        while (next < items.length) {
+            await worker(items[next++]);
+        }
+    });
+    await Promise.all(runners);
+}
+
+const DEFAULT_BACKOFF_MS = 1_000;
+/** Longest pause a request will sit out; a longer Retry-After blocks the platform instead. */
+const MAX_WAIT_MS = 5_000;
+
+function parseRetryAfter(header: string | null): number | null {
+    if (!header) return null;
+    const seconds = Number(header);
+    if (Number.isFinite(seconds)) return seconds * 1000;
+    const at = Date.parse(header);
+    return Number.isNaN(at) ? null : at - Date.now();
+}
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Per-platform fetch gate: caps concurrent requests, spaces their starts by
+ * `minIntervalMs`, and on HTTP 429 pauses the platform for `Retry-After`
+ * (default 1 s). A short pause is waited out and the request retried once; a
+ * long one (an exhausted daily budget) blocks the platform until it lapses,
+ * and requests arriving meanwhile fail at once instead of queueing.
+ */
+export class RequestGate {
+    private active = 0;
+    private readonly waiting: Array<() => void> = [];
+    private blockedUntil = 0;
+    private nextStartAt = 0;
+
+    constructor(
+        private readonly name: string,
+        private readonly maxConcurrent: number,
+        private readonly minIntervalMs = 0,
+    ) {}
+
+    async fetch(url: string, init?: RequestInit): Promise<Response> {
+        await this.acquire();
+        try {
+            for (let attempt = 0; ; attempt++) {
+                const now = Date.now();
+                const startAt = Math.max(now, this.nextStartAt, this.blockedUntil);
+                if (startAt - now > MAX_WAIT_MS) {
+                    throw new Error(`${this.name} rate limited (paused for another ${Math.round((startAt - now) / 1000)} s)`);
+                }
+                this.nextStartAt = startAt + this.minIntervalMs;
+                if (startAt > now) await sleep(startAt - now);
+
+                const response = await fetch(url, init);
+                if (response.status !== 429 || attempt > 0) return response;
+
+                const backoff = parseRetryAfter(response.headers.get("retry-after")) ?? DEFAULT_BACKOFF_MS;
+                this.blockedUntil = Math.max(this.blockedUntil, Date.now() + backoff);
+                if (backoff > MAX_WAIT_MS) {
+                    debugWarn(`${this.name}: HTTP 429 with Retry-After ${Math.round(backoff / 1000)} s — pausing this platform until then`);
+                    return response;
+                }
+                debugWarn(`${this.name}: HTTP 429 — pausing ${backoff} ms, then retrying once`);
+            }
+        } finally {
+            this.release();
+        }
+    }
+
+    private acquire(): Promise<void> {
+        if (this.active < this.maxConcurrent) {
+            this.active++;
+            return Promise.resolve();
+        }
+        return new Promise((resolve) => this.waiting.push(() => { this.active++; resolve(); }));
+    }
+
+    private release(): void {
+        this.active--;
+        this.waiting.shift()?.();
+    }
+}

--- a/tests/unit/doi-augment.test.ts
+++ b/tests/unit/doi-augment.test.ts
@@ -641,6 +641,38 @@ describe("augmentDOIs", () => {
     expect(results.get(title)).toBe("10.1146/annurev-psych-020821-114157");
   });
 
+  it("asks one platform per title, alternating, and the other only when the first finds nothing", async () => {
+    // Alpha is on Crossref, Beta on neither platform's first stop: title 0 goes
+    // Crossref-first and stops; title 1 goes OpenAlex-first, misses, then falls
+    // back to Crossref.
+    const asked: string[] = [];
+    const record = (platform: string, url: string) => {
+      const q = decodeURIComponent(new URL(url).search);
+      asked.push(`${platform}:${/Alpha/.test(q) ? "alpha" : /Beta/.test(q) ? "beta" : "?"}`);
+    };
+    server.use(
+      http.get(CROSSREF_URL, ({ request }) => {
+        record("crossref", request.url);
+        const q = decodeURIComponent(request.url);
+        const items = /Alpha/.test(q)
+          ? [{ DOI: "10.1000/alpha", title: ["Alpha Study of Things"], issued: { "date-parts": [[2020]] } }]
+          : /Beta/.test(q)
+            ? [{ DOI: "10.1000/beta", title: ["Beta Study of Things"], issued: { "date-parts": [[2021]] } }]
+            : [];
+        return HttpResponse.json({ message: { items } });
+      }),
+      http.get(OPENALEX_URL, ({ request }) => {
+        record("openalex", request.url);
+        return HttpResponse.json({ results: [] });
+      })
+    );
+
+    const results = await augmentDOIs(["Alpha Study of Things", "Beta Study of Things"]);
+    expect(results.get("Alpha Study of Things")).toBe("10.1000/alpha");
+    expect(results.get("Beta Study of Things")).toBe("10.1000/beta");
+    expect(asked.sort()).toEqual(["crossref:alpha", "crossref:beta", "openalex:beta"]);
+  });
+
   it("returns null for ambiguous same-score candidates when metadata cannot break the tie", async () => {
     server.use(
       http.get(CROSSREF_URL, () => HttpResponse.json({ message: { items: [] } })),

--- a/tests/unit/doi-augment.test.ts
+++ b/tests/unit/doi-augment.test.ts
@@ -8,6 +8,16 @@ vi.mock("../../src/shared/settings", () => ({
   isSetupComplete: vi.fn().mockResolvedValue(true),
 }));
 
+// The request gate spaces real requests out; these tests exercise matching,
+// not pacing, so route its fetch straight through.
+vi.mock("../../src/shared/request-gate", () => ({
+  RequestGate: class {
+    fetch(url: string, init?: RequestInit) {
+      return fetch(url, init);
+    }
+  },
+}));
+
 import { normalizeTitle, similarity, tokenSetRatio, augmentDOIs, fetchTitleByDoi, _resetAugmentCachesForTesting } from "../../src/shared/doi-augment";
 import { getSettings } from "../../src/shared/settings";
 

--- a/tests/unit/request-gate.test.ts
+++ b/tests/unit/request-gate.test.ts
@@ -1,0 +1,56 @@
+import {describe, it, expect, vi} from "vitest";
+import {RequestGate} from "../../src/shared/request-gate";
+
+function deferredFetch() {
+    const pending: Array<(r: Response) => void> = [];
+    const fetchMock = vi.fn(() => new Promise<Response>((resolve) => pending.push(resolve)));
+    vi.stubGlobal("fetch", fetchMock);
+    return {fetchMock, pending};
+}
+
+describe("RequestGate", () => {
+    it("keeps at most the configured number of requests in flight", async () => {
+        const {fetchMock, pending} = deferredFetch();
+        const gate = new RequestGate("Test", 2);
+        const calls = [1, 2, 3, 4].map((i) => gate.fetch(`https://x/${i}`));
+        await Promise.resolve();
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        pending.shift()!(new Response("", {status: 200}));
+        await calls[0];
+        expect(fetchMock).toHaveBeenCalledTimes(3);
+        for (const resolve of pending.splice(0)) resolve(new Response("", {status: 200}));
+        await Promise.all(calls.slice(1, 3));
+        expect(fetchMock).toHaveBeenCalledTimes(4);
+        pending.shift()!(new Response("", {status: 200}));
+        await Promise.all(calls);
+        vi.unstubAllGlobals();
+    });
+
+    it("waits out Retry-After on a 429 and retries once", async () => {
+        vi.useFakeTimers();
+        const fetchMock = vi.fn()
+            .mockResolvedValueOnce(new Response("", {status: 429, headers: {"retry-after": "2"}}))
+            .mockResolvedValueOnce(new Response("ok", {status: 200}));
+        vi.stubGlobal("fetch", fetchMock);
+        const gate = new RequestGate("Test", 1);
+        const request = gate.fetch("https://x/1");
+        await vi.advanceTimersByTimeAsync(1_999);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        await vi.advanceTimersByTimeAsync(2);
+        expect((await request).status).toBe(200);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        vi.useRealTimers();
+        vi.unstubAllGlobals();
+    });
+
+    it("blocks the platform on a long Retry-After instead of queueing behind it", async () => {
+        const fetchMock = vi.fn()
+            .mockResolvedValue(new Response("", {status: 429, headers: {"retry-after": "39000"}}));
+        vi.stubGlobal("fetch", fetchMock);
+        const gate = new RequestGate("Test", 2);
+        expect((await gate.fetch("https://x/1")).status).toBe(429);
+        await expect(gate.fetch("https://x/2")).rejects.toThrow(/rate limited/);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        vi.unstubAllGlobals();
+    });
+});

--- a/tests/unit/title-doi-encoding.test.ts
+++ b/tests/unit/title-doi-encoding.test.ts
@@ -8,6 +8,15 @@ vi.mock("../../src/shared/settings", () => ({
   isSetupComplete: vi.fn().mockResolvedValue(true),
 }));
 
+// Pacing between real requests is not under test here.
+vi.mock("../../src/shared/request-gate", () => ({
+  RequestGate: class {
+    fetch(url: string, init?: RequestInit) {
+      return fetch(url, init);
+    }
+  },
+}));
+
 const server = setupServer();
 beforeAll(() => server.listen({ onUnhandledRequest: "bypass" }));
 afterEach(() => server.resetHandlers());


### PR DESCRIPTION
## TL;DR

**Issue.** Resolving DOI-less references (title search on Crossref + OpenAlex) was both failing and slow, and the whole page waited for it:
1. Every title was sent to *both* platforms at once. On a page with 30 such references both answered HTTP 429 within a second and most titles ended unresolved.
2. The APIs are tighter than the code assumed: Crossref's polite pool is **3 requests/s, 3 concurrent**; OpenAlex meters title searches at 10 credits each against a **free budget of 1000 credits/day per client** (~100 searches), then 429s until midnight UTC.
3. `runScanPass` awaited reference resolution *before* the retraction check and FLoRA lookup, so the reader saw nothing until the slowest title query returned — with paced requests that would be 10+ s.

**Solution.**
1. `RequestGate` per platform: 3 in flight, starts spaced (Crossref 400 ms, OpenAlex 100 ms); short `Retry-After` → wait and retry once; long `Retry-After` (spent daily budget) → pause that platform, fail fast, let the other answer.
2. One platform per title, alternating Crossref/OpenAlex; the other is asked only on a miss, a failure, or an ambiguous multi-DOI answer. Halves OpenAlex spend, no recall loss.
3. Reference resolution runs off the pass: page DOIs are checked, looked up and pilled immediately; `finishReferences()` pills resolved references when their DOIs land, keeps the toast up ("Resolving references without a DOI…") and settles the "nothing to flag" verdict afterwards.

Measured on the Wikipedia "Replication crisis" page (179 DOIs, 30 DOI-less refs): page results now appear ~3 s after validation instead of after the last title query; 0 titles left unanswered by rate limits (was ~17 of 30).

## Details

### `src/shared/request-gate.ts` (new)
- `RequestGate(name, maxConcurrent, minIntervalMs)`: semaphore + start spacing; on 429 reads `Retry-After` (default 1 s). ≤5 s: wait, retry once. >5 s: mark platform blocked until then, return the 429; later requests throw immediately (`"<name> rate limited (paused for another N s)"`).
- `mapWithLimit` moved here from `doi-validate.ts`.

### `src/shared/doi-augment.ts`
- `crossrefGate = RequestGate("Crossref", 3, 400)`, `openalexGate = RequestGate("OpenAlex", 3, 100)`; all four fetches (two title searches, two DOI→title lookups) go through them.
- Lookup loop: title *i* asks Crossref first when *i* is even, OpenAlex first when odd; stops when the first platform returns exactly one distinct DOI; otherwise (nothing, error, or ≥2 DOIs such as a preprint/journal pair) asks the other and merges candidates as before. Provenance (`crossref` / `openalex` / `both`) unchanged.

### `src/content-general/index.ts`
- Retraction notices split into `pageNotices` (replaced per page check) and `refNotices` (accumulated per URL); `redacts` is their union, so a resolved reference's notice survives later page-DOI rechecks (previously it was dropped).
- `finishReferences(refsPromise)`: retraction check for the resolved DOIs, `renderResolvedReferences`, badge refresh, and the deferred `reportNothingToFlag`. Holds a work-indicator ref; never rejects (failure releases the entries for a later pass); discards results if the URL changed meanwhile. `checkPubPeer` now awaits this so the panel sees the reference notices.

### Tests
- `tests/unit/request-gate.test.ts`: concurrency cap, short-429 retry, long-429 platform block.
- `doi-augment.test.ts`: alternation and fallback order asserted; the gate is mocked as pass-through there and in `title-doi-encoding.test.ts` so the suite does not pace real time.
- `npm test` 643 passing, `npm run typecheck` clean; live checks in Chrome for Testing as above.

### Seen but not addressed here
Reference augmentation on ordinary pages rarely resolves anything even without rate limits: the query text is the whole citation (authors, year, journal, volume), and `titleCoverage` requires the candidate to cover ≥75 % of the *queried* tokens, which a bare title never does. On a fixture with four textbook references (Wakefield 1998, Bem 2011, OSC 2015, Simmons 2011) all four correct titles were returned by Crossref and all four rejected ("0 usable"), on `main` as well. Fixing that means extracting the title from the citation before querying — a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)