### PR TITLE
Resolve DOI-less references by verifying candidates against the citation text

### DIFF
--- a/src/content-general/references.ts
+++ b/src/content-general/references.ts
@@ -222,7 +222,7 @@ export async function resolveReferenceDois(): Promise<ResolvedReference[]> {
     const empty = new Map<string, DoiString | null>();
     const [augmentSettled, pmcSettled] = await Promise.allSettled([
         augmentTargets.length > 0
-            ? augmentDOIsViaWorker(augmentTargets.map((p) => p.entry.text))
+            ? augmentDOIsViaWorker(augmentTargets.map((p) => ({title: p.entry.text, kind: "citation" as const})))
             : Promise.resolve(empty),
         pmcTargets.length > 0
             ? resolvePmcIdsViaWorker(pmcTargets.map((p) => p.pmcid))

--- a/src/shared/doi-augment.ts
+++ b/src/shared/doi-augment.ts
@@ -48,6 +48,17 @@ interface DoiCandidate {
     firstAuthor?: string | null;
     year?: number | null;
     urls?: string[];
+    containerTitle?: string | null;
+    volume?: string | null;
+    firstPage?: string | null;
+    /** Citation requests only: which candidate fields the citation text confirmed. */
+    citationMatches?: CitationMatches;
+}
+
+interface CitationMatches {
+    year: boolean;
+    author: boolean;
+    locator: boolean;
 }
 
 async function getUserEmail(): Promise<string> {
@@ -83,15 +94,15 @@ function cleanTitleForSearch(title: string): string {
  */
 function normalizeAuthorName(author: string | null | undefined): string {
     if (!author) return "";
-    const ascii = author
+    const plain = author
         .normalize("NFKD")
         .replace(/[̀-ͯ]/g, "")
         .toLowerCase()
-        .replace(/[^\w\s-]/g, " ")
+        .replace(/[^\p{L}\p{N}\s-]/gu, " ")
         .replace(/\s+/g, " ")
         .trim();
-    if (!ascii) return "";
-    const tokens = ascii.split(/\s+/).filter((token) => token && !/^[a-z]\.?$/.test(token));
+    if (!plain) return "";
+    const tokens = plain.split(/\s+/).filter((token) => token && !/^\p{L}$/u.test(token));
     return tokens[tokens.length - 1] ?? "";
 }
 
@@ -99,6 +110,7 @@ function normalizeRequest(input: string | DoiAugmentRequest): DoiAugmentRequest 
     if (typeof input === "string") return {title: input};
     return {
         title: input.title,
+        kind: input.kind ?? "title",
         firstAuthor: input.firstAuthor ?? null,
         year: input.year ?? null,
         sourceUrl: input.sourceUrl ?? null,
@@ -148,7 +160,132 @@ function candidateMerit(request: DoiAugmentRequest, candidate: DoiCandidate): nu
     if (candidateMatchesSourceUrl(request, candidate)) merit += 8;
     if (yearsMatch(request.year, candidate.year)) merit += 3;
     if (authorsMatch(request.firstAuthor, candidate.firstAuthor)) merit += 3;
+    // Fields the citation text confirmed outrank ones it merely didn't contradict,
+    // so a journal article (volume/pages present in the citation) beats the
+    // same-titled preprint that has no locators to check.
+    const m = candidate.citationMatches;
+    if (m) merit += (m.year ? 3 : 0) + (m.author ? 3 : 0) + (m.locator ? 4 : 0);
     return merit;
+}
+
+// ── Citation-string verification ────────────────────────────────────────────
+// A reference-list entry ("Wakefield, A. J., … (1998). Ileal-lymphoid-nodular
+// hyperplasia … The Lancet, 351(9103), 637–641.") is not parsed: it is reduced
+// to a bag of tokens, and each candidate's *structured* fields — which
+// Crossref returns already parsed — are checked for presence in that bag.
+// That is format-agnostic (APA, Vancouver, Wikipedia's markup all contain the
+// same surname, year, volume and page tokens) and mirrors Crossref's own
+// search-then-validate reference matching.
+
+/** Share of the candidate title's tokens the citation must contain. */
+const CITATION_TITLE_COVERAGE = 80;
+/** Share of the journal-name tokens (generic words removed) the citation must contain. */
+const CITATION_JOURNAL_COVERAGE = 50;
+/** Words too common across journal names to count as evidence for one journal. */
+const JOURNAL_STOPWORDS = new Set([
+    "the", "of", "and", "for", "in", "on", "de", "la", "le", "der", "und", "des",
+    "journal", "journals", "review", "reviews", "annals", "proceedings", "transactions", "letters",
+    "bulletin", "archives", "acta", "advances", "reports", "research", "studies", "quarterly",
+    "international", "national", "european", "american", "british", "science", "sciences",
+]);
+/** The first-author surname must sit within this many leading citation tokens. */
+const AUTHOR_LEAD_TOKENS = 8;
+
+/**
+ * Lowercase, diacritics stripped, split on anything that is not a letter or
+ * digit in any script (so en/em dashes split page ranges and CJK runs stay
+ * whole). Order-preserving; wrap in a Set for membership tests.
+ */
+export function citationTokenList(text: string): string[] {
+    return text
+        .normalize("NFKD")
+        .replace(/[\u0300-\u036f]/g, "")
+        .toLowerCase()
+        .replace(/[^\p{L}\p{N}\s]/gu, " ")
+        .split(/\s+/)
+        .filter(Boolean);
+}
+
+export function citationTokens(text: string): Set<string> {
+    return new Set(citationTokenList(text));
+}
+
+function tokenCoverage(needle: string, haystack: Set<string>, ignore?: Set<string>): {covered: number; total: number} {
+    const tokens = [...citationTokens(needle)].filter((t) => !ignore?.has(t));
+    let covered = 0;
+    for (const t of tokens) if (haystack.has(t)) covered++;
+    return {covered, total: tokens.length};
+}
+
+/**
+ * Verify a candidate against a citation string. Returns the title coverage
+ * (0–100, used as the candidate's score) plus which fields the citation
+ * confirmed, or null when the candidate is contradicted or under-supported:
+ *  - title: ≥ 80 % of the candidate's title tokens present;
+ *  - year: present within ±1 (online-first vs print), if the candidate has one;
+ *  - first author: surname among the leading tokens (reference styles put the
+ *    first author first), if the candidate has a usable one — this also keeps
+ *    a co-author, or the author of a second work in the same entry, from
+ *    standing in;
+ *  - locator: volume, first page, or half the journal-name tokens (generic
+ *    words removed) present, if the candidate has any of those; a token that
+ *    served as the year cannot serve as volume or page too.
+ * A field the candidate lacks cannot contradict, but at least two of the
+ * three must be positively confirmed, and all three for a candidate title of
+ * ≤ 3 tokens (generic titles like "Editorial" match anything).
+ */
+export function verifyAgainstCitation(
+    citation: string,
+    candidate: {title: string; firstAuthor?: string | null; year?: number | null; containerTitle?: string | null; volume?: string | null; firstPage?: string | null},
+): {coverage: number; matches: CitationMatches} | null {
+    const tokens = citationTokenList(citation);
+    const bag = new Set(tokens);
+
+    // Crossref prefixes the record of a retracted/withdrawn article with its
+    // status; the citation was written before that happened.
+    const plainTitle = candidate.title.replace(/^\s*(retracted|withdrawn)(\s+article)?\s*[:\-–—]\s*/i, "");
+    const title = tokenCoverage(plainTitle, bag);
+    if (title.total === 0) return null;
+    const coverage = (title.covered / title.total) * 100;
+    if (coverage < CITATION_TITLE_COVERAGE) return null;
+
+    let year = false;
+    let yearToken: string | null = null;
+    if (typeof candidate.year === "number") {
+        yearToken = [candidate.year, candidate.year - 1, candidate.year + 1].map(String).find((y) => bag.has(y)) ?? null;
+        year = yearToken !== null;
+        if (!year) return null;
+    }
+
+    let author = false;
+    const surname = normalizeAuthorName(candidate.firstAuthor);
+    // Skip initials-only or empty names; a two-character non-Latin surname is a real one.
+    if (surname.length >= 3 || (surname.length > 0 && /[^\x00-\x7f]/.test(surname))) {
+        const lead = tokens.slice(0, AUTHOR_LEAD_TOKENS);
+        const last = surname.split(/[\s-]+/).pop() ?? "";
+        author = lead.includes(surname) || lead.includes(last);
+        if (!author) return null;
+    }
+
+    let locator = false;
+    const hasLocator = !!(candidate.volume || candidate.firstPage || candidate.containerTitle);
+    if (hasLocator) {
+        const usable = (v: string | null | undefined): boolean => !!v && v.toLowerCase() !== yearToken && bag.has(v.toLowerCase());
+        const volumeHit = usable(candidate.volume);
+        const pageHit = usable(candidate.firstPage);
+        let journalHit = false;
+        if (candidate.containerTitle) {
+            const j = tokenCoverage(candidate.containerTitle, bag, JOURNAL_STOPWORDS);
+            journalHit = j.total > 0 && (j.covered / j.total) * 100 >= CITATION_JOURNAL_COVERAGE;
+        }
+        locator = volumeHit || pageHit || journalHit;
+        if (!locator) return null;
+    }
+
+    const confirmed = [year, author, locator].filter(Boolean).length;
+    if (confirmed < 2) return null;
+    if (title.total <= 3 && confirmed < 3) return null;
+    return {coverage, matches: {year, author, locator}};
 }
 
 /**
@@ -157,14 +294,15 @@ function candidateMerit(request: DoiAugmentRequest, candidate: DoiCandidate): nu
  * DOI — better to show nothing than to guess the wrong paper.
  */
 function selectBestCandidate(request: DoiAugmentRequest, candidates: DoiCandidate[]): DoiCandidate | null {
-    const eligible = candidates.filter((candidate) => candidate.score >= MATCH_THRESHOLD_TSR);
+    const threshold = request.kind === "citation" ? CITATION_TITLE_COVERAGE : MATCH_THRESHOLD_TSR;
+    const eligible = candidates.filter((candidate) => candidate.score >= threshold);
     if (eligible.length === 0) {
-        debugLog(`Augment: no candidate cleared ${MATCH_THRESHOLD_TSR} for "${request.title.slice(0, 80)}"`);
+        debugLog(`Augment: no candidate cleared ${threshold} for "${request.title.slice(0, 80)}"`);
         return null;
     }
 
     const highestScore = Math.max(...eligible.map((candidate) => candidate.score));
-    const titleBand = request.firstAuthor || request.year
+    const titleBand = request.kind === "citation" || request.firstAuthor || request.year
         ? eligible.filter((candidate) => candidate.score >= highestScore - METADATA_TITLE_BAND)
         : eligible.filter((candidate) => candidate.score === highestScore);
 
@@ -323,9 +461,15 @@ function logQueryOutcome(
  */
 async function queryCrossref(request: DoiAugmentRequest, email: string): Promise<DoiCandidate[]> {
     const {title} = request;
+    const isCitation = request.kind === "citation";
     const cleaned = cleanTitleForSearch(title);
-    const url = `${CROSSREF_BASE}?query.title=${encodeURIComponent(cleaned)}&rows=5&select=DOI,title,author,issued,published-print,published-online,published,URL,link&mailto=${encodeURIComponent(email)}`;
-    debugLog(`Augment [crossref] query: "${cleaned}"`);
+    // `query.bibliographic` is Crossref's field for whole reference strings;
+    // `query.title` for a bare title.
+    const query = isCitation
+        ? `query.bibliographic=${encodeURIComponent(cleaned)}`
+        : `query.title=${encodeURIComponent(cleaned)}`;
+    const url = `${CROSSREF_BASE}?${query}&rows=5&select=DOI,title,author,issued,published-print,published-online,published,URL,link,container-title,volume,page&mailto=${encodeURIComponent(email)}`;
+    debugLog(`Augment [crossref] ${isCitation ? "citation" : "query"}: "${cleaned}"`);
     const response = await crossrefGate.fetch(url);
     if (!response.ok) throw new Error(`Crossref HTTP ${response.status}`);
 
@@ -341,6 +485,9 @@ async function queryCrossref(request: DoiAugmentRequest, email: string): Promise
                 published?: {"date-parts"?: number[][]};
                 URL?: string;
                 link?: Array<{URL?: string}>;
+                "container-title"?: string[];
+                volume?: string;
+                page?: string;
             }>;
         };
     };
@@ -351,25 +498,34 @@ async function queryCrossref(request: DoiAugmentRequest, email: string): Promise
 
     for (const item of items) {
         if (!item.DOI || !item.title?.[0]) continue;
+        const doi = normaliseDOI(item.DOI);
+        if (!doi) continue;
+        const fields = {
+            title: item.title[0],
+            firstAuthor: item.author?.[0]?.family ?? item.author?.[0]?.name ?? null,
+            year: extractCrossrefYear(item),
+            urls: compactUrls([item.URL, ...(item.link ?? []).map((link) => link.URL)]),
+            containerTitle: item["container-title"]?.[0] ?? null,
+            volume: item.volume ?? null,
+            firstPage: item.page?.split(/[-–—]/)[0]?.trim() || null,
+        };
 
-        const tsr = tokenSetRatio(title, item.title[0]);
-        const coverage = titleCoverage(title, item.title[0]);
-        if (tsr < MATCH_THRESHOLD_TSR || coverage < MATCH_THRESHOLD_COVERAGE) {
-            rejected.push({score: tsr, coverage, title: item.title[0]});
-        }
-        if (tsr >= MATCH_THRESHOLD_TSR && coverage >= MATCH_THRESHOLD_COVERAGE) {
-            const doi = normaliseDOI(item.DOI);
-            if (doi) {
-                candidates.push({
-                    doi,
-                    title: item.title[0],
-                    score: tsr,
-                    source: "crossref",
-                    firstAuthor: item.author?.[0]?.family ?? item.author?.[0]?.name ?? null,
-                    year: extractCrossrefYear(item),
-                    urls: compactUrls([item.URL, ...(item.link ?? []).map((link) => link.URL)]),
-                });
+        if (isCitation) {
+            const verdict = verifyAgainstCitation(title, fields);
+            if (verdict) {
+                candidates.push({doi, score: verdict.coverage, source: "crossref", citationMatches: verdict.matches, ...fields});
+            } else {
+                rejected.push({score: 0, coverage: 0, title: fields.title});
             }
+            continue;
+        }
+
+        const tsr = tokenSetRatio(title, fields.title);
+        const coverage = titleCoverage(title, fields.title);
+        if (tsr >= MATCH_THRESHOLD_TSR && coverage >= MATCH_THRESHOLD_COVERAGE) {
+            candidates.push({doi, score: tsr, source: "crossref", ...fields});
+        } else {
+            rejected.push({score: tsr, coverage, title: fields.title});
         }
     }
 
@@ -475,7 +631,12 @@ export async function augmentDOIsDetailed(
     // Check cache first — single-blob lookup keyed by normalized title. The
     // cache stays title-keyed; page metadata only influences candidate choice,
     // not the cache identity.
-    const keyByTitle = new Map(requests.map((r) => [r.title, normalizeTitle(r.title)] as const));
+    // Citation requests get their own key space: a whole-citation miss cached
+    // under the title-matching rules must not answer for the field-verified path.
+    const keyByTitle = new Map(requests.map((r) => [
+        r.title,
+        (r.kind === "citation" ? "cite:" : "") + normalizeTitle(r.title),
+    ] as const));
     const cached = await DOI_AUGMENT_CACHE.getMany([...new Set(keyByTitle.values())]);
 
     // Group cache misses by their normalized key so titles that only differ in
@@ -526,7 +687,12 @@ export async function augmentDOIsDetailed(
     const updates: Array<[string, CachedDoiResult]> = [];
     const lookupPromises = [...uncachedByKey.entries()].map(async ([key, group], index) => {
         const request = group[0];
-        const order: AugmentPlatform[] = index % 2 === 0 ? ["crossref", "openalex"] : ["openalex", "crossref"];
+        // OpenAlex's title search needs every query token in the title, so a
+        // whole citation string returns nothing there; citations go to Crossref
+        // alone (its `query.bibliographic` is built for them).
+        const order: AugmentPlatform[] = request.kind === "citation"
+            ? ["crossref"]
+            : index % 2 === 0 ? ["crossref", "openalex"] : ["openalex", "crossref"];
         const outcomes: Partial<Record<AugmentPlatform, PromiseSettledResult<DoiCandidate[]>>> = {};
         for (const platform of order) {
             const [outcome] = await Promise.allSettled([

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -115,7 +115,15 @@ export interface RetractionResponse {
 
 /** Input to the DOI-augmentation title search */
 export interface DoiAugmentRequest {
+    /** A bare title, or — with kind "citation" — a whole reference-list entry. */
     title: string;
+    /**
+     * "title" (default): `title` is a paper title; candidates must match it
+     * closely. "citation": `title` is a full citation string (authors, year,
+     * title, venue, locators) — candidates are verified field by field
+     * against it instead.
+     */
+    kind?: "title" | "citation";
     firstAuthor?: string | null;
     year?: number | null;
     sourceUrl?: string | null;

--- a/tests/unit/citation-verify.test.ts
+++ b/tests/unit/citation-verify.test.ts
@@ -1,0 +1,151 @@
+import {describe, it, expect, vi, beforeEach, beforeAll, afterAll, afterEach} from "vitest";
+import {http, HttpResponse} from "msw";
+import {setupServer} from "msw/node";
+
+vi.mock("../../src/shared/settings", () => ({
+  getSettings: vi.fn().mockResolvedValue({email: "test@example.com"}),
+  isSetupComplete: vi.fn().mockResolvedValue(true),
+}));
+vi.mock("../../src/shared/request-gate", () => ({
+  RequestGate: class {
+    fetch(url: string, init?: RequestInit) {
+      return fetch(url, init);
+    }
+  },
+}));
+
+import {verifyAgainstCitation, citationTokens, augmentDOIs, _resetAugmentCachesForTesting} from "../../src/shared/doi-augment";
+
+const WAKEFIELD =
+  "Wakefield, A. J., Murch, S. H., Anthony, A., et al. (1998). Ileal-lymphoid-nodular hyperplasia, non-specific colitis, and pervasive developmental disorder in children. The Lancet, 351(9103), 637–641.";
+
+describe("verifyAgainstCitation", () => {
+  it("tokenises across styles: dashes split page ranges, diacritics are stripped", () => {
+    const t = citationTokens("Müller-Lyer, F. (1889). Optische Urteilstäuschungen. Arch. 2, 263–270.");
+    for (const tok of ["muller", "lyer", "1889", "263", "270"]) expect(t.has(tok)).toBe(true);
+  });
+
+  it("accepts the cited article and ignores Crossref's RETRACTED: prefix", () => {
+    const v = verifyAgainstCitation(WAKEFIELD, {
+      title: "RETRACTED: Ileal-lymphoid-nodular hyperplasia, non-specific colitis, and pervasive developmental disorder in children",
+      firstAuthor: "Wakefield", year: 1998, containerTitle: "The Lancet", volume: "351", firstPage: "637",
+    });
+    expect(v).not.toBeNull();
+    expect(v!.coverage).toBe(100);
+    expect(v!.matches).toEqual({year: true, author: true, locator: true});
+  });
+
+  it("rejects the retraction notice (wrong year) and a same-titled letter (wrong author)", () => {
+    expect(verifyAgainstCitation(WAKEFIELD, {
+      title: "Retraction—Ileal-lymphoid-nodular hyperplasia, non-specific colitis, and pervasive developmental disorder in children",
+      firstAuthor: "The Editors of The Lancet", year: 2010, containerTitle: "The Lancet", volume: "375", firstPage: "445",
+    })).toBeNull();
+    expect(verifyAgainstCitation(WAKEFIELD, {
+      title: "Ileal-lymphoid-nodular hyperplasia, non-specific colitis, and pervasive developmental disorder in children",
+      firstAuthor: "Sabra", year: 1998, containerTitle: "The Lancet", volume: "352", firstPage: "234",
+    })).toBeNull();
+  });
+
+  it("lets a subtitle-less candidate title through above 80 % coverage, and blocks below", () => {
+    const cite = "Bem, D. J. (2011). Feeling the future: Experimental evidence for anomalous retroactive influences on cognition and affect. Journal of Personality and Social Psychology, 100(3), 407–425.";
+    expect(verifyAgainstCitation(cite, {title: "Feeling the future: Experimental evidence for anomalous retroactive influences on cognition and affect", firstAuthor: "Bem", year: 2011, volume: "100"})).not.toBeNull();
+    expect(verifyAgainstCitation(cite, {title: "Feeling the future of quantum gravity in curved spacetime models", firstAuthor: "Bem", year: 2011, volume: "100"})).toBeNull();
+  });
+
+  it("requires year, author and locator all confirmed for a generic short title", () => {
+    const cite = "Smith, J. (2011). Editorial. Journal of Mock Studies, 12(1), 1–2.";
+    expect(verifyAgainstCitation(cite, {title: "Editorial", firstAuthor: "Smith", year: 2011, containerTitle: "Journal of Mock Studies", volume: "12"})).not.toBeNull();
+    // Same generic title, different volume and journal → cannot be confirmed.
+    expect(verifyAgainstCitation(cite, {title: "Editorial", firstAuthor: "Smith", year: 2011, containerTitle: "Annals of Something Else", volume: "40"})).toBeNull();
+    // No locator fields at all on the candidate: a generic title is not enough.
+    expect(verifyAgainstCitation(cite, {title: "Editorial", firstAuthor: "Smith", year: 2011})).toBeNull();
+  });
+
+  it("does not let a field the candidate lacks contradict, but needs two confirmed fields", () => {
+    const title = "Ileal-lymphoid-nodular hyperplasia, non-specific colitis, and pervasive developmental disorder in children";
+    // No locator fields on the candidate (a preprint, say): year + author carry it.
+    const v = verifyAgainstCitation(WAKEFIELD, {title, firstAuthor: "Wakefield", year: 1998});
+    expect(v).not.toBeNull();
+    expect(v!.matches).toEqual({year: true, author: true, locator: false});
+    // Title alone, nothing to corroborate: not enough.
+    expect(verifyAgainstCitation(WAKEFIELD, {title, firstAuthor: null, year: null})).toBeNull();
+  });
+
+  it("binds the first author to the start of the entry, so the author of a second work cannot stand in", () => {
+    const two = "Smith, J., Jones, R. (2020). Alpha beta gamma delta. Journal of Tests, 12, 56–60. Brown, T. (2021). Epsilon zeta eta theta. Other Journal, 20, 77–80.";
+    expect(verifyAgainstCitation(two, {title: "Alpha beta gamma delta", firstAuthor: "Brown", year: 2021, volume: "20", firstPage: "77"})).toBeNull();
+    expect(verifyAgainstCitation(two, {title: "Alpha beta gamma delta", firstAuthor: "Smith", year: 2020, volume: "12", firstPage: "56"})).not.toBeNull();
+  });
+
+  it("does not let one number serve as year and volume, and ignores generic journal words", () => {
+    const cite = "Smith, J. (2020). Alpha beta gamma delta. Journal of Chemistry, 12(1), 2021–2025.";
+    // Year matched by the page token, volume by the year token: nothing left for the locator.
+    expect(verifyAgainstCitation(cite, {title: "Alpha beta gamma delta", firstAuthor: "Smith", year: 2021, volume: "2021", firstPage: "9"})).toBeNull();
+    // "Journal of Biology" shares only the generic word "journal" with the citation.
+    expect(verifyAgainstCitation(cite, {title: "Alpha beta gamma delta", firstAuthor: "Smith", year: 2020, containerTitle: "Journal of Biology", volume: "99", firstPage: "999"})).toBeNull();
+    expect(verifyAgainstCitation(cite, {title: "Alpha beta gamma delta", firstAuthor: "Smith", year: 2020, containerTitle: "Journal of Chemistry", volume: "99", firstPage: "999"})).not.toBeNull();
+  });
+
+  it("handles non-Latin scripts: mixed-script wrong titles are rejected, CJK titles remain matchable", () => {
+    const cite = "Li, X. (2020). A study 机器学习模型. Journal of Tests, 12, 10.";
+    expect(verifyAgainstCitation(cite, {title: "A study 金融市场", firstAuthor: "Li", year: 2020, volume: "12", firstPage: "10"})).toBeNull();
+    expect(verifyAgainstCitation("李明 (2020). 机器学习模型研究. 计算机学报, 43, 1–10.", {title: "机器学习模型研究", firstAuthor: "李明", year: 2020, volume: "43", firstPage: "1"})).not.toBeNull();
+  });
+});
+
+describe("augmentDOIs with citation requests", () => {
+  const server = setupServer();
+  beforeAll(() => server.listen({onUnhandledRequest: "bypass"}));
+  afterEach(() => server.resetHandlers());
+  afterAll(() => server.close());
+  beforeEach(() => {
+    _resetAugmentCachesForTesting();
+    (chrome.storage.local.get as ReturnType<typeof vi.fn>).mockResolvedValue({});
+    (chrome.storage.local.set as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+  });
+
+  it("queries Crossref alone via query.bibliographic and prefers the journal article over its preprint", async () => {
+    const seen: string[] = [];
+    server.use(
+      http.get("https://api.crossref.org/works", ({request}) => {
+        seen.push(request.url);
+        return HttpResponse.json({message: {items: [
+          {DOI: "10.31234/osf.io/abcde", title: ["Ileal-lymphoid-nodular hyperplasia, non-specific colitis, and pervasive developmental disorder in children"],
+            author: [{family: "Wakefield"}], issued: {"date-parts": [[1998]]}},
+          {DOI: "10.1016/S0140-6736(97)11096-0", title: ["RETRACTED: Ileal-lymphoid-nodular hyperplasia, non-specific colitis, and pervasive developmental disorder in children"],
+            author: [{family: "Wakefield"}], issued: {"date-parts": [[1998, 2]]}, "container-title": ["The Lancet"], volume: "351", page: "637-641"},
+        ]}});
+      }),
+      http.get("https://api.openalex.org/works", ({request}) => {
+        seen.push(request.url);
+        return HttpResponse.json({results: []});
+      }),
+    );
+
+    const results = await augmentDOIs([{title: WAKEFIELD, kind: "citation"}]);
+    expect(results.get(WAKEFIELD)).toBe("10.1016/s0140-6736(97)11096-0");
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toContain("api.crossref.org");
+    expect(seen[0]).toContain("query.bibliographic=");
+  });
+
+  it("does not reuse a whole-citation miss cached under the title-matching rules", async () => {
+    const {normalizeTitle} = await import("../../src/shared/doi-augment");
+    (chrome.storage.local.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+      flora_doi_blob: {[normalizeTitle(WAKEFIELD)]: {v: {found: false, doi: null}, t: Date.now()}},
+    });
+    let crossrefCalls = 0;
+    server.use(
+      http.get("https://api.crossref.org/works", () => {
+        crossrefCalls++;
+        return HttpResponse.json({message: {items: [
+          {DOI: "10.1016/S0140-6736(97)11096-0", title: ["RETRACTED: Ileal-lymphoid-nodular hyperplasia, non-specific colitis, and pervasive developmental disorder in children"],
+            author: [{family: "Wakefield"}], issued: {"date-parts": [[1998, 2]]}, "container-title": ["The Lancet"], volume: "351", page: "637-641"},
+        ]}});
+      }),
+    );
+    const results = await augmentDOIs([{title: WAKEFIELD, kind: "citation"}]);
+    expect(crossrefCalls).toBe(1);
+    expect(results.get(WAKEFIELD)).toBe("10.1016/s0140-6736(97)11096-0");
+  });
+});

--- a/tests/unit/reference-retry.test.ts
+++ b/tests/unit/reference-retry.test.ts
@@ -67,8 +67,8 @@ describe("reference entries are retried when a lookup never answered", () => {
 
   it("keeps the entry marked when the lookup answered 'no match'", async () => {
     const { resolveReferenceDois } = await import("../../src/content-general/references");
-    augmentMock.mockImplementation(async (titles: string[]) =>
-      new Map(titles.map((t) => [t, null]))
+    augmentMock.mockImplementation(async (requests: Array<{title: string}>) =>
+      new Map(requests.map((r) => [r.title, null]))
     );
 
     const target = augmentTargetElement();
@@ -85,8 +85,8 @@ describe("reference entries are retried when a lookup never answered", () => {
       expect.arrayContaining([expect.objectContaining({ mode: "hidden" })])
     );
 
-    augmentMock.mockImplementation(async (titles: string[]) =>
-      new Map(titles.map((t) => [t, "10.1234/recovered" as DoiString]))
+    augmentMock.mockImplementation(async (requests: Array<{title: string}>) =>
+      new Map(requests.map((r) => [r.title, "10.1234/recovered" as DoiString]))
     );
     const second = await resolveReferenceDois();
 
@@ -95,8 +95,8 @@ describe("reference entries are retried when a lookup never answered", () => {
 
   it("does not re-augment entries that already resolved", async () => {
     const { resolveReferenceDois } = await import("../../src/content-general/references");
-    augmentMock.mockImplementation(async (titles: string[]) =>
-      new Map(titles.map((t) => [t, "10.1234/found" as DoiString]))
+    augmentMock.mockImplementation(async (requests: Array<{title: string}>) =>
+      new Map(requests.map((r) => [r.title, "10.1234/found" as DoiString]))
     );
 
     await resolveReferenceDois();


### PR DESCRIPTION
Stacked on #184 (base branch `augment-rate-limits`).

## TL;DR

**Issue.** Reference-list entries without a DOI reach the augmenter as whole citation strings ("Wakefield, A. J., … (1998). Ileal-lymphoid-nodular hyperplasia … The Lancet, 351(9103), 637–641."). Retrieval worked — Crossref returned the right paper as the top hit — but the acceptance check demanded that the *candidate title* cover ≥ 75 % of the *query's* tokens, and a title never covers the authors, journal and page numbers. Result: on ordinary pages this feature resolved essentially nothing (0 of 4 textbook references on a fixture; 0 of 16 on Wikipedia "Stereotype threat"), rate limits aside.

**Solution.** Do not parse the citation. Reduce it to a bag of tokens and check the *candidate's structured fields* (which Crossref returns already parsed) for presence in that bag — Crossref's own "search, then validate" approach to reference matching, style-agnostic by construction. Fixture: 4 of 4 resolve (incl. the retracted Wakefield paper, which now gets its pill); Wikipedia "Stereotype threat": 5 of 16, the rest being news, web pages and book chapters that are correctly left alone.

## Details

### Request kind
`DoiAugmentRequest.kind: "title" | "citation"` (`src/shared/types.ts`). `references.ts` sends reference entries as `kind: "citation"`. Scholar and title-based callers are unchanged (`"title"`, default) — same thresholds, same Crossref/OpenAlex alternation.

### Retrieval (`queryCrossref`)
Citation requests use `query.bibliographic=` (Crossref's field for whole reference strings) and select `container-title,volume,page` in addition. Citations go to Crossref only: OpenAlex's `title.search` requires every query token in the title and returns nothing for a citation string (checked live), and its `search=` returns noise; this also spares OpenAlex's metered daily budget.

### Verification (`verifyAgainstCitation`, `src/shared/doi-augment.ts`)
Citation → token list (NFKD, diacritics stripped, lowercase, split on anything that is not a letter/digit in any script, so "637–641" yields `637`,`641` and CJK runs stay whole). Per candidate:
- **title**: ≥ 80 % of the candidate's title tokens present (Crossref's `RETRACTED:`/`WITHDRAWN:` prefix stripped first); coverage becomes the candidate's score.
- **year**: candidate year ±1 present, if the candidate has one.
- **first author**: surname among the first 8 citation tokens, if the candidate has a usable one — reference styles lead with the first author, so a second work in the same entry cannot supply it.
- **locator**: volume, first page, or ≥ 50 % of the journal-name tokens (generic words such as "journal", "review", "international", "science" removed) present, if the candidate has any of these; the token that satisfied the year cannot also serve as volume/page.
- A field the candidate lacks cannot contradict, but **at least two of year/author/locator must be positively confirmed**, and all three for a title of ≤ 3 tokens ("Editorial", "Reply to Smith").

Confirmed fields add merit (+3 year, +3 author, +4 locator) so a journal article outranks its same-titled preprint (no locators). `selectBestCandidate` uses the 80 threshold and the metadata band for citation kind; the tie rule (several DOIs at equal merit → null) is unchanged, which is also what happens for an entry citing two works whose candidates both pass.

### Cache
Citation requests use a `cite:` key prefix in the augment cache, so whole-citation misses cached under the old title rules do not answer for the new path.

### Review
Reviewed by Codex (read-only) before opening; its findings and what changed:
- old negative cache entries would suppress the fix for 30 days → separate key space (test added);
- author/year/locator evidence not bound to one work → first-author position rule; multi-work entries otherwise fall to the tie rule;
- one number serving as year *and* volume/page → year token excluded from locator matching (test added);
- "Journal of X" passing on the word "journal" → generic journal words removed before coverage (test added);
- ASCII-only `\w` → Unicode letter/digit classes for citation tokens and author names (mixed-script and CJK tests added);
- title-only acceptance when the candidate has no metadata → two confirmed fields required.
Residual, documented: a co-author who is first author of a different work with an ≥ 80 %-overlapping title, matching year and matching locator could still pass; the augmented pill is already rendered as "unconfirmed" provenance.

### Tests
`tests/unit/citation-verify.test.ts` (11 cases: fixture references, retraction notice and same-titled letter rejected, subtitle tolerance, generic titles, second-work author, numeric collision, journal stopwords, scripts, Crossref-only + `query.bibliographic`, stale negative cache). `reference-retry.test.ts` mocks updated to the request-object shape. `npm test`: 654 passing; `npm run typecheck` clean; live checks in Chrome for Testing as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)