### PR TITLE
Coalesce fast toast item updates

### DIFF
--- a/src/shared/progress-toast.ts
+++ b/src/shared/progress-toast.ts
@@ -209,6 +209,8 @@ function formatDuration(ms: number): string {
 }
 
 function removeToast(): void {
+    // A frame queued before removal must not rebuild the toast afterwards.
+    cancelQueuedRender();
     const host = document.getElementById(WORK_TOAST_ID);
     if (!host) return;
     document.removeEventListener("keydown", onKeydown, true);

--- a/src/shared/progress-toast.ts
+++ b/src/shared/progress-toast.ts
@@ -641,6 +641,9 @@ function render(immediate = true): void {
         else queueRender();
         return;
     }
+    // The toast is gone. A straggler from a pass that already ended must not
+    // bring it back — only a running pass gets a fresh one.
+    if (refCount === 0) return;
     if (showTimer) return;
     showTimer = setTimeout(() => {
         showTimer = null;

--- a/src/shared/progress-toast.ts
+++ b/src/shared/progress-toast.ts
@@ -146,6 +146,7 @@ let refCount = 0;
 let showTimer: ReturnType<typeof setTimeout> | null = null;
 let hideTimer: ReturnType<typeof setTimeout> | null = null;
 let removeTimer: ReturnType<typeof setTimeout> | null = null;
+let renderFrame: number | null = null;
 // 0 = nothing reported yet, and the bar runs indeterminate.
 let progress = 0;
 let labelText = DEFAULT_LABEL;
@@ -164,6 +165,10 @@ let passStartedAt = 0;
 function clearTimers(): void {
     for (const timer of [showTimer, hideTimer, removeTimer]) {
         if (timer) clearTimeout(timer);
+    }
+    if (renderFrame !== null) {
+        cancelAnimationFrame(renderFrame);
+        renderFrame = null;
     }
     showTimer = hideTimer = removeTimer = null;
 }
@@ -611,12 +616,22 @@ function renderNow(): void {
     });
 }
 
-/** Update now if the toast is already up, else once the pass proves slow. */
-function render(): void {
+/** Coalesce state changes that arrive in the same frame into one DOM render. */
+function queueRender(): void {
+    if (renderFrame !== null) return;
+    renderFrame = requestAnimationFrame(() => {
+        renderFrame = null;
+        renderNow();
+    });
+}
+
+/** Update now if requested; item bursts can defer to the next animation frame. */
+function render(immediate = true): void {
     if (suppressed || dismissed) return;
     if (refCount === 0 && !finished) return;
     if (document.getElementById(WORK_TOAST_ID)) {
-        renderNow();
+        if (immediate) renderNow();
+        else queueRender();
         return;
     }
     if (showTimer) return;
@@ -734,7 +749,9 @@ export function updateWorkItem(id: string, status: WorkItemStatus, detail?: stri
         if (detail !== undefined) item.detail = detail;
         touched = true;
     }
-    if (touched) render();
+    // A fast batch completes many items in one synchronous loop. Keep the
+    // state changes immediate, but coalesce the expensive DOM rebuild.
+    if (touched) render(false);
 }
 
 /** True once the user pressed Cancel on this pass; pipelines stop at their next stage boundary. */

--- a/src/shared/progress-toast.ts
+++ b/src/shared/progress-toast.ts
@@ -166,11 +166,14 @@ function clearTimers(): void {
     for (const timer of [showTimer, hideTimer, removeTimer]) {
         if (timer) clearTimeout(timer);
     }
-    if (renderFrame !== null) {
-        cancelAnimationFrame(renderFrame);
-        renderFrame = null;
-    }
+    cancelQueuedRender();
     showTimer = hideTimer = removeTimer = null;
+}
+
+function cancelQueuedRender(): void {
+    if (renderFrame === null) return;
+    cancelAnimationFrame(renderFrame);
+    renderFrame = null;
 }
 
 function now(): number {
@@ -604,6 +607,8 @@ function paint(host: HTMLElement): void {
 function renderNow(): void {
     if (suppressed || dismissed) return;
     if (refCount === 0 && !finished) return;
+    // An immediate stage update supersedes any deferred item update.
+    cancelQueuedRender();
     const host = ensureToast();
     const label = host.querySelector<HTMLElement>("[data-flora-work-label]");
     if (label) label.textContent = labelText;

--- a/tests/unit/progress-toast.test.ts
+++ b/tests/unit/progress-toast.test.ts
@@ -297,6 +297,25 @@ describe("progress toast", () => {
         expect(toast()).toBeNull();
     });
 
+    it("does not bring a dismissed finished toast back for a late item update", async () => {
+        setDebug(true);
+        settings.offerLogCopyAfterPass = true;
+        beginWorkIndicator({stages: ["lookup"]});
+        await vi.advanceTimersByTimeAsync(0); // the setting is read asynchronously
+        reportWorkStage("lookup", "Looking up 1 DOI…");
+        settle();
+        setWorkItems([{id: "i0", label: "Paper 0", status: "pending"}]);
+        endWorkIndicator(); // leaves the one-line copy offer up
+        settings.offerLogCopyAfterPass = false;
+
+        toast()!.querySelector<HTMLButtonElement>("[data-flora-work-finish] button:last-of-type")!.click();
+        expect(toast()).toBeNull();
+
+        updateWorkItem("i0", "done"); // a straggler arrives after the toast is gone
+        vi.advanceTimersByTime(1000);
+        expect(toast()).toBeNull();
+    });
+
     it("dismisses the toast for the pass and shows it again on the next one", () => {
         beginWorkIndicator();
         reportWorkStage("scan", "Scanning this page for DOIs…");

--- a/tests/unit/progress-toast.test.ts
+++ b/tests/unit/progress-toast.test.ts
@@ -226,7 +226,13 @@ describe("progress toast", () => {
         expect(itemRows()).toHaveLength(6);
         expect(toast()!.querySelector("[data-flora-work-more]")?.textContent).toBe("2 more…");
 
+        const frames: FrameRequestCallback[] = [];
+        vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+            frames.push(callback);
+            return frames.length;
+        });
         updateWorkItem("i0", "done", "10.1234/x");
+        frames[0](0);
         const first = toast()!.querySelector<HTMLElement>('[data-flora-work-item="i0"]')!;
         expect(first.textContent).toContain("✓");
         expect(first.textContent).toContain("10.1234/x");
@@ -234,6 +240,25 @@ describe("progress toast", () => {
         // Items belong to the stage that reported them.
         reportWorkStage("lookup", "Looking up 14 DOIs…");
         expect(itemRows()).toHaveLength(0);
+    });
+
+    it("coalesces a synchronous burst of item updates into one render frame", () => {
+        beginWorkIndicator({stages: ["lookup"]});
+        reportWorkStage("lookup", "Looking up 8 DOIs…");
+        settle();
+        expand();
+        const requestFrame = vi.spyOn(window, "requestAnimationFrame").mockImplementation(() => 1);
+        setWorkItems(
+            Array.from({length: 8}, (_, i) => ({id: `i${i}`, label: `Paper ${i}`, status: "pending" as const}))
+        );
+        requestFrame.mockClear();
+
+        for (let i = 0; i < 8; i++) updateWorkItem(`i${i}`, "done");
+
+        expect(requestFrame).toHaveBeenCalledTimes(1);
+        const render = requestFrame.mock.calls[0][0];
+        render(0);
+        expect(itemRows().every((row) => row.textContent?.includes("✓"))).toBe(true);
     });
 
     it("dismisses the toast for the pass and shows it again on the next one", () => {

--- a/tests/unit/progress-toast.test.ts
+++ b/tests/unit/progress-toast.test.ts
@@ -261,6 +261,42 @@ describe("progress toast", () => {
         expect(itemRows().every((row) => row.textContent?.includes("✓"))).toBe(true);
     });
 
+    it("drops a render queued just before the toast is removed", async () => {
+        setDebug(true);
+        settings.offerLogCopyAfterPass = true;
+        beginWorkIndicator({stages: ["lookup"]});
+        await vi.advanceTimersByTimeAsync(0); // the setting is read asynchronously
+        reportWorkStage("lookup", "Looking up 1 DOI…");
+        settle();
+        setWorkItems([{id: "i0", label: "Paper 0", status: "pending"}]);
+        endWorkIndicator(); // leaves the one-line copy offer up
+        settings.offerLogCopyAfterPass = false;
+
+        const pending = new Map<number, FrameRequestCallback>();
+        let nextFrame = 0;
+        vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+            pending.set(++nextFrame, callback);
+            return nextFrame;
+        });
+        const cancelFrame = vi
+            .spyOn(window, "cancelAnimationFrame")
+            .mockImplementation((id) => void pending.delete(id));
+
+        updateWorkItem("i0", "done"); // a straggler queues a render
+        const queued = nextFrame;
+        expect(pending.has(queued)).toBe(true);
+
+        button("final-copy").click(); // fades the toast out, then removes it
+        await vi.advanceTimersByTimeAsync(6000);
+        expect(toast()).toBeNull();
+        expect(cancelFrame).toHaveBeenCalledWith(queued);
+        expect(pending.has(queued)).toBe(false);
+
+        // Nothing left to rebuild the removed toast.
+        for (const callback of [...pending.values()]) callback(0);
+        expect(toast()).toBeNull();
+    });
+
     it("dismisses the toast for the pass and shows it again on the next one", () => {
         beginWorkIndicator();
         reportWorkStage("scan", "Scanning this page for DOIs…");


### PR DESCRIPTION
## What changed

Coalesce per-item progress-toast renders onto a single animation frame when multiple item statuses arrive synchronously.

Stage transitions and initial item-list updates remain immediate. Pending frame renders are cancelled with the existing toast timers and cleanup paths.

## Why

Scholar validation, augmentation, and lookup complete items in synchronous loops. Previously each updateWorkItem rebuilt the toast DOM and queued another animation-frame callback. With the details panel open, every update rebuilt the full stage and item list, even though the browser could only present the final state for that frame.

## Validation

- npm test — 704 tests passed
- npm run typecheck
- git diff --check
- Added a regression test covering eight synchronous item updates and asserting one queued render frame.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved progress notifications so rapid updates render smoothly and efficiently.
  * Reduced unnecessary visual refreshes during bursts of progress activity, improving responsiveness and reducing flicker.
  * Ensured completed items consistently display their final status after updates are processed.
  * Prevented dismissed or cleaned-up notifications from reappearing when late progress updates arrive.
  * Ensured pending updates are cancelled when a notification is removed, keeping the interface accurate and responsive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->