### PR TITLE
Progress toast: stage checklist, Scholar worklist, dismiss, per-site pause, debug-log copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,12 +165,14 @@ the `flora_debug_log` storage key — so there is no read-modify-write race betw
 contexts. The log is a ring buffer capped at 800 entries.
 
 With debug mode on, the progress toast (bottom right while a page is worked)
-also offers **Copy log** and **Copy log when finished** in its expanded panel, and
-every stage transition is logged with its duration (`Work: augment done in 2310 ms`),
-so a slow pass shows which stage took the time. The same panel lists the stages of
-the current pass — and on Google Scholar the DOIs and titles being resolved — and
-holds **Pause on this site** (an hour, until tomorrow, or block outright; resume
-from the popup).
+also offers **Copy log** in its expanded panel, and — with the popup's
+*Offer "Copy log" after each pass* switch on — stays up as a one-line
+`Done in 2.3 s · Copy log` after the pass. Every stage transition is logged with
+its duration (`Work: augment done in 2310 ms`), so a slow pass shows which stage
+took the time. The same panel lists the stages of the current pass (on Google
+Scholar also the DOIs and titles being resolved) and a **Cancel** button; the ⏸
+icon pauses ORE on the site for an hour or until tomorrow (resume from the popup)
+or disables it on the domain.
 
 To report a bug: turn debug mode on, reload the page, reproduce, then hit
 **Report an issue** in the popup. The diagnostic report — build, user agent,

--- a/README.md
+++ b/README.md
@@ -164,6 +164,14 @@ their entries and message them to the service worker, which is the only writer o
 the `flora_debug_log` storage key — so there is no read-modify-write race between
 contexts. The log is a ring buffer capped at 800 entries.
 
+With debug mode on, the progress toast (bottom right while a page is worked)
+also offers **Copy log** and **Copy log when finished** in its expanded panel, and
+every stage transition is logged with its duration (`Work: augment done in 2310 ms`),
+so a slow pass shows which stage took the time. The same panel lists the stages of
+the current pass — and on Google Scholar the DOIs and titles being resolved — and
+holds **Pause on this site** (an hour, until tomorrow, or block outright; resume
+from the popup).
+
 To report a bug: turn debug mode on, reload the page, reproduce, then hit
 **Report an issue** in the popup. The diagnostic report — build, user agent,
 behaviour-changing settings and the log — is written into the GitHub issue body

--- a/README.md
+++ b/README.md
@@ -170,8 +170,8 @@ also offers **Copy log** in its expanded panel, and — with the popup's
 `Done in 2.3 s · Copy log` after the pass. Every stage transition is logged with
 its duration (`Work: augment done in 2310 ms`), so a slow pass shows which stage
 took the time. The same panel lists the stages of the current pass (on Google
-Scholar also the DOIs and titles being resolved) and a **Cancel** button; the ⏸
-icon pauses ORE on the site for an hour or until tomorrow (resume from the popup)
+Scholar also the DOIs and titles being resolved) and a **Cancel** button; the clock
+icon snoozes ORE on the site for an hour or until tomorrow (resume from the popup)
 or disables it on the domain.
 
 To report a bug: turn debug mode on, reload the page, reproduce, then hit

--- a/src/content-general/index.ts
+++ b/src/content-general/index.ts
@@ -21,6 +21,7 @@ import {
     beginWorkIndicator,
     count,
     endWorkIndicator,
+    isWorkCancelled,
     reportWorkStage,
     hideAllFloraUI,
     removeSidePanel,
@@ -394,9 +395,9 @@ async function runScanPass(): Promise<void> {
         }
         pageStateVersion++; // signal that replication data is now available
 
-        // Paused or hidden while the lookup ran — the results stay in pageState
-        // for a later pass, but nothing goes on the page.
-        if (floraHidden) return;
+        // Paused, hidden or cancelled while the lookup ran — the results stay
+        // in pageState for a later pass, but nothing goes on the page.
+        if (floraHidden || isWorkCancelled()) return;
 
         try {
             reportWorkStage("report", "Generating report…");
@@ -464,8 +465,8 @@ function finishReferences(refsPromise: Promise<ResolvedReference[]>): Promise<Re
     beginWorkIndicator();
     return refsPromise
         .then(async (resolvedRefs) => {
-            if (floraHidden) {
-                // Paused or hidden while these were resolving — leave the page alone.
+            if (floraHidden || isWorkCancelled()) {
+                // Paused, hidden or cancelled while these were resolving — leave the page alone.
                 releaseReferenceEntries(resolvedRefs);
                 return [];
             }

--- a/src/content-general/index.ts
+++ b/src/content-general/index.ts
@@ -35,7 +35,7 @@ import {
 import {lookupPubPeer, lookupPubPeerForDois, type PubPeerFeedback} from "@shared/pubpeer-api";
 import {debugError, debugLog, debugWarn} from "@shared/debug";
 import {isSetupComplete} from "@shared/settings";
-import {isDomainBlocked} from "@shared/domains";
+import {isDomainBlocked, isDomainSnoozed} from "@shared/domains";
 import {isBotCheckPage} from "@shared/bot-check";
 import {injectInlineRetractionPills, resetRetractionPills, retractionCheck, RetractionResponse} from "@shared/doi-retraction"
 import {createIndicatorPill, removeIndicatorPills, updateIndicatorPillBadges, INDICATOR_PILL_CLASS} from "@shared/indicator-pill";
@@ -119,6 +119,15 @@ chrome.runtime.onMessage.addListener((message: unknown, _sender, sendResponse) =
     }
 });
 
+// The pause control on the work toast writes the snooze (or block) to storage
+// itself, then announces it here so this page clears immediately instead of
+// waiting for a reload.
+document.addEventListener("flora-pause-site", () => {
+    floraHidden = true;
+    hideAllFloraUI();
+    reportActiveState(false);
+});
+
 async function primaryDoiFastPath(): Promise<void> {
     const primary = extractPrimaryDOI(document);
     if (!primary) return;
@@ -134,7 +143,7 @@ async function primaryDoiFastPath(): Promise<void> {
         doiContext.delete(primary);
     };
 
-    beginWorkIndicator();
+    beginWorkIndicator({stages: ["scan"]});
     try {
         // "scan", not "lookup": the bar only moves forward, and the full page
         // pass runs alongside this one.
@@ -183,7 +192,9 @@ const runScanPasses = serializeWithRerun(() => runScanPass());
 
 /** Holds one work indicator across the pass so the bar doesn't restart mid-pipeline. */
 async function scanWholePage(): Promise<void> {
-    beginWorkIndicator();
+    // "augment" comes from references.ts, which resolves DOI-less references
+    // inside this pass.
+    beginWorkIndicator({stages: ["scan", "validate", "augment", "notices", "lookup", "report"]});
     try {
         await runScanPasses();
     } finally {
@@ -383,6 +394,10 @@ async function runScanPass(): Promise<void> {
         }
         pageStateVersion++; // signal that replication data is now available
 
+        // Paused or hidden while the lookup ran — the results stay in pageState
+        // for a later pass, but nothing goes on the page.
+        if (floraHidden) return;
+
         try {
             reportWorkStage("report", "Generating report…");
             // Collect matched DOIs for display
@@ -449,6 +464,11 @@ function finishReferences(refsPromise: Promise<ResolvedReference[]>): Promise<Re
     beginWorkIndicator();
     return refsPromise
         .then(async (resolvedRefs) => {
+            if (floraHidden) {
+                // Paused or hidden while these were resolving — leave the page alone.
+                releaseReferenceEntries(resolvedRefs);
+                return [];
+            }
             if (location.href !== passUrl) {
                 // Navigated away while resolving — these entries belong to the old page.
                 releaseReferenceEntries(resolvedRefs);
@@ -834,6 +854,12 @@ async function fetchSheetDois(): Promise<void> {
     if (await isDomainBlocked(location.hostname)) {
         debugLog("Domain is blocked:", location.hostname);
         reportActiveState(false); // gray toolbar icon — disabled on this domain
+        return;
+    }
+
+    if (await isDomainSnoozed(location.hostname)) {
+        debugLog("Domain is snoozed:", location.hostname);
+        reportActiveState(false); // gray toolbar icon — paused on this domain
         return;
     }
     // Applicable page — mark the toolbar icon active for this tab.

--- a/src/content-general/injector.ts
+++ b/src/content-general/injector.ts
@@ -12,7 +12,7 @@ import {ensureFocusStyle, FLORA_UI_SELECTOR} from "@shared/flora-ui";
 
 // The work/progress toast lives in shared so the Scholar content script can
 // drive it without importing this module's article-page rendering.
-export {beginWorkIndicator, count, endWorkIndicator, reportWorkStage} from "@shared/progress-toast";
+export {beginWorkIndicator, count, endWorkIndicator, isWorkCancelled, reportWorkStage} from "@shared/progress-toast";
 
 const BANNER_HOST_ID = "flora-banner-host";
 

--- a/src/content-scholar/index.ts
+++ b/src/content-scholar/index.ts
@@ -1,7 +1,7 @@
-import { observeScholarResults, processScholarResults } from "./observer";
+import { isScholarHidden, observeScholarResults, processScholarResults, setScholarHidden } from "./observer";
 import { debugError, debugLog } from "@shared/debug";
 import { isSetupComplete } from "@shared/settings";
-import { isDomainBlocked } from "@shared/domains";
+import { isDomainBlocked, isDomainSnoozed } from "@shared/domains";
 import { renderSetupPrompt, hideAllFloraUI, showAllFloraUI } from "../content-general/injector";
 
 // Tell the service worker whether FLoRA is active on this tab (toolbar icon).
@@ -19,6 +19,12 @@ function reportActiveState(active: boolean): void {
 
     if (await isDomainBlocked(location.hostname)) {
       debugLog("Domain is blocked:", location.hostname);
+      reportActiveState(false);
+      return;
+    }
+
+    if (await isDomainSnoozed(location.hostname)) {
+      debugLog("Domain is snoozed:", location.hostname);
       reportActiveState(false);
       return;
     }
@@ -43,8 +49,6 @@ function reportActiveState(active: boolean): void {
   }
 })();
 
-let floraHidden = false;
-
 // hideAllFloraUI/showAllFloraUI already sweep the merged indicator pills, which
 // is the only per-result UI Scholar rows carry.
 function hideScholarUI(): void {
@@ -60,16 +64,25 @@ chrome.runtime.onMessage.addListener((message: unknown, _sender, sendResponse) =
   const type = (message as { type?: string }).type;
 
   if (type === "FLORA_HIDE_UI") {
-    floraHidden = true;
+    setScholarHidden(true);
     hideScholarUI();
     reportActiveState(false);
     sendResponse({ ok: true });
   } else if (type === "FLORA_SHOW_UI") {
-    floraHidden = false;
+    setScholarHidden(false);
     showScholarUI();
     reportActiveState(true);
     sendResponse({ ok: true });
   } else if (type === "FLORA_GET_STATE") {
-    sendResponse({ hidden: floraHidden });
+    sendResponse({ hidden: isScholarHidden() });
   }
+});
+
+// The pause control on the work toast writes the snooze (or block) to storage
+// itself, then announces it here so this page clears immediately instead of
+// waiting for a reload.
+document.addEventListener("flora-pause-site", () => {
+  setScholarHidden(true);
+  hideScholarUI();
+  reportActiveState(false);
 });

--- a/src/content-scholar/observer.ts
+++ b/src/content-scholar/observer.ts
@@ -9,7 +9,15 @@ import type {DoiString, DoiSource, LookupState, RetractionResponse} from "@share
 import type {LookupRequest, LookupResponse} from "@shared/messages";
 import {createIndicatorPanel, updateIndicatorPillBadges} from "@shared/indicator-pill";
 import {fetchOpenAccess} from "@shared/openaccess";
-import {beginWorkIndicator, count, endWorkIndicator, reportWorkStage} from "@shared/progress-toast";
+import {
+    beginWorkIndicator,
+    count,
+    endWorkIndicator,
+    reportWorkStage,
+    setWorkItems,
+    updateWorkItem,
+    type WorkItem,
+} from "@shared/progress-toast";
 import {debugError, debugLog, debugWarn} from "@shared/debug";
 
 // One colour for every provenance — an unconfirmed DOI is marked by the
@@ -24,6 +32,19 @@ const scholarRedacts = new Map<DoiString, RetractionResponse>();
 
 function refreshScholarBadges(): void {
     updateIndicatorPillBadges(document, scholarState, [...scholarRedacts.values()]);
+}
+
+// Set by the popup's hide command and by the work toast's pause control (both
+// handled in index.ts). Lives here because the pass reads it to stop marking up
+// rows, and index.ts already imports this module.
+let scholarHidden = false;
+
+export function setScholarHidden(hidden: boolean): void {
+    scholarHidden = hidden;
+}
+
+export function isScholarHidden(): boolean {
+    return scholarHidden;
 }
 
 const RESULT_CONTAINER = "#gs_res_ccl";
@@ -61,13 +82,17 @@ export function observeScholarResults(): void {
 
 /** Holds one work indicator across the row batch — extraction through to badges. */
 export async function processScholarResults(doc: Document): Promise<void> {
+    if (scholarHidden) {
+        debugLog("Scholar: paused on this site — skipping the pass");
+        return;
+    }
     const rows = doc.querySelectorAll<HTMLElement>(
         `${RESULT_ROW}:not([${PROCESSED_ATTR}])`
     );
     debugLog(`Scholar: ${rows.length} new result row(s) to process`);
     if (rows.length === 0) return;
 
-    beginWorkIndicator();
+    beginWorkIndicator({stages: ["scan", "validate", "augment", "lookup", "report"]});
     try {
         await runScholarPass(rows);
     } finally {
@@ -134,17 +159,20 @@ async function runScholarPass(rows: NodeListOf<HTMLElement>): Promise<void> {
     // Phase 2: Validate extracted DOIs via doi.org, then augment only what's still unresolved
     if (rowInfos.length > 0) {
         // Step 1: Validate extracted DOIs with doi.org (cheap HEAD-like check)
-        const doisToValidate = rowInfos
-            .filter((r) => r.extractedDoi !== null)
-            .map((r) => r.extractedDoi!);
+        const withExtracted = rowInfos.filter((r) => r.extractedDoi !== null);
+        const doisToValidate = withExtracted.map((r) => r.extractedDoi!);
 
         let validated = new Map<DoiString, boolean>();
         if (doisToValidate.length > 0) {
             reportWorkStage("validate", `Checking ${count(doisToValidate.length, "DOI")} resolve…`);
+            setWorkItems(withExtracted.map((r) => workItem(r.extractedDoi!, r.title, r.extractedDoi!)));
             try {
                 validated = await validateDOIs(doisToValidate);
             } catch (err) {
                 debugWarn(`Scholar: validation failed for ${doisToValidate.length} DOI(s) —`, err);
+            }
+            for (const doi of doisToValidate) {
+                updateWorkItem(doi, validated.get(doi) ? "done" : "failed");
             }
         }
 
@@ -170,14 +198,13 @@ async function runScholarPass(rows: NodeListOf<HTMLElement>): Promise<void> {
 
         // Step 2: Augment only the remaining unresolved rows
         if (pendingInfos.length > 0) {
-            const requestsToAugment: DoiAugmentRequest[] = pendingInfos
-                .filter((r) => r.title)
-                .map((r) => ({
-                    title: r.title,
-                    firstAuthor: r.firstAuthor,
-                    year: r.year,
-                    sourceUrl: r.sourceUrl,
-                }));
+            const titledInfos = pendingInfos.filter((r) => r.title);
+            const requestsToAugment: DoiAugmentRequest[] = titledInfos.map((r) => ({
+                title: r.title,
+                firstAuthor: r.firstAuthor,
+                year: r.year,
+                sourceUrl: r.sourceUrl,
+            }));
             let augmented = new Map<string, DoiString | null>();
             try {
                 if (requestsToAugment.length > 0) {
@@ -185,10 +212,15 @@ async function runScholarPass(rows: NodeListOf<HTMLElement>): Promise<void> {
                         "augment",
                         `Augmenting ${count(requestsToAugment.length, "result")} without a DOI…`
                     );
+                    setWorkItems(titledInfos.map((r) => workItem(r.title, r.title, rowByline(r))));
                     augmented = await augmentDOIsViaWorker(requestsToAugment);
                 }
             } catch (err) {
                 debugWarn(`Scholar: augmentation failed for ${requestsToAugment.length} row(s) —`, err);
+            }
+            for (const info of titledInfos) {
+                const doi = augmented.get(info.title) ?? null;
+                updateWorkItem(info.title, doi ? "done" : "failed", doi ?? "no DOI found");
             }
 
             for (const info of pendingInfos) {
@@ -271,6 +303,11 @@ async function runScholarPass(rows: NodeListOf<HTMLElement>): Promise<void> {
     const uniqueDois = [...new Set(rowDois.map((rd) => rd.doi))];
     debugLog("Scholar: Sending lookup for", uniqueDois.length, "unique DOIs:", uniqueDois);
     reportWorkStage("lookup", `Found ${count(uniqueDois.length, "unique DOI")} — looking them up…`);
+    const titleByDoi = new Map<DoiString, string>();
+    for (const {row, doi} of rowDois) {
+        if (!titleByDoi.has(doi)) titleByDoi.set(doi, rowTitle(row));
+    }
+    setWorkItems(uniqueDois.map((doi) => workItem(doi, titleByDoi.get(doi) ?? doi, doi)));
     const request: LookupRequest = {type: "FLORA_LOOKUP", dois: uniqueDois};
 
     try {
@@ -285,12 +322,37 @@ async function runScholarPass(rows: NodeListOf<HTMLElement>): Promise<void> {
                 badgedCount++;
             }
         }
+        for (const doi of uniqueDois) {
+            if (response.errors[doi]) updateWorkItem(doi, "failed");
+            else updateWorkItem(doi, response.results[doi] ? "flagged" : "done");
+        }
+
+        // Paused while the lookup ran — the results stay in scholarState for a
+        // later pass, but nothing goes on the page.
+        if (scholarHidden) return;
+
         reportWorkStage("report", `Marking up ${count(badgedCount, "result")}…`);
         refreshScholarBadges();
         debugLog("Scholar: Rendered", badgedCount, "badge(s)");
     } catch (err) {
         debugLog("Scholar: Lookup failed:", err);
     }
+}
+
+function rowTitle(row: HTMLElement): string {
+    // The heading starts with Scholar's type tags ("[HTML]", "[PDF]") — not part of the title.
+    return row.querySelector(".gs_rt a, .gs_rt")?.textContent?.replace(/^(\s*\[[A-Z]+\])+\s*/, "").trim() ?? "";
+}
+
+/** First author and year of a row, for the item's right-hand detail column. */
+function rowByline(info: {firstAuthor: string | null; year: number | null}): string | undefined {
+    const parts = [info.firstAuthor, info.year?.toString()].filter(Boolean);
+    return parts.length > 0 ? parts.join(" ") : undefined;
+}
+
+/** One work-toast item, pending until its stage reports back on it. */
+function workItem(id: string, label: string, detail?: string): WorkItem {
+    return {id, label: label || id, detail, status: "pending"};
 }
 
 async function preInjectLabels(row: HTMLElement, doi: DoiString, color: string, isAugmented = false): Promise<void> {

--- a/src/content-scholar/observer.ts
+++ b/src/content-scholar/observer.ts
@@ -340,8 +340,12 @@ async function runScholarPass(rows: NodeListOf<HTMLElement>): Promise<void> {
 }
 
 function rowTitle(row: HTMLElement): string {
-    // The heading starts with Scholar's type tags ("[HTML]", "[PDF]") — not part of the title.
-    return row.querySelector(".gs_rt a, .gs_rt")?.textContent?.replace(/^(\s*\[[A-Z]+\])+\s*/, "").trim() ?? "";
+    return row.querySelector(".gs_rt")?.textContent?.trim() ?? "";
+}
+
+/** Scholar prefixes headings with type tags ("[HTML]", "[PDF]"); the toast shows the title alone. */
+function stripTypeTags(title: string): string {
+    return title.replace(/^(\s*\[[A-Z]+\])+\s*/, "");
 }
 
 /** First author and year of a row, for the item's right-hand detail column. */
@@ -352,7 +356,7 @@ function rowByline(info: {firstAuthor: string | null; year: number | null}): str
 
 /** One work-toast item, pending until its stage reports back on it. */
 function workItem(id: string, label: string, detail?: string): WorkItem {
-    return {id, label: label || id, detail, status: "pending"};
+    return {id, label: stripTypeTags(label) || id, detail, status: "pending"};
 }
 
 async function preInjectLabels(row: HTMLElement, doi: DoiString, color: string, isAugmented = false): Promise<void> {

--- a/src/content-scholar/observer.ts
+++ b/src/content-scholar/observer.ts
@@ -13,6 +13,7 @@ import {
     beginWorkIndicator,
     count,
     endWorkIndicator,
+    isWorkCancelled,
     reportWorkStage,
     setWorkItems,
     updateWorkItem,
@@ -174,6 +175,7 @@ async function runScholarPass(rows: NodeListOf<HTMLElement>): Promise<void> {
             for (const doi of doisToValidate) {
                 updateWorkItem(doi, validated.get(doi) ? "done" : "failed");
             }
+            if (isWorkCancelled()) return;
         }
 
         // Separate rows into validated (done) vs still-pending (need augmentation)
@@ -222,6 +224,7 @@ async function runScholarPass(rows: NodeListOf<HTMLElement>): Promise<void> {
                 const doi = augmented.get(info.title) ?? null;
                 updateWorkItem(info.title, doi ? "done" : "failed", doi ?? "no DOI found");
             }
+            if (isWorkCancelled()) return;
 
             for (const info of pendingInfos) {
                 const augmentedDoi = augmented.get(info.title) ?? null;
@@ -327,9 +330,9 @@ async function runScholarPass(rows: NodeListOf<HTMLElement>): Promise<void> {
             else updateWorkItem(doi, response.results[doi] ? "flagged" : "done");
         }
 
-        // Paused while the lookup ran — the results stay in scholarState for a
-        // later pass, but nothing goes on the page.
-        if (scholarHidden) return;
+        // Paused or cancelled while the lookup ran — the results stay in
+        // scholarState for a later pass, but nothing goes on the page.
+        if (scholarHidden || isWorkCancelled()) return;
 
         reportWorkStage("report", `Marking up ${count(badgedCount, "result")}…`);
         refreshScholarBadges();

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -88,6 +88,15 @@ body {
   white-space: nowrap;
 }
 
+.popup-snooze-note {
+  font-size: 12px;
+  color: var(--text-secondary);
+  padding: 6px 10px;
+  background: var(--surface);
+  border-radius: var(--radius);
+  text-align: center;
+}
+
 .popup-divider {
   height: 1px;
   background: var(--border-light);
@@ -126,6 +135,10 @@ a:focus-visible {
 }
 
 .popup-btn--block.is-blocked {
+  color: var(--success);
+}
+
+.popup-btn--resume {
   color: var(--success);
 }
 

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -261,3 +261,10 @@ a:focus-visible {
   color: var(--error);
   background: var(--error-bg);
 }
+
+/* Secondary toggle that belongs to the debug switch above it */
+.popup-toggle--sub {
+  padding-left: 32px;
+  font-weight: 500;
+  font-size: 12px;
+}

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -65,6 +65,14 @@
         the issue and the log comes with it.
       </p>
 
+      <label class="popup-toggle popup-toggle--sub" for="log-copy-toggle" id="log-copy-row" hidden>
+        <span class="popup-toggle-label">Offer "Copy log" after each pass</span>
+        <span class="toggle-switch">
+          <input type="checkbox" id="log-copy-toggle" />
+          <span class="toggle-track"></span>
+        </span>
+      </label>
+
       <button id="report-btn" class="popup-btn popup-btn--report" type="button">
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
           <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -17,6 +17,16 @@
     <div class="popup-body">
       <div class="popup-domain" id="current-domain"></div>
 
+      <div id="snooze-note" class="popup-snooze-note" hidden></div>
+
+      <button id="resume-btn" class="popup-btn popup-btn--resume" type="button" hidden>
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <circle cx="12" cy="12" r="10" />
+          <path d="M10 8l6 4-6 4z" />
+        </svg>
+        <span>Resume here</span>
+      </button>
+
       <button id="block-btn" class="popup-btn popup-btn--block" type="button">
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
           <circle cx="12" cy="12" r="10" />

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -1,10 +1,18 @@
-import { getBlockedDomains, saveBlockedDomains, isDomainBlocked } from "../shared/domains";
+import {
+  getBlockedDomains,
+  saveBlockedDomains,
+  isDomainBlocked,
+  getSnooze,
+  clearSnooze,
+} from "../shared/domains";
 import { debugError, debugWarn, isDebugEnabledAsync, setDebug } from "../shared/debug";
 import { buildDebugReport, issueUrl, stashIssueReport } from "../shared/debug-report";
 
 const domainEl = document.getElementById("current-domain")!;
 const blockBtn = document.getElementById("block-btn")!;
 const blockLabel = document.getElementById("block-btn-label")!;
+const snoozeNote = document.getElementById("snooze-note")!;
+const resumeBtn = document.getElementById("resume-btn")!;
 const hideBtn = document.getElementById("hide-btn")!;
 const hideLabel = document.getElementById("hide-btn-label")!;
 const tourBtn = document.getElementById("tour-btn")!;
@@ -17,6 +25,7 @@ const statusEl = document.getElementById("popup-status")!;
 
 let currentDomain = "";
 let blocked = false;
+let snoozedUntil: number | null = null;
 let hidden = false;
 let debugOn = false;
 let activeTabId: number | undefined;
@@ -39,6 +48,22 @@ function updateBlockUI(): void {
   } else {
     blockLabel.textContent = "Disable on this domain";
     blockBtn.classList.remove("is-blocked");
+  }
+}
+
+/** "14:35", or "tomorrow at 09:00" when the pause runs past midnight. */
+function formatUntil(until: number): string {
+  const end = new Date(until);
+  const time = end.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  return end.toDateString() === new Date().toDateString() ? time : `tomorrow at ${time}`;
+}
+
+function updateSnoozeUI(): void {
+  const paused = snoozedUntil !== null;
+  snoozeNote.hidden = !paused;
+  resumeBtn.hidden = !paused;
+  if (paused) {
+    snoozeNote.textContent = `Paused on ${currentDomain} until ${formatUntil(snoozedUntil!)}`;
   }
 }
 
@@ -91,6 +116,8 @@ async function init(): Promise<void> {
 
   blocked = await isDomainBlocked(currentDomain);
   updateBlockUI();
+  snoozedUntil = await getSnooze(currentDomain);
+  updateSnoozeUI();
   reportBtn.style.display = "";
 
   // Ask the content script whether UI is currently hidden
@@ -148,6 +175,16 @@ blockBtn.addEventListener("click", async () => {
   }
 
   updateBlockUI();
+});
+
+// End a temporary pause on the current domain
+resumeBtn.addEventListener("click", async () => {
+  if (!currentDomain) return;
+
+  await clearSnooze(currentDomain);
+  snoozedUntil = null;
+  updateSnoozeUI();
+  showStatus(`Resumed on ${currentDomain} — reload to apply`, "success");
 });
 
 // Toggle FLoRA UI visibility on the current page (session only)

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -7,6 +7,7 @@ import {
 } from "../shared/domains";
 import { debugError, debugWarn, isDebugEnabledAsync, setDebug } from "../shared/debug";
 import { buildDebugReport, issueUrl, stashIssueReport } from "../shared/debug-report";
+import { getSettings, saveSettings } from "../shared/settings";
 
 const domainEl = document.getElementById("current-domain")!;
 const blockBtn = document.getElementById("block-btn")!;
@@ -21,6 +22,8 @@ const reportBtn = document.getElementById("report-btn")!;
 const reportLabel = document.getElementById("report-btn-label")!;
 const debugToggle = document.getElementById("debug-toggle") as HTMLInputElement;
 const debugHint = document.getElementById("debug-hint")!;
+const logCopyRow = document.getElementById("log-copy-row")!;
+const logCopyToggle = document.getElementById("log-copy-toggle") as HTMLInputElement;
 const statusEl = document.getElementById("popup-status")!;
 
 let currentDomain = "";
@@ -85,10 +88,12 @@ function updateDebugUI(): void {
   reportLabel.textContent = debugOn
     ? "Report an issue with debug log"
     : "Report an issue on this domain";
+  logCopyRow.hidden = !debugOn;
 }
 
 async function init(): Promise<void> {
   debugOn = await isDebugEnabledAsync();
+  logCopyToggle.checked = (await getSettings()).offerLogCopyAfterPass;
   updateDebugUI();
 
   const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
@@ -213,6 +218,11 @@ debugToggle.addEventListener("change", () => {
     debugOn ? "Debug mode on — reload the page to record it" : "Debug mode off",
     "success"
   );
+});
+
+// Keep a one-line "Copy log" toast up after each pass (debug mode only)
+logCopyToggle.addEventListener("change", () => {
+  void saveSettings({ offerLogCopyAfterPass: logCopyToggle.checked });
 });
 
 // Report an issue on the current domain. With debug mode on the report is

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -63,7 +63,7 @@ function updateSnoozeUI(): void {
   snoozeNote.hidden = !paused;
   resumeBtn.hidden = !paused;
   if (paused) {
-    snoozeNote.textContent = `Paused on ${currentDomain} until ${formatUntil(snoozedUntil!)}`;
+    snoozeNote.textContent = `Paused until ${formatUntil(snoozedUntil!)}`;
   }
 }
 

--- a/src/shared/domains.ts
+++ b/src/shared/domains.ts
@@ -7,8 +7,10 @@
  */
 
 const BLACKLIST_KEY = "flora_blocked_domains";
+const SNOOZE_KEY = "flora_snoozed_domains";
 import { debugError } from "./debug";
 let cachedBlockedDomains: string[] | null = null;
+let cachedSnoozes: Record<string, number> | null = null;
 let domainListenerInstalled = false;
 
 function installDomainInvalidation(): void {
@@ -18,6 +20,9 @@ function installDomainInvalidation(): void {
     chrome.storage.onChanged?.addListener((changes, area) => {
       if (area === "sync" && changes[BLACKLIST_KEY]) {
         cachedBlockedDomains = (changes[BLACKLIST_KEY].newValue as string[] | undefined) ?? [];
+      }
+      if (area === "local" && changes[SNOOZE_KEY]) {
+        cachedSnoozes = (changes[SNOOZE_KEY].newValue as Record<string, number> | undefined) ?? {};
       }
     });
   } catch {
@@ -59,7 +64,96 @@ export async function isDomainBlocked(hostname: string): Promise<boolean> {
   const host = hostname.toLowerCase();
 
   for (const domain of blocked) {
-    if (host === domain || host.endsWith(`.${domain}`)) return true;
+    if (matchesDomain(host, domain)) return true;
   }
   return false;
+}
+
+/** Add a hostname to the blocked-domain list. */
+export async function blockDomain(hostname: string): Promise<void> {
+  const domains = await getBlockedDomains();
+  if (domains.includes(hostname)) return;
+  await saveBlockedDomains([...domains, hostname]);
+}
+
+/** `host` equals `domain` or is a subdomain of it. Both lower-case. */
+function matchesDomain(host: string, domain: string): boolean {
+  return host === domain || host.endsWith(`.${domain}`);
+}
+
+/**
+ * Temporary per-site pause.
+ *
+ * Snoozes live in chrome.storage.local as hostname → expiry epoch (ms).  They
+ * are deliberately device-local: a pause is about the session in front of the
+ * user, not a preference worth syncing.
+ */
+async function getSnoozes(): Promise<Record<string, number>> {
+  installDomainInvalidation();
+  if (cachedSnoozes) return cachedSnoozes;
+  try {
+    const raw = await chrome.storage.local.get(SNOOZE_KEY);
+    cachedSnoozes = (raw[SNOOZE_KEY] as Record<string, number> | undefined) ?? {};
+  } catch (err) {
+    debugError("Snoozed domains: read failed — no site will be treated as paused:", err);
+    cachedSnoozes = {};
+  }
+  return cachedSnoozes;
+}
+
+async function saveSnoozes(snoozes: Record<string, number>): Promise<void> {
+  cachedSnoozes = snoozes;
+  await chrome.storage.local.set({ [SNOOZE_KEY]: snoozes });
+}
+
+/** Pause FLoRA on `hostname` for `durationMs`. Returns the expiry epoch (ms). */
+export async function snoozeDomain(hostname: string, durationMs: number): Promise<number> {
+  const until = Date.now() + durationMs;
+  const snoozes = await getSnoozes();
+  await saveSnoozes({ ...snoozes, [hostname.toLowerCase()]: until });
+  return until;
+}
+
+/**
+ * End the pause on `hostname`, dropping every entry that covers it (the host
+ * itself and any snoozed parent domain) so a resume actually resumes.
+ */
+export async function clearSnooze(hostname: string): Promise<void> {
+  const snoozes = await getSnoozes();
+  const host = hostname.toLowerCase();
+  const kept = Object.entries(snoozes).filter(([domain]) => !matchesDomain(host, domain));
+  if (kept.length === Object.keys(snoozes).length) return;
+  await saveSnoozes(Object.fromEntries(kept));
+}
+
+/**
+ * Expiry epoch of the pause covering `hostname` — exact host or a snoozed
+ * parent domain, whichever runs longest — or `null` when nothing covers it.
+ * Expired entries are dropped from storage on the way past.
+ */
+export async function getSnooze(hostname: string): Promise<number | null> {
+  const snoozes = await getSnoozes();
+  const host = hostname.toLowerCase();
+  const now = Date.now();
+
+  let until: number | null = null;
+  let expired = false;
+  for (const [domain, expiry] of Object.entries(snoozes)) {
+    if (expiry <= now) {
+      expired = true;
+      continue;
+    }
+    if (matchesDomain(host, domain) && (until === null || expiry > until)) until = expiry;
+  }
+
+  if (expired) {
+    const live = Object.fromEntries(Object.entries(snoozes).filter(([, e]) => e > now));
+    await saveSnoozes(live);
+  }
+  return until;
+}
+
+/** Whether FLoRA is paused on `hostname`. */
+export async function isDomainSnoozed(hostname: string): Promise<boolean> {
+  return (await getSnooze(hostname)) !== null;
 }

--- a/src/shared/progress-toast.ts
+++ b/src/shared/progress-toast.ts
@@ -110,11 +110,13 @@ const PANEL_STYLE =
 const CHEVRON_SVG =
     `<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" ` +
     `style="width:12px;height:12px;display:block;transition:transform 0.18s ease;">` +
-    `<path d="M3 10l5-5 5 5"/></svg>`;
+    `<path d="M3 6l5 5 5-5"/></svg>`;
 
+// Same clock as the Sheets modal's snooze button.
 const PAUSE_SVG =
-    `<svg viewBox="0 0 16 16" fill="currentColor" style="width:12px;height:12px;display:block;">` +
-    `<rect x="3" y="2" width="3.5" height="12" rx="1"/><rect x="9.5" y="2" width="3.5" height="12" rx="1"/></svg>`;
+    `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" ` +
+    `stroke-linejoin="round" style="width:13px;height:13px;display:block;">` +
+    `<circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>`;
 
 const CLOSE_SVG =
     `<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" ` +
@@ -260,12 +262,12 @@ function buildPauseRow(): HTMLElement {
     const row = document.createElement("div");
     row.setAttribute("data-flora-work-pause-row", "");
     row.setAttribute("role", "group");
-    row.setAttribute("aria-label", "Pause ORE on this site");
+    row.setAttribute("aria-label", "Snooze ORE on this site");
     row.style.cssText = PAUSE_ROW_STYLE;
 
     const caption = document.createElement("span");
     caption.style.cssText = "color:rgba(255,255,255,0.75);font-size:11px;margin-right:2px;";
-    caption.textContent = "Pause ORE here:";
+    caption.textContent = "Snooze ORE here:";
 
     const hour = textButton("1 hour");
     hour.addEventListener("click", () => {
@@ -391,7 +393,7 @@ function ensureToast(): HTMLElement {
     label.textContent = labelText;
 
     const pauseRow = buildPauseRow();
-    const pause = iconButton("Pause ORE on this site", PAUSE_SVG);
+    const pause = iconButton("Snooze ORE on this site", PAUSE_SVG);
     pause.setAttribute("data-flora-work-pause", "");
     pause.setAttribute("aria-expanded", "false");
     pause.addEventListener("click", () => {

--- a/src/shared/progress-toast.ts
+++ b/src/shared/progress-toast.ts
@@ -231,6 +231,7 @@ function textButton(text: string): HTMLButtonElement {
 function menuItem(text: string): HTMLButtonElement {
     const button = document.createElement("button");
     button.type = "button";
+    button.setAttribute("role", "menuitem");
     button.textContent = text;
     button.style.cssText = MENU_ITEM_STYLE;
     return button;
@@ -244,11 +245,20 @@ function msUntilTomorrow6am(): number {
     return Math.max(60_000, target.getTime() - Date.now());
 }
 
-function pauseSite(detail: {hostname: string; until?: number; blocked?: boolean}): void {
-    document.dispatchEvent(new CustomEvent("flora-pause-site", {detail}));
+/** Persist the pause first, so a Resume in the popup cannot read storage ahead of it. */
+async function pauseSite(
+    write: Promise<unknown>,
+    detail: {hostname: string; until?: number; blocked?: boolean},
+): Promise<void> {
     clearTimers();
     removeToast();
     dismissed = true;
+    try {
+        await write;
+    } catch (err) {
+        debugLog("Work: pause could not be saved —", err);
+    }
+    document.dispatchEvent(new CustomEvent("flora-pause-site", {detail}));
 }
 
 function buildPauseMenu(): HTMLElement {
@@ -258,6 +268,7 @@ function buildPauseMenu(): HTMLElement {
 
     const menu = document.createElement("div");
     menu.setAttribute("data-flora-work-pause-menu", "");
+    menu.setAttribute("role", "menu");
     menu.style.cssText = MENU_STYLE;
 
     const trigger = textButton("Pause on this site ▾");
@@ -272,23 +283,21 @@ function buildPauseMenu(): HTMLElement {
     const hour = menuItem("Pause here for 1 hour");
     hour.addEventListener("click", () => {
         const hostname = location.hostname;
-        void snoozeDomain(hostname, 60 * 60 * 1000);
-        pauseSite({hostname, until: Date.now() + 60 * 60 * 1000});
+        const until = Date.now() + 60 * 60 * 1000;
+        void pauseSite(snoozeDomain(hostname, 60 * 60 * 1000), {hostname, until});
     });
 
     const tomorrow = menuItem("Pause here until tomorrow");
     tomorrow.addEventListener("click", () => {
         const hostname = location.hostname;
         const duration = msUntilTomorrow6am();
-        void snoozeDomain(hostname, duration);
-        pauseSite({hostname, until: Date.now() + duration});
+        void pauseSite(snoozeDomain(hostname, duration), {hostname, until: Date.now() + duration});
     });
 
     const block = menuItem("Block this site (undo in options)");
     block.addEventListener("click", () => {
         const hostname = location.hostname;
-        void blockDomain(hostname);
-        pauseSite({hostname, blocked: true});
+        void pauseSite(blockDomain(hostname), {hostname, blocked: true});
     });
 
     menu.append(hour, tomorrow, block);
@@ -406,6 +415,7 @@ function ensureToast(): HTMLElement {
     const track = document.createElement("div");
     track.setAttribute("data-flora-work-track", "");
     track.setAttribute("role", "progressbar");
+    track.setAttribute("aria-label", "ORE progress on this page");
     track.setAttribute("aria-valuemin", "0");
     track.setAttribute("aria-valuemax", "100");
     track.style.cssText = TRACK_STYLE;
@@ -676,8 +686,9 @@ export function reportWorkStage(stage: WorkStage, detail: string): void {
 
     record.detail = detail;
     record.skipped = false;
+    // A stage that ran already (a nested pass re-entering it) is timed afresh.
+    if (record.startedAt === undefined || record.endedAt !== undefined) record.startedAt = now();
     record.endedAt = undefined;
-    if (record.startedAt === undefined) record.startedAt = now();
     currentStage = stage;
     items = [];
     debugLog(`Work: ${stage} started — ${detail}`);
@@ -690,23 +701,22 @@ export function setWorkItems(itemList: WorkItem[]): void {
     render();
 }
 
-/** Update one item's status (and optionally its detail); unknown id is a no-op. */
+/** Update every item carrying `id` (two rows can share a DOI); unknown id is a no-op. */
 export function updateWorkItem(id: string, status: WorkItemStatus, detail?: string): void {
-    const item = items.find((entry) => entry.id === id);
-    if (!item) return;
-    item.status = status;
-    if (detail !== undefined) item.detail = detail;
-    render();
-}
-
-/** True once the user dismissed this pass's toast. Cleared when the pass ends. */
-export function isWorkDismissed(): boolean {
-    return dismissed;
+    let touched = false;
+    for (const item of items) {
+        if (item.id !== id) continue;
+        item.status = status;
+        if (detail !== undefined) item.detail = detail;
+        touched = true;
+    }
+    if (touched) render();
 }
 
 /** Hide the toast once all outstanding work has finished. */
 export function endWorkIndicator(): void {
-    refCount = Math.max(0, refCount - 1);
+    if (refCount === 0) return; // unmatched end — nothing to close
+    refCount--;
     if (refCount > 0) return;
 
     const ending = currentStage ? stages.find((entry) => entry.stage === currentStage) : undefined;

--- a/src/shared/progress-toast.ts
+++ b/src/shared/progress-toast.ts
@@ -1,9 +1,33 @@
 // Progress toast — the bottom-right indicator shown while ORE works a page.
 // Stage-weighted, not item-counted: each stage is one batched worker call.
+//
+// Collapsed it is a spinner, a label and a bar. The chevron opens a panel with
+// the stage checklist, the items of the running stage, and the controls that
+// let a user silence ORE on this site. The panel is self-contained: inline
+// styles only, so no page stylesheet can reach it.
+
+import {debugLog, flushDebugLog, isDebugEnabled} from "@shared/debug";
+import {buildDebugReport} from "@shared/debug-report";
+import {writeClipboard} from "@shared/clipboard";
+import {blockDomain, snoozeDomain} from "@shared/domains";
 
 export const WORK_TOAST_ID = "flora-working-toast";
 
 export type WorkStage = "scan" | "validate" | "augment" | "notices" | "lookup" | "report";
+
+/** Ordered stages a pass is expected to run. */
+export interface WorkPlan {
+    stages: WorkStage[];
+}
+
+export type WorkItemStatus = "pending" | "done" | "flagged" | "skipped" | "failed";
+
+export interface WorkItem {
+    id: string;
+    label: string;
+    detail?: string;
+    status: WorkItemStatus;
+}
 
 export function count(n: number, noun: string): string {
     return `${n} ${noun}${n === 1 ? "" : "s"}`;
@@ -19,7 +43,20 @@ const STAGE_PROGRESS: Record<WorkStage, number> = {
     report: 0.9,
 };
 
+const STAGE_ORDER = Object.keys(STAGE_PROGRESS) as WorkStage[];
+
+/** Shown for a stage that has not reported a detail of its own yet. */
+const STAGE_LABEL: Record<WorkStage, string> = {
+    scan: "Read the page",
+    validate: "Check DOIs resolve",
+    augment: "Find DOIs for references without one",
+    notices: "Check for retractions",
+    lookup: "Look up in FORRT / Retraction Watch / PubPeer",
+    report: "Mark up results",
+};
+
 const DEFAULT_LABEL = "ORE is looking up the papers on this page…";
+const FINISHED_LABEL = "Pass finished — log ready";
 
 const HOST_STYLE =
     "position:fixed;bottom:18px;right:18px;z-index:2147483647;" +
@@ -36,6 +73,11 @@ const SPINNER_STYLE =
     "border:2px solid rgba(255,255,255,0.35);border-top-color:#fff;" +
     "animation:flora-work-spin 0.7s linear infinite;";
 
+const SMALL_SPINNER_STYLE =
+    "display:inline-block;width:9px;height:9px;border-radius:50%;box-sizing:border-box;" +
+    "border:1.5px solid rgba(255,255,255,0.35);border-top-color:#fff;" +
+    "animation:flora-work-spin 0.7s linear infinite;";
+
 const TRACK_STYLE =
     "position:relative;overflow:hidden;height:3px;border-radius:2px;" +
     "background:rgba(255,255,255,0.25);";
@@ -44,12 +86,57 @@ const FILL_STYLE =
     "height:100%;width:0;border-radius:2px;background:#fff;" +
     "transition:width 0.25s ease;";
 
+const ICON_BUTTON_STYLE =
+    "width:20px;height:20px;border:0;border-radius:5px;background:transparent;" +
+    "color:rgba(255,255,255,0.85);cursor:pointer;display:inline-flex;" +
+    "align-items:center;justify-content:center;padding:0;flex-shrink:0;pointer-events:auto;";
+
+const TEXT_BUTTON_STYLE =
+    "border:1px solid rgba(255,255,255,0.45);background:transparent;color:#fff;" +
+    "font:inherit;font-size:11px;padding:3px 9px;border-radius:5px;cursor:pointer;" +
+    "pointer-events:auto;white-space:nowrap;";
+
+const MENU_STYLE =
+    "display:none;flex-direction:column;gap:2px;margin-top:5px;padding:4px;" +
+    "border-radius:6px;background:rgba(0,0,0,0.28);pointer-events:auto;";
+
+const MENU_ITEM_STYLE =
+    "border:0;background:transparent;color:#fff;font:inherit;font-size:11px;" +
+    "text-align:left;padding:4px 7px;border-radius:4px;cursor:pointer;pointer-events:auto;";
+
+const PANEL_STYLE =
+    "display:none;flex-direction:column;gap:6px;padding-top:4px;margin-top:2px;" +
+    "border-top:1px solid rgba(255,255,255,0.22);" +
+    "max-height:min(60vh,420px);overflow-y:auto;pointer-events:auto;";
+
+const CHEVRON_SVG =
+    `<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" ` +
+    `style="width:12px;height:12px;display:block;transition:transform 0.18s ease;">` +
+    `<path d="M3 10l5-5 5 5"/></svg>`;
+
+const CLOSE_SVG =
+    `<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" ` +
+    `style="width:12px;height:12px;display:block;"><path d="M4 4l8 8M12 4l-8 8"/></svg>`;
+
 const KEYFRAMES =
     "@keyframes flora-work-spin{to{transform:rotate(360deg)}}" +
     "@keyframes flora-work-slide{0%{transform:translateX(-110%)}100%{transform:translateX(260%)}}";
 
 // The DOM listener runs a pass per mutation; a cached one is over in millis.
 const SHOW_DELAY_MS = 250;
+// Batch flush (800 ms) plus the store's persist debounce, so the report the
+// copy renders includes the lines the pass wrote as it finished.
+const COPY_LOG_WAIT_MS = 1500;
+const BUTTON_FLASH_MS = 1500;
+const MAX_ITEM_ROWS = 6;
+
+interface StageRecord {
+    stage: WorkStage;
+    detail?: string;
+    startedAt?: number;
+    endedAt?: number;
+    skipped?: boolean;
+}
 
 let refCount = 0;
 let showTimer: ReturnType<typeof setTimeout> | null = null;
@@ -59,12 +146,218 @@ let removeTimer: ReturnType<typeof setTimeout> | null = null;
 let progress = 0;
 let labelText = DEFAULT_LABEL;
 let suppressed = false;
+let dismissed = false;
+let expanded = false;
+let copyWhenFinished = false;
+let finished = false;
+let stages: StageRecord[] = [];
+let currentStage: WorkStage | null = null;
+let items: WorkItem[] = [];
+let passStartedAt = 0;
 
 function clearTimers(): void {
     for (const timer of [showTimer, hideTimer, removeTimer]) {
         if (timer) clearTimeout(timer);
     }
     showTimer = hideTimer = removeTimer = null;
+}
+
+function now(): number {
+    return typeof performance !== "undefined" ? performance.now() : Date.now();
+}
+
+function planStages(plan?: WorkPlan): void {
+    const wanted = plan?.stages?.length ? plan.stages : STAGE_ORDER;
+    stages = wanted.map((stage) => ({stage}));
+}
+
+/** A nested pass adds the stages it plans that the outer one did not, in canonical order. */
+function mergePlan(plan: WorkPlan): void {
+    const present = new Set(stages.map((entry) => entry.stage));
+    const missing = plan.stages.filter((stage) => !present.has(stage));
+    if (!missing.length) return;
+    const merged = new Set([...stages.map((entry) => entry.stage), ...missing]);
+    const ordered = STAGE_ORDER.filter((stage) => merged.has(stage));
+    stages = ordered.map((stage) => stages.find((entry) => entry.stage === stage) ?? {stage});
+}
+
+function stageRecord(stage: WorkStage): StageRecord {
+    let record = stages.find((entry) => entry.stage === stage);
+    if (!record) {
+        record = {stage};
+        stages.push(record);
+    }
+    return record;
+}
+
+function formatDuration(ms: number): string {
+    return ms >= 1000 ? `${(ms / 1000).toFixed(1)} s` : `${Math.round(ms)} ms`;
+}
+
+function removeToast(): void {
+    const host = document.getElementById(WORK_TOAST_ID);
+    if (!host) return;
+    document.removeEventListener("keydown", onKeydown, true);
+    host.remove();
+}
+
+function onKeydown(event: KeyboardEvent): void {
+    if (event.key !== "Escape" || !expanded) return;
+    expanded = false;
+    const host = document.getElementById(WORK_TOAST_ID);
+    if (host) applyExpanded(host);
+}
+
+// ── DOM ─────────────────────────────────────────────────────────────────────
+
+function iconButton(title: string, svg: string): HTMLButtonElement {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.title = title;
+    button.setAttribute("aria-label", title);
+    button.style.cssText = ICON_BUTTON_STYLE;
+    button.innerHTML = svg;
+    return button;
+}
+
+function textButton(text: string): HTMLButtonElement {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.textContent = text;
+    button.style.cssText = TEXT_BUTTON_STYLE;
+    return button;
+}
+
+function menuItem(text: string): HTMLButtonElement {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.textContent = text;
+    button.style.cssText = MENU_ITEM_STYLE;
+    return button;
+}
+
+/** 6 am the next calendar day, in the user's own timezone. */
+function msUntilTomorrow6am(): number {
+    const target = new Date();
+    target.setDate(target.getDate() + 1);
+    target.setHours(6, 0, 0, 0);
+    return Math.max(60_000, target.getTime() - Date.now());
+}
+
+function pauseSite(detail: {hostname: string; until?: number; blocked?: boolean}): void {
+    document.dispatchEvent(new CustomEvent("flora-pause-site", {detail}));
+    clearTimers();
+    removeToast();
+    dismissed = true;
+}
+
+function buildPauseMenu(): HTMLElement {
+    const wrap = document.createElement("div");
+    wrap.setAttribute("data-flora-work-pause", "");
+    wrap.style.cssText = "position:relative;pointer-events:auto;";
+
+    const menu = document.createElement("div");
+    menu.setAttribute("data-flora-work-pause-menu", "");
+    menu.style.cssText = MENU_STYLE;
+
+    const trigger = textButton("Pause on this site ▾");
+    trigger.setAttribute("aria-haspopup", "menu");
+    trigger.setAttribute("aria-expanded", "false");
+    trigger.addEventListener("click", () => {
+        const open = menu.style.display === "flex";
+        menu.style.display = open ? "none" : "flex";
+        trigger.setAttribute("aria-expanded", String(!open));
+    });
+
+    const hour = menuItem("Pause here for 1 hour");
+    hour.addEventListener("click", () => {
+        const hostname = location.hostname;
+        void snoozeDomain(hostname, 60 * 60 * 1000);
+        pauseSite({hostname, until: Date.now() + 60 * 60 * 1000});
+    });
+
+    const tomorrow = menuItem("Pause here until tomorrow");
+    tomorrow.addEventListener("click", () => {
+        const hostname = location.hostname;
+        const duration = msUntilTomorrow6am();
+        void snoozeDomain(hostname, duration);
+        pauseSite({hostname, until: Date.now() + duration});
+    });
+
+    const block = menuItem("Block this site (undo in options)");
+    block.addEventListener("click", () => {
+        const hostname = location.hostname;
+        void blockDomain(hostname);
+        pauseSite({hostname, blocked: true});
+    });
+
+    menu.append(hour, tomorrow, block);
+    wrap.append(trigger, menu);
+    return wrap;
+}
+
+/** Flash the outcome on the button that started the copy. */
+function flashButton(button: HTMLButtonElement, text: string): void {
+    const original = button.textContent ?? "";
+    button.textContent = text;
+    setTimeout(() => {
+        if (button.isConnected) button.textContent = original;
+    }, BUTTON_FLASH_MS);
+}
+
+async function copyLog(button: HTMLButtonElement): Promise<boolean> {
+    flushDebugLog();
+    await new Promise((resolve) => setTimeout(resolve, COPY_LOG_WAIT_MS));
+    let ok = false;
+    try {
+        const report = await buildDebugReport({pageUrl: location.href});
+        ok = await writeClipboard(report.text);
+    } catch {
+        ok = false;
+    }
+    flashButton(button, ok ? "Copied ✓" : "Copy failed");
+    return ok;
+}
+
+function buildFooter(): HTMLElement {
+    const footer = document.createElement("div");
+    footer.setAttribute("data-flora-work-footer", "");
+    footer.style.cssText =
+        "display:flex;flex-wrap:wrap;gap:6px;justify-content:flex-end;" +
+        "align-items:flex-start;padding-top:6px;";
+    footer.append(buildPauseMenu());
+
+    if (isDebugEnabled()) {
+        const copy = textButton("Copy log");
+        copy.setAttribute("data-flora-work-copy", "");
+        copy.addEventListener("click", () => void copyLog(copy));
+
+        const arm = textButton("Copy log when finished");
+        arm.setAttribute("data-flora-work-arm", "");
+        arm.addEventListener("click", () => {
+            copyWhenFinished = !copyWhenFinished;
+            arm.textContent = copyWhenFinished ? "Will copy when finished ✓" : "Copy log when finished";
+        });
+
+        footer.append(copy, arm);
+    }
+    return footer;
+}
+
+/** The row that stands in for the footer once an armed pass has finished. */
+function buildFinishRow(): HTMLElement {
+    const row = document.createElement("div");
+    row.setAttribute("data-flora-work-finish", "");
+    row.style.cssText = "display:none;justify-content:flex-end;gap:6px;";
+    const copy = textButton("Copy log");
+    copy.setAttribute("data-flora-work-final-copy", "");
+    copy.addEventListener("click", () => {
+        void copyLog(copy).then(() => {
+            hideTimer = setTimeout(fadeOut, BUTTON_FLASH_MS);
+        });
+    });
+    row.append(copy);
+    return row;
 }
 
 function ensureToast(): HTMLElement {
@@ -85,11 +378,30 @@ function ensureToast(): HTMLElement {
     const row = document.createElement("div");
     row.style.cssText = "display:flex;align-items:center;gap:8px;line-height:1.4;";
     const spinner = document.createElement("span");
+    spinner.setAttribute("data-flora-work-spinner", "");
     spinner.style.cssText = SPINNER_STYLE;
     const label = document.createElement("span");
     label.setAttribute("data-flora-work-label", "");
-    label.textContent = DEFAULT_LABEL;
-    row.append(spinner, label);
+    label.style.cssText = "flex:1;";
+    label.textContent = labelText;
+
+    const chevron = iconButton("Show details", CHEVRON_SVG);
+    chevron.setAttribute("data-flora-work-chevron", "");
+    chevron.setAttribute("aria-expanded", "false");
+    chevron.addEventListener("click", () => {
+        expanded = !expanded;
+        applyExpanded(host);
+    });
+
+    const close = iconButton("Dismiss", CLOSE_SVG);
+    close.setAttribute("data-flora-work-close", "");
+    close.addEventListener("click", () => {
+        dismissed = true;
+        clearTimers();
+        removeToast();
+    });
+
+    row.append(spinner, label, chevron, close);
 
     const track = document.createElement("div");
     track.setAttribute("data-flora-work-track", "");
@@ -102,9 +414,151 @@ function ensureToast(): HTMLElement {
     fill.style.cssText = FILL_STYLE;
     track.appendChild(fill);
 
-    host.append(style, row, track);
+    const panel = document.createElement("div");
+    panel.setAttribute("data-flora-work-panel", "");
+    panel.style.cssText = PANEL_STYLE;
+    const list = document.createElement("ul");
+    list.setAttribute("data-flora-work-stages", "");
+    list.style.cssText =
+        "list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:4px;font-weight:400;";
+    panel.append(list, buildFooter());
+
+    host.append(style, row, track, panel, buildFinishRow());
     document.body.appendChild(host);
+    document.addEventListener("keydown", onKeydown, true);
     return host;
+}
+
+function applyExpanded(host: HTMLElement): void {
+    const panel = host.querySelector<HTMLElement>("[data-flora-work-panel]");
+    const chevron = host.querySelector<HTMLElement>("[data-flora-work-chevron]");
+    const arrow = chevron?.querySelector<SVGElement>("svg");
+    if (panel) panel.style.display = expanded ? "flex" : "none";
+    if (chevron) {
+        chevron.setAttribute("aria-expanded", String(expanded));
+        chevron.title = expanded ? "Hide details" : "Show details";
+    }
+    if (arrow) arrow.style.transform = expanded ? "rotate(180deg)" : "rotate(0deg)";
+    host.style.maxWidth = expanded && items.length ? "360px" : "320px";
+    if (expanded) renderStages(host);
+}
+
+function itemGlyph(status: WorkItemStatus): HTMLElement {
+    const glyph = document.createElement("span");
+    glyph.style.cssText = "width:14px;flex-shrink:0;text-align:center;font-size:10px;";
+    if (status === "pending") {
+        const spinner = document.createElement("span");
+        spinner.style.cssText = SMALL_SPINNER_STYLE;
+        glyph.appendChild(spinner);
+        return glyph;
+    }
+    if (status === "done") {
+        glyph.textContent = "✓";
+        glyph.style.color = "#b8f0c8";
+    } else if (status === "flagged") {
+        glyph.textContent = "!";
+        glyph.style.color = "#ffd58a";
+    } else if (status === "failed") {
+        glyph.textContent = "✕";
+        glyph.style.color = "#ffd58a";
+    } else {
+        glyph.textContent = "–";
+        glyph.style.color = "rgba(255,255,255,0.55)";
+    }
+    return glyph;
+}
+
+function renderItems(): HTMLElement {
+    const list = document.createElement("ul");
+    list.setAttribute("data-flora-work-items", "");
+    list.style.cssText =
+        "list-style:none;margin:2px 0 0;padding:0 0 0 20px;font-weight:400;font-size:11px;";
+
+    for (const item of items.slice(0, MAX_ITEM_ROWS)) {
+        const row = document.createElement("li");
+        row.setAttribute("data-flora-work-item", item.id);
+        row.style.cssText = "display:flex;gap:7px;align-items:center;padding:2px 0;line-height:1.3;";
+        const title = document.createElement("span");
+        title.style.cssText = "flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;";
+        title.textContent = item.label;
+        if (item.status === "skipped") title.style.color = "rgba(255,255,255,0.55)";
+        row.append(itemGlyph(item.status), title);
+        if (item.detail) {
+            const detail = document.createElement("span");
+            detail.style.cssText =
+                "color:rgba(255,255,255,0.6);font-family:ui-monospace,Menlo,monospace;" +
+                "font-size:10px;max-width:130px;overflow:hidden;text-overflow:ellipsis;" +
+                "white-space:nowrap;flex-shrink:0;";
+            detail.textContent = item.detail;
+            row.append(detail);
+        }
+        list.append(row);
+    }
+
+    if (items.length > MAX_ITEM_ROWS) {
+        const more = document.createElement("li");
+        more.setAttribute("data-flora-work-more", "");
+        more.style.cssText = "padding:2px 0 2px 21px;color:rgba(255,255,255,0.55);";
+        more.textContent = `${items.length - MAX_ITEM_ROWS} more…`;
+        list.append(more);
+    }
+    return list;
+}
+
+function renderStages(host: HTMLElement): void {
+    const list = host.querySelector<HTMLElement>("[data-flora-work-stages]");
+    if (!list) return;
+    list.textContent = "";
+
+    for (const record of stages) {
+        const row = document.createElement("li");
+        row.setAttribute("data-flora-work-stage", record.stage);
+        row.style.cssText = "display:flex;gap:8px;align-items:flex-start;line-height:1.35;";
+
+        const icon = document.createElement("span");
+        icon.style.cssText =
+            "width:12px;height:12px;flex-shrink:0;margin-top:2px;display:inline-flex;" +
+            "align-items:center;justify-content:center;font-size:10px;";
+        const text = document.createElement("span");
+        text.style.cssText = "flex:1;";
+
+        const isCurrent = record.stage === currentStage;
+        if (isCurrent) {
+            row.dataset.floraWorkState = "current";
+            const spinner = document.createElement("span");
+            spinner.style.cssText = SMALL_SPINNER_STYLE;
+            icon.append(spinner);
+            row.style.fontWeight = "600";
+            text.textContent = record.detail ?? STAGE_LABEL[record.stage];
+        } else if (record.endedAt !== undefined) {
+            row.dataset.floraWorkState = "done";
+            icon.textContent = "✓";
+            row.style.color = "rgba(255,255,255,0.75)";
+            text.textContent = record.detail ?? STAGE_LABEL[record.stage];
+        } else if (record.skipped) {
+            row.dataset.floraWorkState = "skipped";
+            icon.textContent = "–";
+            row.style.color = "rgba(255,255,255,0.5)";
+            text.textContent = STAGE_LABEL[record.stage];
+        } else {
+            row.dataset.floraWorkState = "pending";
+            icon.textContent = "○";
+            row.style.color = "rgba(255,255,255,0.5)";
+            text.textContent = STAGE_LABEL[record.stage];
+        }
+
+        row.append(icon, text);
+        if (record.endedAt !== undefined && record.startedAt !== undefined) {
+            const duration = document.createElement("span");
+            duration.setAttribute("data-flora-work-duration", "");
+            duration.style.cssText = "flex-shrink:0;color:rgba(255,255,255,0.6);font-size:11px;";
+            duration.textContent = formatDuration(record.endedAt - record.startedAt);
+            row.append(duration);
+        }
+        list.append(row);
+
+        if (isCurrent && items.length) list.append(renderItems());
+    }
 }
 
 function paint(host: HTMLElement): void {
@@ -126,11 +580,13 @@ function paint(host: HTMLElement): void {
 }
 
 function renderNow(): void {
-    if (suppressed || refCount === 0) return;
+    if (suppressed || dismissed) return;
+    if (refCount === 0 && !finished) return;
     const host = ensureToast();
     const label = host.querySelector<HTMLElement>("[data-flora-work-label]");
     if (label) label.textContent = labelText;
     paint(host);
+    applyExpanded(host);
     requestAnimationFrame(() => {
         host.style.opacity = "1";
         host.style.transform = "translateY(0)";
@@ -139,7 +595,8 @@ function renderNow(): void {
 
 /** Update now if the toast is already up, else once the pass proves slow. */
 function render(): void {
-    if (suppressed || refCount === 0) return;
+    if (suppressed || dismissed) return;
+    if (refCount === 0 && !finished) return;
     if (document.getElementById(WORK_TOAST_ID)) {
         renderNow();
         return;
@@ -151,13 +608,35 @@ function render(): void {
     }, SHOW_DELAY_MS);
 }
 
+function fadeOut(): void {
+    const host = document.getElementById(WORK_TOAST_ID);
+    if (!host) return;
+    host.style.opacity = "0";
+    host.style.transform = "translateY(6px)";
+    removeTimer = setTimeout(removeToast, 200);
+}
+
+// ── API ─────────────────────────────────────────────────────────────────────
+
 /** Show the progress toast (ref-counted — nested calls keep it visible). */
-export function beginWorkIndicator(): void {
+export function beginWorkIndicator(plan?: WorkPlan): void {
     refCount++;
     // Also covers a pass starting while the last one's toast is still fading.
     if (refCount === 1) {
+        // The finished-pass toast holds a copy button, so it is rebuilt whole.
+        if (finished) removeToast();
         progress = 0;
         labelText = DEFAULT_LABEL;
+        dismissed = false;
+        expanded = false;
+        finished = false;
+        copyWhenFinished = false;
+        currentStage = null;
+        items = [];
+        passStartedAt = now();
+        planStages(plan);
+    } else if (plan) {
+        mergePlan(plan);
     }
     if (hideTimer) {
         clearTimeout(hideTimer);
@@ -175,31 +654,103 @@ export function reportWorkStage(stage: WorkStage, detail: string): void {
     if (refCount === 0) return; // no pass in flight — a late straggler
     progress = Math.max(progress, STAGE_PROGRESS[stage]);
     labelText = detail;
+
+    const record = stageRecord(stage);
+    if (currentStage === stage) {
+        record.detail = detail;
+        render();
+        return;
+    }
+
+    const previous = currentStage ? stages.find((entry) => entry.stage === currentStage) : undefined;
+    if (previous && previous.startedAt !== undefined && previous.endedAt === undefined) {
+        previous.endedAt = now();
+        debugLog(`Work: ${previous.stage} done in ${Math.round(previous.endedAt - previous.startedAt)} ms`);
+    }
+
+    // Anything planned ahead of this stage that never reported is not coming.
+    for (const entry of stages) {
+        if (entry.stage === stage) break;
+        if (entry.startedAt === undefined) entry.skipped = true;
+    }
+
+    record.detail = detail;
+    record.skipped = false;
+    record.endedAt = undefined;
+    if (record.startedAt === undefined) record.startedAt = now();
+    currentStage = stage;
+    items = [];
+    debugLog(`Work: ${stage} started — ${detail}`);
     render();
+}
+
+/** Replace the item list shown under the current stage. `[]` clears it. */
+export function setWorkItems(itemList: WorkItem[]): void {
+    items = itemList.slice();
+    render();
+}
+
+/** Update one item's status (and optionally its detail); unknown id is a no-op. */
+export function updateWorkItem(id: string, status: WorkItemStatus, detail?: string): void {
+    const item = items.find((entry) => entry.id === id);
+    if (!item) return;
+    item.status = status;
+    if (detail !== undefined) item.detail = detail;
+    render();
+}
+
+/** True once the user dismissed this pass's toast. Cleared when the pass ends. */
+export function isWorkDismissed(): boolean {
+    return dismissed;
 }
 
 /** Hide the toast once all outstanding work has finished. */
 export function endWorkIndicator(): void {
     refCount = Math.max(0, refCount - 1);
     if (refCount > 0) return;
+
+    const ending = currentStage ? stages.find((entry) => entry.stage === currentStage) : undefined;
+    if (ending && ending.startedAt !== undefined && ending.endedAt === undefined) {
+        ending.endedAt = now();
+    }
+    currentStage = null;
+    const breakdown = stages
+        .filter((entry) => entry.startedAt !== undefined && entry.endedAt !== undefined)
+        .map((entry) => `${entry.stage}: ${Math.round((entry.endedAt as number) - (entry.startedAt as number))} ms`)
+        .join(", ");
+    debugLog(`Work: pass done in ${Math.round(now() - passStartedAt)} ms (${breakdown})`);
+
     clearTimers(); // a pass that finished before the toast appeared stays silent
+    const wasDismissed = dismissed;
+    dismissed = false;
+
+    if (copyWhenFinished && !wasDismissed) {
+        finished = true;
+        progress = 1;
+        labelText = FINISHED_LABEL;
+        const host = ensureToast();
+        host.querySelector<HTMLElement>("[data-flora-work-spinner]")?.style.setProperty("display", "none");
+        host.querySelector<HTMLElement>("[data-flora-work-chevron]")?.style.setProperty("display", "none");
+        expanded = false;
+        renderNow();
+        const finishRow = host.querySelector<HTMLElement>("[data-flora-work-finish]");
+        if (finishRow) finishRow.style.display = "flex";
+        return;
+    }
+
     const host = document.getElementById(WORK_TOAST_ID);
     if (!host) return;
     progress = 1;
     paint(host);
     // Brief delay so quick back-to-back passes don't flicker the toast.
-    hideTimer = setTimeout(() => {
-        host.style.opacity = "0";
-        host.style.transform = "translateY(6px)";
-        removeTimer = setTimeout(() => host.remove(), 200);
-    }, 500);
+    hideTimer = setTimeout(fadeOut, 500);
 }
 
 /** Popup hid all FLoRA UI — stay quiet until it comes back. */
 export function hideWorkIndicator(): void {
     suppressed = true;
     clearTimers();
-    document.getElementById(WORK_TOAST_ID)?.remove();
+    removeToast();
 }
 
 /** Popup restored FLoRA UI — back if a pass is still running. */
@@ -215,5 +766,13 @@ export function _resetWorkIndicatorForTesting(): void {
     progress = 0;
     labelText = DEFAULT_LABEL;
     suppressed = false;
-    document.getElementById(WORK_TOAST_ID)?.remove();
+    dismissed = false;
+    expanded = false;
+    finished = false;
+    copyWhenFinished = false;
+    stages = [];
+    currentStage = null;
+    items = [];
+    passStartedAt = 0;
+    removeToast();
 }

--- a/src/shared/progress-toast.ts
+++ b/src/shared/progress-toast.ts
@@ -10,6 +10,7 @@ import {debugLog, flushDebugLog, isDebugEnabled} from "@shared/debug";
 import {buildDebugReport} from "@shared/debug-report";
 import {writeClipboard} from "@shared/clipboard";
 import {blockDomain, snoozeDomain} from "@shared/domains";
+import {getSettings} from "@shared/settings";
 
 export const WORK_TOAST_ID = "flora-working-toast";
 
@@ -56,7 +57,6 @@ const STAGE_LABEL: Record<WorkStage, string> = {
 };
 
 const DEFAULT_LABEL = "ORE is looking up the papers on this page…";
-const FINISHED_LABEL = "Pass finished — log ready";
 
 const HOST_STYLE =
     "position:fixed;bottom:18px;right:18px;z-index:2147483647;" +
@@ -64,17 +64,19 @@ const HOST_STYLE =
     "background:linear-gradient(135deg,#853953,#612D53);color:#fff;" +
     "font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;" +
     "font-size:12px;font-weight:500;padding:9px 12px;border-radius:8px;" +
-    "min-width:220px;max-width:320px;box-sizing:border-box;" +
+    "min-width:220px;max-width:360px;box-sizing:border-box;" +
     "box-shadow:0 4px 16px rgba(0,0,0,0.18);" +
     "opacity:0;transform:translateY(6px);transition:opacity 0.18s ease,transform 0.18s ease;";
 
+// Page stylesheets reach into the toast (Scholar gives every button a
+// min-width, for one), so every control starts from all:unset.
 const SPINNER_STYLE =
-    "width:12px;height:12px;border-radius:50%;flex-shrink:0;box-sizing:border-box;" +
+    "all:unset;display:block;width:12px;height:12px;border-radius:50%;flex-shrink:0;box-sizing:border-box;" +
     "border:2px solid rgba(255,255,255,0.35);border-top-color:#fff;" +
     "animation:flora-work-spin 0.7s linear infinite;";
 
 const SMALL_SPINNER_STYLE =
-    "display:inline-block;width:9px;height:9px;border-radius:50%;box-sizing:border-box;" +
+    "all:unset;display:inline-block;width:9px;height:9px;border-radius:50%;box-sizing:border-box;" +
     "border:1.5px solid rgba(255,255,255,0.35);border-top-color:#fff;" +
     "animation:flora-work-spin 0.7s linear infinite;";
 
@@ -87,22 +89,18 @@ const FILL_STYLE =
     "transition:width 0.25s ease;";
 
 const ICON_BUTTON_STYLE =
-    "width:20px;height:20px;border:0;border-radius:5px;background:transparent;" +
+    "all:unset;box-sizing:border-box;width:20px;height:20px;border-radius:5px;" +
     "color:rgba(255,255,255,0.85);cursor:pointer;display:inline-flex;" +
-    "align-items:center;justify-content:center;padding:0;flex-shrink:0;pointer-events:auto;";
+    "align-items:center;justify-content:center;flex-shrink:0;pointer-events:auto;";
 
 const TEXT_BUTTON_STYLE =
-    "border:1px solid rgba(255,255,255,0.45);background:transparent;color:#fff;" +
-    "font:inherit;font-size:11px;padding:3px 9px;border-radius:5px;cursor:pointer;" +
-    "pointer-events:auto;white-space:nowrap;";
+    "all:unset;box-sizing:border-box;border:1px solid rgba(255,255,255,0.45);color:#fff;" +
+    "font-family:inherit;font-size:11px;line-height:1.3;padding:3px 9px;border-radius:5px;" +
+    "cursor:pointer;pointer-events:auto;white-space:nowrap;";
 
-const MENU_STYLE =
-    "display:none;flex-direction:column;gap:2px;margin-top:5px;padding:4px;" +
-    "border-radius:6px;background:rgba(0,0,0,0.28);pointer-events:auto;";
-
-const MENU_ITEM_STYLE =
-    "border:0;background:transparent;color:#fff;font:inherit;font-size:11px;" +
-    "text-align:left;padding:4px 7px;border-radius:4px;cursor:pointer;pointer-events:auto;";
+// The pause choices sit in their own row under the bar while the ⏸ is open.
+const PAUSE_ROW_STYLE =
+    "display:none;flex-wrap:wrap;gap:5px;align-items:center;pointer-events:auto;";
 
 const PANEL_STYLE =
     "display:none;flex-direction:column;gap:6px;padding-top:4px;margin-top:2px;" +
@@ -113,6 +111,10 @@ const CHEVRON_SVG =
     `<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" ` +
     `style="width:12px;height:12px;display:block;transition:transform 0.18s ease;">` +
     `<path d="M3 10l5-5 5 5"/></svg>`;
+
+const PAUSE_SVG =
+    `<svg viewBox="0 0 16 16" fill="currentColor" style="width:12px;height:12px;display:block;">` +
+    `<rect x="3" y="2" width="3.5" height="12" rx="1"/><rect x="9.5" y="2" width="3.5" height="12" rx="1"/></svg>`;
 
 const CLOSE_SVG =
     `<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" ` +
@@ -148,8 +150,10 @@ let labelText = DEFAULT_LABEL;
 let suppressed = false;
 let dismissed = false;
 let expanded = false;
-let copyWhenFinished = false;
+let cancelled = false;
 let finished = false;
+// Debug setting: keep a compact "Copy log" row up once the pass ends.
+let offerLogCopy = false;
 let stages: StageRecord[] = [];
 let currentStage: WorkStage | null = null;
 let items: WorkItem[] = [];
@@ -228,15 +232,6 @@ function textButton(text: string): HTMLButtonElement {
     return button;
 }
 
-function menuItem(text: string): HTMLButtonElement {
-    const button = document.createElement("button");
-    button.type = "button";
-    button.setAttribute("role", "menuitem");
-    button.textContent = text;
-    button.style.cssText = MENU_ITEM_STYLE;
-    return button;
-}
-
 /** 6 am the next calendar day, in the user's own timezone. */
 function msUntilTomorrow6am(): number {
     const target = new Date();
@@ -261,48 +256,40 @@ async function pauseSite(
     document.dispatchEvent(new CustomEvent("flora-pause-site", {detail}));
 }
 
-function buildPauseMenu(): HTMLElement {
-    const wrap = document.createElement("div");
-    wrap.setAttribute("data-flora-work-pause", "");
-    wrap.style.cssText = "position:relative;pointer-events:auto;";
+function buildPauseRow(): HTMLElement {
+    const row = document.createElement("div");
+    row.setAttribute("data-flora-work-pause-row", "");
+    row.setAttribute("role", "group");
+    row.setAttribute("aria-label", "Pause ORE on this site");
+    row.style.cssText = PAUSE_ROW_STYLE;
 
-    const menu = document.createElement("div");
-    menu.setAttribute("data-flora-work-pause-menu", "");
-    menu.setAttribute("role", "menu");
-    menu.style.cssText = MENU_STYLE;
+    const caption = document.createElement("span");
+    caption.style.cssText = "color:rgba(255,255,255,0.75);font-size:11px;margin-right:2px;";
+    caption.textContent = "Pause ORE here:";
 
-    const trigger = textButton("Pause on this site ▾");
-    trigger.setAttribute("aria-haspopup", "menu");
-    trigger.setAttribute("aria-expanded", "false");
-    trigger.addEventListener("click", () => {
-        const open = menu.style.display === "flex";
-        menu.style.display = open ? "none" : "flex";
-        trigger.setAttribute("aria-expanded", String(!open));
-    });
-
-    const hour = menuItem("Pause here for 1 hour");
+    const hour = textButton("1 hour");
     hour.addEventListener("click", () => {
         const hostname = location.hostname;
         const until = Date.now() + 60 * 60 * 1000;
         void pauseSite(snoozeDomain(hostname, 60 * 60 * 1000), {hostname, until});
     });
 
-    const tomorrow = menuItem("Pause here until tomorrow");
+    const tomorrow = textButton("Until tomorrow");
     tomorrow.addEventListener("click", () => {
         const hostname = location.hostname;
         const duration = msUntilTomorrow6am();
         void pauseSite(snoozeDomain(hostname, duration), {hostname, until: Date.now() + duration});
     });
 
-    const block = menuItem("Block this site (undo in options)");
+    const block = textButton("Disable on this domain");
+    block.title = "Re-enable from the ORE popup or options";
     block.addEventListener("click", () => {
         const hostname = location.hostname;
         void pauseSite(blockDomain(hostname), {hostname, blocked: true});
     });
 
-    menu.append(hour, tomorrow, block);
-    wrap.append(trigger, menu);
-    return wrap;
+    row.append(caption, hour, tomorrow, block);
+    return row;
 }
 
 /** Flash the outcome on the button that started the copy. */
@@ -332,32 +319,36 @@ function buildFooter(): HTMLElement {
     const footer = document.createElement("div");
     footer.setAttribute("data-flora-work-footer", "");
     footer.style.cssText =
-        "display:flex;flex-wrap:wrap;gap:6px;justify-content:flex-end;" +
-        "align-items:flex-start;padding-top:6px;";
-    footer.append(buildPauseMenu());
+        "display:flex;flex-wrap:wrap;gap:6px;justify-content:flex-end;align-items:center;padding-top:6px;";
 
     if (isDebugEnabled()) {
         const copy = textButton("Copy log");
         copy.setAttribute("data-flora-work-copy", "");
         copy.addEventListener("click", () => void copyLog(copy));
-
-        const arm = textButton("Copy log when finished");
-        arm.setAttribute("data-flora-work-arm", "");
-        arm.addEventListener("click", () => {
-            copyWhenFinished = !copyWhenFinished;
-            arm.textContent = copyWhenFinished ? "Will copy when finished ✓" : "Copy log when finished";
-        });
-
-        footer.append(copy, arm);
+        footer.append(copy);
     }
+
+    const cancel = textButton("Cancel");
+    cancel.setAttribute("data-flora-work-cancel", "");
+    cancel.title = "Stop this pass — ORE runs again on the next page";
+    cancel.addEventListener("click", () => {
+        cancelled = true;
+        dismissed = true;
+        clearTimers();
+        removeToast();
+    });
+    footer.append(cancel);
     return footer;
 }
 
-/** The row that stands in for the footer once an armed pass has finished. */
+/** Compact row that replaces the toast once a pass ends with the log-copy offer on. */
 function buildFinishRow(): HTMLElement {
     const row = document.createElement("div");
     row.setAttribute("data-flora-work-finish", "");
-    row.style.cssText = "display:none;justify-content:flex-end;gap:6px;";
+    row.style.cssText = "display:none;align-items:center;gap:8px;line-height:1.4;";
+    const label = document.createElement("span");
+    label.setAttribute("data-flora-work-finish-label", "");
+    label.style.cssText = "flex:1;";
     const copy = textButton("Copy log");
     copy.setAttribute("data-flora-work-final-copy", "");
     copy.addEventListener("click", () => {
@@ -365,7 +356,12 @@ function buildFinishRow(): HTMLElement {
             hideTimer = setTimeout(fadeOut, BUTTON_FLASH_MS);
         });
     });
-    row.append(copy);
+    const close = iconButton("Dismiss", CLOSE_SVG);
+    close.addEventListener("click", () => {
+        clearTimers();
+        removeToast();
+    });
+    row.append(label, copy, close);
     return row;
 }
 
@@ -394,6 +390,16 @@ function ensureToast(): HTMLElement {
     label.style.cssText = "flex:1;";
     label.textContent = labelText;
 
+    const pauseRow = buildPauseRow();
+    const pause = iconButton("Pause ORE on this site", PAUSE_SVG);
+    pause.setAttribute("data-flora-work-pause", "");
+    pause.setAttribute("aria-expanded", "false");
+    pause.addEventListener("click", () => {
+        const open = pauseRow.style.display === "flex";
+        pauseRow.style.display = open ? "none" : "flex";
+        pause.setAttribute("aria-expanded", String(!open));
+    });
+
     const chevron = iconButton("Show details", CHEVRON_SVG);
     chevron.setAttribute("data-flora-work-chevron", "");
     chevron.setAttribute("aria-expanded", "false");
@@ -410,7 +416,7 @@ function ensureToast(): HTMLElement {
         removeToast();
     });
 
-    row.append(spinner, label, chevron, close);
+    row.append(spinner, label, chevron, pause, close);
 
     const track = document.createElement("div");
     track.setAttribute("data-flora-work-track", "");
@@ -433,7 +439,7 @@ function ensureToast(): HTMLElement {
         "list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:4px;font-weight:400;";
     panel.append(list, buildFooter());
 
-    host.append(style, row, track, panel, buildFinishRow());
+    host.append(style, row, track, pauseRow, panel, buildFinishRow());
     document.body.appendChild(host);
     document.addEventListener("keydown", onKeydown, true);
     return host;
@@ -449,7 +455,6 @@ function applyExpanded(host: HTMLElement): void {
         chevron.title = expanded ? "Hide details" : "Show details";
     }
     if (arrow) arrow.style.transform = expanded ? "rotate(180deg)" : "rotate(0deg)";
-    host.style.maxWidth = expanded && items.length ? "360px" : "320px";
     if (expanded) renderStages(host);
 }
 
@@ -597,6 +602,7 @@ function renderNow(): void {
     if (label) label.textContent = labelText;
     paint(host);
     applyExpanded(host);
+    if (finished) showFinishRow(host);
     requestAnimationFrame(() => {
         host.style.opacity = "1";
         host.style.transform = "translateY(0)";
@@ -616,6 +622,19 @@ function render(): void {
         showTimer = null;
         renderNow();
     }, SHOW_DELAY_MS);
+}
+
+/** Collapse the toast to one line: "Done in 2.3 s · Copy log ×". */
+function showFinishRow(host: HTMLElement): void {
+    for (const part of host.children) {
+        const el = part as HTMLElement;
+        if (el.tagName === "STYLE" || el.hasAttribute("data-flora-work-finish")) continue;
+        el.style.display = "none";
+    }
+    const finishRow = host.querySelector<HTMLElement>("[data-flora-work-finish]");
+    const finishLabel = host.querySelector<HTMLElement>("[data-flora-work-finish-label]");
+    if (finishLabel) finishLabel.textContent = labelText;
+    if (finishRow) finishRow.style.display = "flex";
 }
 
 function fadeOut(): void {
@@ -638,9 +657,12 @@ export function beginWorkIndicator(plan?: WorkPlan): void {
         progress = 0;
         labelText = DEFAULT_LABEL;
         dismissed = false;
+        cancelled = false;
         expanded = false;
         finished = false;
-        copyWhenFinished = false;
+        void getSettings().then((settings) => {
+            offerLogCopy = settings.offerLogCopyAfterPass;
+        });
         currentStage = null;
         items = [];
         passStartedAt = now();
@@ -713,6 +735,11 @@ export function updateWorkItem(id: string, status: WorkItemStatus, detail?: stri
     if (touched) render();
 }
 
+/** True once the user pressed Cancel on this pass; pipelines stop at their next stage boundary. */
+export function isWorkCancelled(): boolean {
+    return cancelled;
+}
+
 /** Hide the toast once all outstanding work has finished. */
 export function endWorkIndicator(): void {
     if (refCount === 0) return; // unmatched end — nothing to close
@@ -733,18 +760,14 @@ export function endWorkIndicator(): void {
     clearTimers(); // a pass that finished before the toast appeared stays silent
     const wasDismissed = dismissed;
     dismissed = false;
+    cancelled = false;
 
-    if (copyWhenFinished && !wasDismissed) {
+    if (offerLogCopy && isDebugEnabled() && !wasDismissed && !suppressed) {
         finished = true;
         progress = 1;
-        labelText = FINISHED_LABEL;
-        const host = ensureToast();
-        host.querySelector<HTMLElement>("[data-flora-work-spinner]")?.style.setProperty("display", "none");
-        host.querySelector<HTMLElement>("[data-flora-work-chevron]")?.style.setProperty("display", "none");
+        labelText = `Done in ${formatDuration(now() - passStartedAt)}`;
         expanded = false;
         renderNow();
-        const finishRow = host.querySelector<HTMLElement>("[data-flora-work-finish]");
-        if (finishRow) finishRow.style.display = "flex";
         return;
     }
 
@@ -777,9 +800,10 @@ export function _resetWorkIndicatorForTesting(): void {
     labelText = DEFAULT_LABEL;
     suppressed = false;
     dismissed = false;
+    cancelled = false;
     expanded = false;
     finished = false;
-    copyWhenFinished = false;
+    offerLogCopy = false;
     stages = [];
     currentStage = null;
     items = [];

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -20,6 +20,11 @@ export interface FloraSettings {
    * are evicted first, then live entries oldest-first (LRU).
    */
   cacheQuotaMb: number;
+  /**
+   * With debug mode on, keep a one-line "Done in … · Copy log" toast up after
+   * each pass so the log for a slow or wrong pass is one click away.
+   */
+  offerLogCopyAfterPass: boolean;
 }
 
 const STORAGE_KEY = "flora_settings";
@@ -29,6 +34,7 @@ const DEFAULTS: FloraSettings = {
   showDoiPillsOnAllReferences: false,
   citationStyle: "apa",
   cacheQuotaMb: 50,
+  offerLogCopyAfterPass: false,
 };
 
 let cachedSettings: FloraSettings | null = null;

--- a/tests/unit/domain-snooze.test.ts
+++ b/tests/unit/domain-snooze.test.ts
@@ -1,0 +1,102 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
+
+// Temporary per-site pauses live in chrome.storage.local as
+// hostname → expiry epoch; the permanent blocked list stays in storage.sync.
+
+const SNOOZE_KEY = "flora_snoozed_domains";
+const BLACKLIST_KEY = "flora_blocked_domains";
+
+let localStore: Record<string, unknown> = {};
+let syncStore: Record<string, unknown> = {};
+
+function backStorage(area: "local" | "sync", store: Record<string, unknown>): void {
+  chrome.storage[area].get = vi.fn((keys: string | string[]) => {
+    const names = typeof keys === "string" ? [keys] : keys;
+    const out: Record<string, unknown> = {};
+    for (const name of names) {
+      if (name in store) out[name] = store[name];
+    }
+    return Promise.resolve(out);
+  }) as unknown as typeof chrome.storage.local.get;
+  chrome.storage[area].set = vi.fn((items: Record<string, unknown>) => {
+    Object.assign(store, items);
+    return Promise.resolve();
+  }) as unknown as typeof chrome.storage.local.set;
+}
+
+async function loadDomains() {
+  return import("../../src/shared/domains");
+}
+
+beforeEach(() => {
+  localStore = {};
+  syncStore = {};
+  backStorage("local", localStore);
+  backStorage("sync", syncStore);
+});
+
+afterEach(() => {
+  vi.resetModules();
+  vi.restoreAllMocks();
+});
+
+describe("domain snooze", () => {
+  it("pauses a host for the requested duration", async () => {
+    const {snoozeDomain, isDomainSnoozed, getSnooze} = await loadDomains();
+
+    const until = await snoozeDomain("example.com", 60_000);
+
+    expect(until).toBeGreaterThan(Date.now());
+    await expect(isDomainSnoozed("example.com")).resolves.toBe(true);
+    await expect(getSnooze("example.com")).resolves.toBe(until);
+    expect(localStore[SNOOZE_KEY]).toEqual({"example.com": until});
+  });
+
+  it("covers subdomains of a paused domain", async () => {
+    const {snoozeDomain, isDomainSnoozed} = await loadDomains();
+
+    await snoozeDomain("example.com", 60_000);
+
+    await expect(isDomainSnoozed("journals.example.com")).resolves.toBe(true);
+    await expect(isDomainSnoozed("notexample.com")).resolves.toBe(false);
+  });
+
+  it("treats an expired pause as over and prunes it", async () => {
+    const {snoozeDomain, isDomainSnoozed} = await loadDomains();
+
+    await snoozeDomain("example.com", -1_000);
+
+    await expect(isDomainSnoozed("example.com")).resolves.toBe(false);
+    expect(localStore[SNOOZE_KEY]).toEqual({});
+  });
+
+  it("clears a pause on request", async () => {
+    const {snoozeDomain, clearSnooze, isDomainSnoozed} = await loadDomains();
+
+    await snoozeDomain("example.com", 60_000);
+    await clearSnooze("example.com");
+
+    await expect(isDomainSnoozed("example.com")).resolves.toBe(false);
+    expect(localStore[SNOOZE_KEY]).toEqual({});
+  });
+
+  it("clears a parent-domain pause when resuming on a subdomain", async () => {
+    const {snoozeDomain, clearSnooze, isDomainSnoozed} = await loadDomains();
+
+    await snoozeDomain("example.com", 60_000);
+    await clearSnooze("journals.example.com");
+
+    await expect(isDomainSnoozed("journals.example.com")).resolves.toBe(false);
+    await expect(isDomainSnoozed("example.com")).resolves.toBe(false);
+  });
+
+  it("adds a blocked domain once", async () => {
+    const {blockDomain, getBlockedDomains} = await loadDomains();
+
+    await blockDomain("example.com");
+    await blockDomain("example.com");
+
+    await expect(getBlockedDomains()).resolves.toEqual(["example.com"]);
+    expect(syncStore[BLACKLIST_KEY]).toEqual(["example.com"]);
+  });
+});

--- a/tests/unit/progress-toast.test.ts
+++ b/tests/unit/progress-toast.test.ts
@@ -3,7 +3,6 @@ import {
     beginWorkIndicator,
     endWorkIndicator,
     hideWorkIndicator,
-    isWorkDismissed,
     reportWorkStage,
     setWorkItems,
     showWorkIndicator,
@@ -22,6 +21,12 @@ vi.mock("../../src/shared/debug-report", () => ({
 vi.mock("../../src/shared/clipboard", () => ({
     writeClipboard: vi.fn(async () => true),
 }));
+
+const domainWrites = vi.hoisted(() => ({
+    snoozeDomain: vi.fn(async () => Date.now() + 3_600_000),
+    blockDomain: vi.fn(async () => undefined),
+}));
+vi.mock("../../src/shared/domains", () => domainWrites);
 
 function toast(): HTMLElement | null {
     return document.getElementById(WORK_TOAST_ID);
@@ -231,14 +236,12 @@ describe("progress toast", () => {
         settle();
         button("close").click();
         expect(toast()).toBeNull();
-        expect(isWorkDismissed()).toBe(true);
 
         reportWorkStage("lookup", "Looking up 10 DOIs in FLoRA…");
         settle();
         expect(toast()).toBeNull();
 
         endWorkIndicator();
-        expect(isWorkDismissed()).toBe(false);
         beginWorkIndicator();
         settle();
         expect(toast()).not.toBeNull();
@@ -305,5 +308,29 @@ describe("progress toast", () => {
         expect(buildDebugReport).toHaveBeenCalled();
         expect(writeClipboard).toHaveBeenCalledWith("REPORT");
         expect(copy.textContent).toBe("Copied ✓");
+    });
+    it("pause menu persists the snooze before telling the page to hide", async () => {
+        let resolveWrite: (until: number) => void = () => {};
+        domainWrites.snoozeDomain.mockImplementationOnce(
+            () => new Promise<number>((resolve) => { resolveWrite = resolve; }),
+        );
+        const paused = vi.fn();
+        document.addEventListener("flora-pause-site", paused);
+
+        beginWorkIndicator();
+        reportWorkStage("scan", "Scanning this page for DOIs…");
+        settle();
+        expand();
+        const menu = toast()!.querySelector<HTMLElement>("[data-flora-work-pause-menu]")!;
+        menu.querySelector<HTMLButtonElement>("button")!.click(); // "Pause here for 1 hour"
+
+        expect(domainWrites.snoozeDomain).toHaveBeenCalledWith(location.hostname, 3_600_000);
+        expect(toast()).toBeNull();
+        expect(paused).not.toHaveBeenCalled();
+
+        resolveWrite(Date.now() + 3_600_000);
+        await vi.advanceTimersByTimeAsync(0);
+        expect(paused).toHaveBeenCalledTimes(1);
+        document.removeEventListener("flora-pause-site", paused);
     });
 });

--- a/tests/unit/progress-toast.test.ts
+++ b/tests/unit/progress-toast.test.ts
@@ -3,6 +3,7 @@ import {
     beginWorkIndicator,
     endWorkIndicator,
     hideWorkIndicator,
+    isWorkCancelled,
     reportWorkStage,
     setWorkItems,
     showWorkIndicator,
@@ -27,6 +28,11 @@ const domainWrites = vi.hoisted(() => ({
     blockDomain: vi.fn(async () => undefined),
 }));
 vi.mock("../../src/shared/domains", () => domainWrites);
+
+const settings = vi.hoisted(() => ({offerLogCopyAfterPass: false}));
+vi.mock("../../src/shared/settings", () => ({
+    getSettings: vi.fn(async () => settings),
+}));
 
 function toast(): HTMLElement | null {
     return document.getElementById(WORK_TOAST_ID);
@@ -266,13 +272,13 @@ describe("progress toast", () => {
         expect(toast()!.style.pointerEvents).toBe("none");
         expect(button("chevron").style.pointerEvents).toBe("auto");
         expect(button("close").style.pointerEvents).toBe("auto");
-        expand();
-        expect(toast()!.querySelector<HTMLElement>("[data-flora-work-pause] button")!.style.pointerEvents).toBe(
-            "auto"
-        );
+        button("pause").click();
+        const pauseRow = toast()!.querySelector<HTMLElement>("[data-flora-work-pause-row]")!;
+        expect(pauseRow.style.display).toBe("flex");
+        expect(pauseRow.querySelector<HTMLElement>("button")!.style.pointerEvents).toBe("auto");
     });
 
-    it("offers the copy-log buttons only while debug logging is on", () => {
+    it("offers the copy-log button only while debug logging is on", () => {
         beginWorkIndicator();
         settle();
         expand();
@@ -285,22 +291,22 @@ describe("progress toast", () => {
         settle();
         expand();
         expect(toast()!.querySelector("[data-flora-work-copy]")).not.toBeNull();
-        expect(toast()!.querySelector("[data-flora-work-arm]")).not.toBeNull();
+        expect(toast()!.querySelector("[data-flora-work-cancel]")).not.toBeNull();
     });
 
-    it("holds the toast open when the copy is armed and copies on click", async () => {
+    it("keeps a one-line copy offer up after the pass when the setting is on", async () => {
         setDebug(true);
+        settings.offerLogCopyAfterPass = true;
         beginWorkIndicator();
+        await vi.advanceTimersByTimeAsync(0); // the setting is read asynchronously
         reportWorkStage("scan", "Scanning this page for DOIs…");
         settle();
-        expand();
-        button("arm").click();
-        expect(button("arm").textContent).toBe("Will copy when finished ✓");
 
         endWorkIndicator();
         vi.advanceTimersByTime(2000);
         expect(toast()).not.toBeNull();
-        expect(label()).toBe("Pass finished — log ready");
+        const finishLabel = toast()!.querySelector("[data-flora-work-finish-label]")!.textContent ?? "";
+        expect(finishLabel).toMatch(/^Done in \d+ ms$/);
 
         const copy = button("final-copy");
         copy.click();
@@ -308,8 +314,23 @@ describe("progress toast", () => {
         expect(buildDebugReport).toHaveBeenCalled();
         expect(writeClipboard).toHaveBeenCalledWith("REPORT");
         expect(copy.textContent).toBe("Copied ✓");
+        settings.offerLogCopyAfterPass = false;
     });
-    it("pause menu persists the snooze before telling the page to hide", async () => {
+
+    it("cancel stops the pass at the pipeline's next check and hides the toast", () => {
+        beginWorkIndicator();
+        reportWorkStage("scan", "Scanning this page for DOIs…");
+        settle();
+        expand();
+        expect(isWorkCancelled()).toBe(false);
+        button("cancel").click();
+        expect(isWorkCancelled()).toBe(true);
+        expect(toast()).toBeNull();
+        endWorkIndicator();
+        expect(isWorkCancelled()).toBe(false);
+    });
+
+    it("pause row persists the snooze before telling the page to hide", async () => {
         let resolveWrite: (until: number) => void = () => {};
         domainWrites.snoozeDomain.mockImplementationOnce(
             () => new Promise<number>((resolve) => { resolveWrite = resolve; }),
@@ -320,9 +341,9 @@ describe("progress toast", () => {
         beginWorkIndicator();
         reportWorkStage("scan", "Scanning this page for DOIs…");
         settle();
-        expand();
-        const menu = toast()!.querySelector<HTMLElement>("[data-flora-work-pause-menu]")!;
-        menu.querySelector<HTMLButtonElement>("button")!.click(); // "Pause here for 1 hour"
+        button("pause").click();
+        const pauseRow = toast()!.querySelector<HTMLElement>("[data-flora-work-pause-row]")!;
+        pauseRow.querySelector<HTMLButtonElement>("button")!.click(); // "Pause 1 hour"
 
         expect(domainWrites.snoozeDomain).toHaveBeenCalledWith(location.hostname, 3_600_000);
         expect(toast()).toBeNull();

--- a/tests/unit/progress-toast.test.ts
+++ b/tests/unit/progress-toast.test.ts
@@ -3,11 +3,25 @@ import {
     beginWorkIndicator,
     endWorkIndicator,
     hideWorkIndicator,
+    isWorkDismissed,
     reportWorkStage,
+    setWorkItems,
     showWorkIndicator,
+    updateWorkItem,
     WORK_TOAST_ID,
     _resetWorkIndicatorForTesting,
 } from "../../src/shared/progress-toast";
+import {setDebug, _resetDebugForTesting} from "../../src/shared/debug";
+import {buildDebugReport} from "../../src/shared/debug-report";
+import {writeClipboard} from "../../src/shared/clipboard";
+
+vi.mock("../../src/shared/debug-report", () => ({
+    buildDebugReport: vi.fn(async () => ({text: "REPORT", entryCount: 1, data: {}})),
+}));
+
+vi.mock("../../src/shared/clipboard", () => ({
+    writeClipboard: vi.fn(async () => true),
+}));
 
 function toast(): HTMLElement | null {
     return document.getElementById(WORK_TOAST_ID);
@@ -21,6 +35,25 @@ function percent(): string | null {
     return toast()?.querySelector("[data-flora-work-track]")?.getAttribute("aria-valuenow") ?? null;
 }
 
+function button(name: string): HTMLButtonElement {
+    return toast()!.querySelector<HTMLButtonElement>(`[data-flora-work-${name}]`)!;
+}
+
+function expand(): void {
+    button("chevron").click();
+}
+
+function stageStates(): Record<string, string> {
+    const rows = toast()!.querySelectorAll<HTMLElement>("[data-flora-work-stage]");
+    return Object.fromEntries(
+        [...rows].map((row) => [row.dataset.floraWorkStage ?? "", row.dataset.floraWorkState ?? ""])
+    );
+}
+
+function itemRows(): HTMLElement[] {
+    return [...(toast()?.querySelectorAll<HTMLElement>("[data-flora-work-item]") ?? [])];
+}
+
 /** Past the delay that holds the toast back on a fast pass. */
 function settle(): void {
     vi.advanceTimersByTime(300);
@@ -29,11 +62,14 @@ function settle(): void {
 describe("progress toast", () => {
     beforeEach(() => {
         vi.useFakeTimers();
+        vi.spyOn(console, "log").mockImplementation(() => {});
     });
 
     afterEach(() => {
         _resetWorkIndicatorForTesting();
+        _resetDebugForTesting();
         vi.useRealTimers();
+        vi.restoreAllMocks();
         document.body.innerHTML = "";
     });
 
@@ -134,5 +170,140 @@ describe("progress toast", () => {
         showWorkIndicator();
         settle();
         expect(toast()).toBeNull();
+    });
+
+    it("lists the planned stages and skips the ones that never reported", () => {
+        beginWorkIndicator({stages: ["scan", "validate", "augment", "lookup"]});
+        settle();
+        expand();
+        expect(stageStates()).toEqual({
+            scan: "pending",
+            validate: "pending",
+            augment: "pending",
+            lookup: "pending",
+        });
+
+        let clock = 0;
+        vi.spyOn(performance, "now").mockImplementation(() => clock);
+        reportWorkStage("scan", "Read 20 results");
+        clock = 2300;
+        reportWorkStage("lookup", "Looking up 14 DOIs…");
+        expect(stageStates()).toEqual({
+            scan: "done",
+            validate: "skipped",
+            augment: "skipped",
+            lookup: "current",
+        });
+
+        const done = toast()!.querySelector<HTMLElement>('[data-flora-work-stage="scan"]')!;
+        expect(done.textContent).toContain("Read 20 results");
+        expect(done.querySelector("[data-flora-work-duration]")?.textContent).toBe("2.3 s");
+        // A stage that never ran shows its generic planned label.
+        expect(toast()!.querySelector('[data-flora-work-stage="validate"]')?.textContent).toContain(
+            "Check DOIs resolve"
+        );
+    });
+
+    it("shows items under the current stage, capped at six rows", () => {
+        beginWorkIndicator({stages: ["augment", "lookup"]});
+        reportWorkStage("augment", "Searching OpenAlex for 8 results…");
+        settle();
+        expand();
+        setWorkItems(
+            Array.from({length: 8}, (_, i) => ({id: `i${i}`, label: `Paper ${i}`, status: "pending" as const}))
+        );
+        expect(itemRows()).toHaveLength(6);
+        expect(toast()!.querySelector("[data-flora-work-more]")?.textContent).toBe("2 more…");
+
+        updateWorkItem("i0", "done", "10.1234/x");
+        const first = toast()!.querySelector<HTMLElement>('[data-flora-work-item="i0"]')!;
+        expect(first.textContent).toContain("✓");
+        expect(first.textContent).toContain("10.1234/x");
+
+        // Items belong to the stage that reported them.
+        reportWorkStage("lookup", "Looking up 14 DOIs…");
+        expect(itemRows()).toHaveLength(0);
+    });
+
+    it("dismisses the toast for the pass and shows it again on the next one", () => {
+        beginWorkIndicator();
+        reportWorkStage("scan", "Scanning this page for DOIs…");
+        settle();
+        button("close").click();
+        expect(toast()).toBeNull();
+        expect(isWorkDismissed()).toBe(true);
+
+        reportWorkStage("lookup", "Looking up 10 DOIs in FLoRA…");
+        settle();
+        expect(toast()).toBeNull();
+
+        endWorkIndicator();
+        expect(isWorkDismissed()).toBe(false);
+        beginWorkIndicator();
+        settle();
+        expect(toast()).not.toBeNull();
+    });
+
+    it("forgets the expanded panel between passes", () => {
+        beginWorkIndicator();
+        settle();
+        expand();
+        expect(button("chevron").getAttribute("aria-expanded")).toBe("true");
+
+        endWorkIndicator();
+        vi.advanceTimersByTime(1000);
+        beginWorkIndicator();
+        settle();
+        expect(button("chevron").getAttribute("aria-expanded")).toBe("false");
+    });
+
+    it("keeps the host click-through and the buttons clickable", () => {
+        beginWorkIndicator();
+        settle();
+        expect(toast()!.style.pointerEvents).toBe("none");
+        expect(button("chevron").style.pointerEvents).toBe("auto");
+        expect(button("close").style.pointerEvents).toBe("auto");
+        expand();
+        expect(toast()!.querySelector<HTMLElement>("[data-flora-work-pause] button")!.style.pointerEvents).toBe(
+            "auto"
+        );
+    });
+
+    it("offers the copy-log buttons only while debug logging is on", () => {
+        beginWorkIndicator();
+        settle();
+        expand();
+        expect(toast()!.querySelector("[data-flora-work-copy]")).toBeNull();
+
+        endWorkIndicator();
+        vi.advanceTimersByTime(1000);
+        setDebug(true);
+        beginWorkIndicator();
+        settle();
+        expand();
+        expect(toast()!.querySelector("[data-flora-work-copy]")).not.toBeNull();
+        expect(toast()!.querySelector("[data-flora-work-arm]")).not.toBeNull();
+    });
+
+    it("holds the toast open when the copy is armed and copies on click", async () => {
+        setDebug(true);
+        beginWorkIndicator();
+        reportWorkStage("scan", "Scanning this page for DOIs…");
+        settle();
+        expand();
+        button("arm").click();
+        expect(button("arm").textContent).toBe("Will copy when finished ✓");
+
+        endWorkIndicator();
+        vi.advanceTimersByTime(2000);
+        expect(toast()).not.toBeNull();
+        expect(label()).toBe("Pass finished — log ready");
+
+        const copy = button("final-copy");
+        copy.click();
+        await vi.advanceTimersByTimeAsync(1600);
+        expect(buildDebugReport).toHaveBeenCalled();
+        expect(writeClipboard).toHaveBeenCalledWith("REPORT");
+        expect(copy.textContent).toBe("Copied ✓");
     });
 });

--- a/tests/unit/settings-domains-cache.test.ts
+++ b/tests/unit/settings-domains-cache.test.ts
@@ -8,6 +8,7 @@ const FULL_SETTINGS = {
   showDoiPillsOnAllReferences: false,
   citationStyle: "apa",
   cacheQuotaMb: 50,
+  offerLogCopyAfterPass: false,
 };
 
 describe("settings/domain storage caches", () => {


### PR DESCRIPTION
The progress toast (bottom right while ORE works a page) becomes informative and dismissable.

## What changes

**Toast** (`src/shared/progress-toast.ts`)
- Chevron opens a panel with the pass's stage checklist: done ✓ (with duration), current (spinner), skipped, pending. Closed by default on every pass.
- On Google Scholar the current stage lists the items it is working on — DOIs being validated, titles being augmented (with first author/year), DOIs being looked up — each with its own status (pending / done / flagged / failed). Article pages stay stage-only.
- × dismisses the toast for the rest of the pass; work continues. **Cancel** (panel footer) stops the pass at its next stage boundary in both pipelines.
- **Snooze** (clock icon in the header, as on the Sheets modal) opens a row: snooze ORE here for 1 hour / until tomorrow (a per-device snooze in `chrome.storage.local`, resumable from the popup) / disable on this domain (the existing blocked-domain list). The page's ORE UI hides immediately; a pass already in flight skips its mark-up step.
- With debug mode on: **Copy log** in the footer, and — with the popup's new *Offer "Copy log" after each pass* sub-switch — a one-line `Done in 12.5 s · Copy log ×` toast after the pass.
- Every control starts from `all:unset` (Scholar's stylesheet gives buttons a `min-width`, which otherwise pushes the label onto three lines).
- Every stage transition is debug-logged with timings (`Work: augment done in 9932 ms`, `Work: pass done in 10189 ms (scan: 2 ms, validate: 53 ms, …)`) — this is the instrument for "why is this pass slow".
- Host stays `pointer-events:none`; only the buttons and the open panel catch clicks.

**Snooze** (`src/shared/domains.ts`, popup) — `snoozeDomain` / `clearSnooze` / `getSnooze` / `isDomainSnoozed` / `blockDomain`; both content scripts gate on the snooze like they gate on the block list; the popup shows "Paused until HH:MM" with a Resume button.

**Wiring** — Scholar observer passes its stage plan and reports items; content-general passes its plans (fast path: scan; full scan: all six stages).

## Screenshots

| Collapsed (unchanged look) | Expanded, augment stage with items |
|---|---|
| ![toast-collapsed](https://pub-81cc71242f4640a28e8fae9c3df3d41d.r2.dev/flora/2026/08/toast-collapsed-8c81ddd2.png) | ![toast-expanded-items](https://pub-81cc71242f4640a28e8fae9c3df3d41d.r2.dev/flora/2026/08/toast-expanded-items-06986ccc.png) |

| Snooze row open | Debug: one-line finished state | Popup while paused (debug on) |
|---|---|---|
| ![toast-pause-menu](https://pub-81cc71242f4640a28e8fae9c3df3d41d.r2.dev/flora/2026/08/toast-pause-menu-7dd6ad42.png) | ![toast-finished-copy](https://pub-81cc71242f4640a28e8fae9c3df3d41d.r2.dev/flora/2026/08/toast-finished-copy-240b8cb4.png) | ![popup-paused](https://pub-81cc71242f4640a28e8fae9c3df3d41d.r2.dev/flora/2026/08/popup-paused-ca74af83.png) |

(Timings in the shots come from a harness that delays the worker's fetches by ~9 s to hold the toast up.)

## Notes

- Branched from `main`. #186 (search adapters) moves the Scholar pass into `src/content-search/pipeline.ts`; the item reporting in `observer.ts` (~20 lines) ports there mechanically after whichever lands second.
- Known limit: snooze writes are whole-map read-modify-write; two tabs pausing different sites in the same instant could drop one. Acceptable for a per-device convenience setting.

## Verification

- `npx vitest run`: 70 files, 659 tests pass (9 new toast cases, 6 snooze cases).
- `npm run typecheck`, `npm run build` clean. Visual baselines unaffected (the harness hides the toast).
- Live check in headless Chrome for Testing against a Scholar fixture: stages, items, pause event, copy-when-finished flow, popup paused state — see screenshots.
- Codex read-only review run; its findings (un-awaited pause write, ref-count underflow, re-entered-stage timing, duplicate item ids, menu roles, dead API) are fixed in ea09730. Layout re-checked against Scholar's live CSS after the first screenshots showed the label wrapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
