### PR TITLE
Preserve italics when copying formatted citations

### DIFF
--- a/src/shared/citation.ts
+++ b/src/shared/citation.ts
@@ -94,6 +94,109 @@ function keepInlineMarkup(raw: string): string {
     });
 }
 
+interface CitationRange {
+    start: number;
+    end: number;
+}
+
+function addMatchRange(ranges: CitationRange[], match: RegExpExecArray, group: number): void {
+    const value = match[group];
+    if (!value || match.index === undefined) return;
+    const offset = match[0].indexOf(value);
+    if (offset < 0) return;
+    ranges.push({start: match.index + offset, end: match.index + offset + value.length});
+}
+
+/**
+ * Crossref's text/x-bibliography response is deliberately plain text. That is
+ * useful for a terminal, but it means a rich clipboard write would otherwise
+ * lose the italics required by journal styles. Recover the journal and volume
+ * spans from the stable punctuation emitted by the CSL styles. This is only a
+ * fallback: markup supplied by a resolver remains authoritative.
+ */
+function plainCitationRanges(text: string, format: CitationFormat): CitationRange[] {
+    const ranges: CitationRange[] = [];
+    let journalMatch: RegExpExecArray | null = null;
+
+    switch (format.id) {
+        case "apa":
+            journalMatch = /^(.*\(\d{4}[a-z]?\)\.\s+).+\.\s+(.+?),\s+\d+(?=\(\d+\)|,|\s|\.|$)/.exec(text);
+            break;
+        case "modern-language-association":
+            journalMatch = /^(.+?[”"](?:\s*,)?\s+)(.+?),\s+(?=vol\.)/.exec(text);
+            break;
+        case "chicago-author-date":
+            journalMatch = /^(.+?[”"]\s+)(.+?)\s+\d+(?:\s+\(\d+\))?\s*:/.exec(text);
+            break;
+        case "harvard-cite-them-right":
+            journalMatch = /^(.+?[”"](?:,|\.)?\s+)(.+?)\.\s+(?=\d+\(|\d{4})/.exec(text);
+            break;
+        case "ieee":
+            journalMatch = /^(.+?[”"](?:\s*,)?\s+)(.+?),\s+vol\./.exec(text);
+            break;
+        case "elsevier-vancouver":
+        case "american-medical-association":
+            journalMatch = /^(.+)\.\s+(.+?)\s+\d{4}[.;]/.exec(text);
+            break;
+        case "american-sociological-association":
+            journalMatch = /^(.+?[”"](?:\s*,)?\s+)(.+?)\s+\d+(?:\(\d+\))?:/.exec(text);
+            break;
+        case "nature":
+            journalMatch = /^(.+)\.\s+(.+?)\s+\d+,/.exec(text);
+            break;
+    }
+
+    if (!journalMatch) return ranges;
+    addMatchRange(ranges, journalMatch, 2);
+
+    // APA, Chicago, Harvard, IEEE, Vancouver, AMA, ASA and Nature italicise
+    // the volume alongside the journal. MLA is the exception in this list.
+    const volumeStyles = new Set([
+        "apa",
+        "chicago-author-date",
+        "harvard-cite-them-right",
+        "elsevier-vancouver",
+        "ieee",
+        "american-medical-association",
+        "american-sociological-association",
+        "nature",
+    ]);
+    if (volumeStyles.has(format.id)) {
+        const journalEnd = journalMatch.index! + journalMatch[0].indexOf(journalMatch[2]) + journalMatch[2].length;
+        const volume = /\b\d+(?=\(\d+\)|\s*\(|[,;:]|\s*,)/.exec(text.slice(journalEnd));
+        if (volume && volume.index !== undefined) {
+            ranges.push({start: journalEnd + volume.index, end: journalEnd + volume.index + volume[0].length});
+        }
+    }
+    return ranges;
+}
+
+function escapeHtml(text: string): string {
+    return text.replace(/[&<>"']/g, (character) => ({
+        "&": "&amp;",
+        "<": "&lt;",
+        ">": "&gt;",
+        '"': "&quot;",
+        "'": "&#39;",
+    }[character] ?? character));
+}
+
+function formatPlainCitationHtml(text: string, format: CitationFormat): string {
+    const ranges = plainCitationRanges(text, format)
+        .sort((a, b) => a.start - b.start)
+        .filter((range, index, all) => index === 0 || range.start >= all[index - 1].end);
+    if (ranges.length === 0) return escapeHtml(text);
+
+    let html = "";
+    let cursor = 0;
+    for (const range of ranges) {
+        html += escapeHtml(text.slice(cursor, range.start));
+        html += `<i>${escapeHtml(text.slice(range.start, range.end))}</i>`;
+        cursor = range.end;
+    }
+    return html + escapeHtml(text.slice(cursor));
+}
+
 /**
  * Crossref stores an empty editor list on many journal articles, which citeproc
  * renders as a dangling "edited by ," / ", ed." in the styles that name editors.
@@ -122,7 +225,11 @@ export function tidyCitation(raw: string, format: CitationFormat): string {
 /** The same entry with its emphasis intact, or null where the format has none. */
 export function tidyCitationHtml(raw: string, format: CitationFormat): string | null {
     if (format.verbatim) return null;
-    const html = polish(keepInlineMarkup(raw).trim());
+    const hasInlineMarkup = /<(?:\/?)(?:i|em|b|strong|sub|sup)\b/i.test(raw);
+    const hasMarkup = /<[^>]+>/i.test(raw);
+    const html = hasInlineMarkup || hasMarkup
+        ? polish(keepInlineMarkup(raw).trim())
+        : formatPlainCitationHtml(polish(stripMarkup(raw)), format);
     return html || null;
 }
 

--- a/src/shared/citation.ts
+++ b/src/shared/citation.ts
@@ -99,10 +99,11 @@ interface CitationRange {
     end: number;
 }
 
+/** Add a CSL capture group's final occurrence to the ranges to italicise. */
 function addMatchRange(ranges: CitationRange[], match: RegExpExecArray, group: number): void {
     const value = match[group];
     if (!value || match.index === undefined) return;
-    const offset = match[0].indexOf(value);
+    const offset = match[0].lastIndexOf(value);
     if (offset < 0) return;
     ranges.push({start: match.index + offset, end: match.index + offset + value.length});
 }
@@ -136,7 +137,7 @@ function plainCitationRanges(text: string, format: CitationFormat): CitationRang
             break;
         case "elsevier-vancouver":
         case "american-medical-association":
-            journalMatch = /^(.+)\.\s+(.+?)\s+\d{4}[.;]/.exec(text);
+            journalMatch = /^(.+)\.\s+(.+?)(?:\.)?\s+\d{4}[.;]/.exec(text);
             break;
         case "american-sociological-association":
             journalMatch = /^(.+?[”"](?:\s*,)?\s+)(.+?)\s+\d+(?:\(\d+\))?:/.exec(text);
@@ -162,15 +163,22 @@ function plainCitationRanges(text: string, format: CitationFormat): CitationRang
         "nature",
     ]);
     if (volumeStyles.has(format.id)) {
-        const journalEnd = journalMatch.index! + journalMatch[0].indexOf(journalMatch[2]) + journalMatch[2].length;
-        const volume = /\b\d+(?=\(\d+\)|\s*\(|[,;:]|\s*,)/.exec(text.slice(journalEnd));
+        const journalEnd = journalMatch.index! + journalMatch[0].lastIndexOf(journalMatch[2]) + journalMatch[2].length;
+        const volumePattern = format.id === "elsevier-vancouver" || format.id === "american-medical-association"
+            ? /\b\d{4}[.;]\s*(\d+)(?=\(\d+\)|\s*\(|[,;:]|\s*,)/
+            : /\b\d+(?=\(\d+\)|\s*\(|[,;:]|\s*,)/;
+        const volume = volumePattern.exec(text.slice(journalEnd));
         if (volume && volume.index !== undefined) {
-            ranges.push({start: journalEnd + volume.index, end: journalEnd + volume.index + volume[0].length});
+            const volumeText = volume[1] ?? volume[0];
+            const volumeOffset = volume[1] ? volume[0].lastIndexOf(volume[1]) : 0;
+            const volumeStart = journalEnd + volume.index + volumeOffset;
+            ranges.push({start: volumeStart, end: volumeStart + volumeText.length});
         }
     }
     return ranges;
 }
 
+/** Escape a plain-text citation before inserting it into clipboard HTML. */
 function escapeHtml(text: string): string {
     return text.replace(/[&<>"']/g, (character) => ({
         "&": "&amp;",
@@ -181,6 +189,7 @@ function escapeHtml(text: string): string {
     }[character] ?? character));
 }
 
+/** Reconstruct the inline emphasis omitted by plain text/x-bibliography output. */
 function formatPlainCitationHtml(text: string, format: CitationFormat): string {
     const ranges = plainCitationRanges(text, format)
         .sort((a, b) => a.start - b.start)

--- a/tests/unit/citation.test.ts
+++ b/tests/unit/citation.test.ts
@@ -85,6 +85,30 @@ describe("tidyCitationHtml", () => {
       .toBe("Pelletier, A. <i>pathseq</i> &amp; friends.");
   });
 
+  it("restores journal and volume italics when the resolver returns plain text", () => {
+    expect(tidyCitationHtml(
+      "Ray, O. (2004). How the Mind Hurts and Heals the Body. American Psychologist, 59(1), 29–40.",
+      apa
+    )).toBe(
+      "Ray, O. (2004). How the Mind Hurts and Heals the Body. " +
+      "<i>American Psychologist</i>, <i>59</i>(1), 29–40."
+    );
+  });
+
+  it("uses the selected style's journal punctuation to preserve its emphasis", () => {
+    expect(tidyCitationHtml(
+      "[1]O. Ray, “How the Mind Hurts and Heals the Body.,” American Psychologist, vol. 59, no. 1, pp. 29–40, 2004, doi: x.",
+      citationFormat("ieee")
+    )).toContain("<i>American Psychologist</i>");
+    expect(tidyCitationHtml(
+      "Ray, Oakley. “How the Mind Hurts and Heals the Body.” American Psychologist, vol. 59, no. 1, 2004, pp. 29–40.",
+      citationFormat("modern-language-association")
+    )).toBe(
+      "Ray, Oakley. “How the Mind Hurts and Heals the Body.” " +
+      "<i>American Psychologist</i>, vol. 59, no. 1, 2004, pp. 29–40."
+    );
+  });
+
   it("drops the bibliography number, wrapper and all", () => {
     expect(tidyCitationHtml(`<div class="csl-entry">[1]O. Ray, "Title," 2004.</div>`, citationFormat("ieee")))
       .toBe(`O. Ray, "Title," 2004.`);

--- a/tests/unit/citation.test.ts
+++ b/tests/unit/citation.test.ts
@@ -95,6 +95,33 @@ describe("tidyCitationHtml", () => {
     );
   });
 
+  it("italicises the journal occurrence rather than a matching title phrase", () => {
+    expect(tidyCitationHtml(
+      "Ray, O. (2004). American Psychologist reveals how the field changed. American Psychologist, 59(1), 29–40.",
+      apa
+    )).toBe(
+      "Ray, O. (2004). American Psychologist reveals how the field changed. " +
+      "<i>American Psychologist</i>, <i>59</i>(1), 29–40."
+    );
+  });
+
+  it("skips the publication year when italicising Vancouver and AMA volumes", () => {
+    expect(tidyCitationHtml(
+      "Ray O. How the Mind Hurts and Heals the Body. American Psychologist 2004;59:29–40.",
+      citationFormat("elsevier-vancouver")
+    )).toBe(
+      "Ray O. How the Mind Hurts and Heals the Body. " +
+      "<i>American Psychologist</i> 2004;<i>59</i>:29–40."
+    );
+    expect(tidyCitationHtml(
+      "Ray O. How the Mind Hurts and Heals the Body. American Psychologist. 2004;59(1):29-40.",
+      citationFormat("american-medical-association")
+    )).toBe(
+      "Ray O. How the Mind Hurts and Heals the Body. " +
+      "<i>American Psychologist</i>. 2004;<i>59</i>(1):29-40."
+    );
+  });
+
   it("uses the selected style's journal punctuation to preserve its emphasis", () => {
     expect(tidyCitationHtml(
       "[1]O. Ray, “How the Mind Hurts and Heals the Body.,” American Psychologist, vol. 59, no. 1, pp. 29–40, 2004, doi: x.",


### PR DESCRIPTION
Fixes #196

## What changed

The citation-style selector and copy action already exist, but Crossref plain-text bibliography responses meant the rich clipboard flavour contained no italic markup. This PR reconstructs the journal and volume emphasis from the selected CSL style punctuation, while preserving resolver-supplied markup and safely escaping fallback HTML.

## Validation

- npm run typecheck
- npm test (85 files, 774 tests)
- npm run build

The existing copy action now pastes italicised journal references into Word and Google Docs while retaining plain text for plain-text editors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved citation formatting when resolver output is plain text.
  - Restored italic styling for journal titles and volume numbers.
  - Preserved existing citation markup when available.
  - Improved handling of publication years and repeated title text.
  - Applied style-specific punctuation for IEEE and MLA citations.
  - Kept verbatim citation formats unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->